### PR TITLE
ci: add public pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repository-checks:
+    name: repository checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify repository foundation files
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_files=(
+            "README.md"
+            "AGENTS.md"
+            "CONTEXT.md"
+            "CONTRIBUTING.md"
+            "SECURITY.md"
+            "llms.txt"
+            "docs/repo-map.md"
+            "docs/architecture.md"
+            "docs/manual-install.md"
+            "docs/release.md"
+            ".github/CODEOWNERS"
+            ".github/pull_request_template.md"
+            ".github/ISSUE_TEMPLATE/bug_report.md"
+            ".github/ISSUE_TEMPLATE/feature_request.md"
+            ".github/ISSUE_TEMPLATE/docs_issue.md"
+          )
+
+          for file in "${required_files[@]}"; do
+            if [[ ! -f "$file" ]]; then
+              echo "Missing required file: $file"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary
Adds the first public CI workflow for the Fennara Godot MCP repo.

## Changes
- Adds a lightweight repository foundation check
- Runs on pull requests to main, pushes to main, and manual dispatch
- Uses read-only GitHub Actions permissions

## Testing
Validated the workflow file locally with git diff checks.