### PR TITLE
docs: add source layout placeholders

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -16,13 +16,6 @@ This file explains the main areas of the Fennara Godot MCP repository.
 | `llms.txt` | Short project index for language models and coding agents. |
 | `LICENSE.md` | Project license. |
 | `THIRD_PARTY_NOTICES.md` | Third-party notices. |
-
-## Planned Source Areas
-
-These areas will be added as the repository moves from documentation to source distribution.
-
-| Path | Purpose |
-| --- | --- |
 | `local/` | Rust MCP server, local daemon, and command-line setup/update tools. |
 | `fennara-cpp/` | C++ Godot GDExtension source. |
 | `godot/addons/fennara/` | Installable Godot addon payload. |

--- a/fennara-cpp/README.md
+++ b/fennara-cpp/README.md
@@ -1,0 +1,12 @@
+# Fennara C++ Plugin Source
+
+This directory is reserved for the C++ Godot GDExtension source.
+
+Planned responsibilities:
+
+- expose Godot-aware inspection and editing tools
+- connect the Godot editor/project to the local Fennara daemon
+- collect diagnostics, validation results, screenshots, runtime feedback, and editor state
+- format concise tool results for AI agents
+
+Fennara tools should stay primitive and game-agnostic. Do not add helpers that assume a specific game's controls, objectives, movement, combat, inventory, pathing, economy, quests, or UI flow.

--- a/godot/README.md
+++ b/godot/README.md
@@ -1,0 +1,15 @@
+# Godot Addon
+
+This directory is reserved for Godot-facing addon files.
+
+Planned layout:
+
+```text
+godot/
+  addons/
+    fennara/
+```
+
+The `godot/addons/fennara/` directory will contain the installable addon payload copied into Godot projects.
+
+Do not place build-only temporary files or local user state in this directory.

--- a/godot/addons/README.md
+++ b/godot/addons/README.md
@@ -1,0 +1,9 @@
+# Godot Addons
+
+This directory is reserved for installable Godot addon payloads.
+
+The planned Fennara addon path is:
+
+```text
+godot/addons/fennara/
+```

--- a/godot/addons/fennara/README.md
+++ b/godot/addons/fennara/README.md
@@ -1,0 +1,9 @@
+# Fennara Godot Addon
+
+This directory is reserved for the installable Fennara Godot addon payload.
+
+When source distribution begins, this directory should contain the files that are copied into a user's Godot project under:
+
+```text
+addons/fennara/
+```

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,12 @@
+# Local Tools
+
+This directory is reserved for Fennara's local MCP server, local daemon, and command-line setup/update tools.
+
+Planned responsibilities:
+
+- expose Fennara tools to MCP clients over stdio
+- bridge MCP tool calls to the local Godot plugin
+- manage local runtime helpers used by validation and runtime feedback workflows
+- provide command-line setup, update, doctor, and repair commands
+
+Keep Godot editor integration in the Godot plugin source area. Keep local process, protocol, and filesystem plumbing here.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,12 @@
+# Scripts
+
+This directory is reserved for repository scripts.
+
+Planned responsibilities:
+
+- version updates
+- package assembly
+- release artifact checks
+- local development helpers
+
+Scripts should be small, documented, and safe to run from the repository root unless stated otherwise.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,11 @@
+# Templates
+
+This directory is reserved for generated project guidance templates.
+
+Planned templates include:
+
+- agent instructions added to a Godot project
+- Fennara MCP guidelines read by AI coding agents
+- small config snippets used by setup/update commands
+
+Templates should be versioned and safe to apply repeatedly. Setup and update commands should avoid duplicating generated blocks.


### PR DESCRIPTION
## Summary
Adds lightweight source layout placeholders for the public repository.

## Changes
- Adds README placeholders for future local, C++ plugin, Godot addon, templates, and scripts areas
- Updates the repo map to include the source layout
- Does not move implementation code yet

## Testing
- Ran git diff --check
- Verified layout files exist locally