### PR TITLE
ci: add package preview workflow

### DIFF
--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -1,0 +1,100 @@
+name: Package Preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-preview-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  package:
+    name: package ${{ matrix.platform }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            arch: x86_64
+            os: windows-latest
+          - platform: linux
+            arch: x86_64
+            os: ubuntu-latest
+          - platform: macos
+            arch: arm64
+            os: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install SCons
+        run: pip install scons
+
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y build-essential
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache SCons and godot-cpp outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            fennara-cpp/.scons_cache/
+            fennara-cpp/.sconsign.dblite
+            fennara-cpp/godot-cpp/bin/
+            fennara-cpp/godot-cpp/gen/
+          key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
+          restore-keys: |
+            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
+            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
+
+      - name: Cache Cargo artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            local/target
+          key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}
+          restore-keys: |
+            local-cargo-${{ runner.os }}-
+
+      - name: Build GDExtension
+        working-directory: fennara-cpp
+        env:
+          SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
+        run: scons platform=${{ matrix.platform }} target=editor
+
+      - name: Build local tools
+        working-directory: local
+        run: cargo build --release --locked
+
+      - name: Assemble preview archives
+        run: node scripts/package-preview.mjs --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
+
+      - name: Upload preview archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-package-preview-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/*.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,8 @@ fennara-cpp/build/
 
 local/target/
 
+dist/
+.package-preview/
+
 godot/addons/fennara/bin/*
 !godot/addons/fennara/bin/.gitkeep

--- a/docs/release.md
+++ b/docs/release.md
@@ -7,7 +7,7 @@ This repository is being prepared for source-based releases. Release automation 
 ## Expected Flow
 
 1. Update the release version with `node scripts/set-version.mjs <x.y.z>`.
-2. Build platform artifacts from the release commit.
+2. Run the manual Package Preview workflow from the release commit.
 3. Verify artifacts locally.
 4. Create a GitHub release tag such as `v0.1.0`.
 5. Upload local tool archives and the Godot plugin package.
@@ -23,6 +23,10 @@ This repository is being prepared for source-based releases. Release automation 
 - the C++ plugin version reported by the Godot dock
 
 Pull requests that touch versioned files run `node scripts/check-version.mjs` to catch drift before merge.
+
+## Package Preview
+
+The manual Package Preview workflow builds the Godot addon and local MCP tools on GitHub-hosted Windows, Linux, and macOS runners. It uploads temporary workflow artifacts only. It does not create tags, publish GitHub releases, or publish installer downloads.
 
 ## Rules
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,10 +6,10 @@ Current scripts:
 
 - `set-version.mjs`: updates `VERSION`, Rust package metadata, the lockfile, and the C++ plugin version.
 - `check-version.mjs`: verifies versioned files are in sync.
+- `package-preview.mjs`: assembles temporary addon and local tool zip archives after CI builds.
 
 Planned responsibilities:
 
-- package assembly
 - release artifact checks
 - local development helpers
 

--- a/scripts/package-preview.mjs
+++ b/scripts/package-preview.mjs
@@ -1,0 +1,166 @@
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const args = parseArgs(process.argv.slice(2));
+const version = readVersion();
+const platform = requiredArg("platform");
+const arch = args.arch ?? "x86_64";
+const distDir = path.join(root, "dist");
+const stageRoot = path.join(root, ".package-preview");
+
+rmSync(stageRoot, { recursive: true, force: true });
+mkdirSync(distDir, { recursive: true });
+
+const addonArchive = packageAddon();
+const localArchive = packageLocal();
+
+console.log(`Created ${path.relative(root, addonArchive)}`);
+console.log(`Created ${path.relative(root, localArchive)}`);
+
+function packageAddon() {
+  const stage = path.join(stageRoot, "addon");
+  const source = path.join(root, "godot", "addons", "fennara");
+  const target = path.join(stage, "addons", "fennara");
+
+  mkdirSync(path.join(target, "bin"), { recursive: true });
+  copyDir(source, target, (sourcePath) => {
+    const relative = path.relative(source, sourcePath).replaceAll(path.sep, "/");
+    if (relative === "bin" || relative.startsWith("bin/")) {
+      return relative === "bin" || isAddonBinary(relative);
+    }
+    return true;
+  });
+
+  const archive = path.join(distDir, `fennara-addon-${platform}-${arch}-v${version}.zip`);
+  zipDirectory(stage, archive);
+  return archive;
+}
+
+function packageLocal() {
+  const stage = path.join(stageRoot, "local");
+  const binDir = path.join(stage, "bin");
+  const releaseDir = path.join(root, "local", "target", "release");
+  const extension = platform === "windows" ? ".exe" : "";
+  const binaries = [
+    "fennara-daemon",
+    "fennara-daemon-runtime",
+    "fennara-mcp",
+    "fennara-mcp-runtime",
+  ];
+
+  mkdirSync(binDir, { recursive: true });
+  for (const binary of binaries) {
+    const source = path.join(releaseDir, `${binary}${extension}`);
+    if (!exists(source)) {
+      throw new Error(`Missing local binary: ${path.relative(root, source)}`);
+    }
+    copyFile(source, path.join(binDir, `${binary}${extension}`));
+  }
+
+  copyFile(path.join(root, "VERSION"), path.join(stage, "VERSION"));
+
+  const archive = path.join(distDir, `fennara-local-${platform}-${arch}-v${version}.zip`);
+  zipDirectory(stage, archive);
+  return archive;
+}
+
+function isAddonBinary(relative) {
+  if (platform === "windows") {
+    return relative === "bin/libfennara.windows.editor.x86_64.dll";
+  }
+  if (platform === "linux") {
+    return relative === "bin/libfennara.linux.editor.x86_64.so";
+  }
+  if (platform === "macos") {
+    return relative.startsWith("bin/libfennara.macos.editor.framework/");
+  }
+  throw new Error(`Unsupported platform: ${platform}`);
+}
+
+function zipDirectory(sourceDir, archivePath) {
+  rmSync(archivePath, { force: true });
+
+  const script = [
+    "import os, sys, zipfile",
+    "source, archive = sys.argv[1], sys.argv[2]",
+    "with zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED) as zf:",
+    "    for root, _, files in os.walk(source):",
+    "        for name in files:",
+    "            path = os.path.join(root, name)",
+    "            arcname = os.path.relpath(path, source).replace(os.sep, '/')",
+    "            zf.write(path, arcname)",
+  ].join("\n");
+
+  run("python", ["-c", script, sourceDir, archivePath]);
+}
+
+function copyDir(source, target, filter) {
+  for (const entry of readdirSync(source)) {
+    const sourcePath = path.join(source, entry);
+    if (!filter(sourcePath)) {
+      continue;
+    }
+
+    const targetPath = path.join(target, entry);
+    if (statSync(sourcePath).isDirectory()) {
+      mkdirSync(targetPath, { recursive: true });
+      copyDir(sourcePath, targetPath, filter);
+    } else {
+      copyFile(sourcePath, targetPath);
+    }
+  }
+}
+
+function copyFile(source, target) {
+  mkdirSync(path.dirname(target), { recursive: true });
+  copyFileSync(source, target);
+}
+
+function run(command, commandArgs) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    if (!rawArgs[i + 1] || rawArgs[i + 1].startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+    parsed[arg.slice(2)] = rawArgs[i + 1];
+    i += 1;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  if (!args[name]) {
+    throw new Error(`Missing --${name}`);
+  }
+  return args[name];
+}
+
+function readVersion() {
+  return readFileSync(path.join(root, "VERSION"), "utf8").trim();
+}
+
+function exists(filePath) {
+  try {
+    statSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a manual Package Preview workflow that builds the Godot addon and local MCP tools on Windows, Linux, and macOS
- reuse the same godot-cpp/SCons cache key shape as the normal GDExtension build so main-branch caches can be shared
- assemble temporary addon/local zip archives and upload them as workflow artifacts only
- document that this workflow does not create tags or publish releases

## Verification
- node --check scripts/package-preview.mjs
- node scripts/package-preview.mjs --platform windows --arch x86_64
- inspected generated Windows addon/local zip contents
- git diff --check