### PR TITLE
ci: report build cache usage

### DIFF
--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -100,4 +100,4 @@ jobs:
         working-directory: fennara-cpp
         env:
           SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
-        run: scons platform=${{ matrix.platform }} target=editor
+        run: scons platform=${{ matrix.platform }} target=editor --debug=explain --cache-show

--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Cache SCons and godot-cpp outputs
         if: steps.source.outputs.available == 'true'
+        id: godot_cpp_cache
         uses: actions/cache@v4
         with:
           path: |
@@ -87,6 +88,12 @@ jobs:
           restore-keys: |
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
+
+      - name: Report godot-cpp cache
+        if: steps.source.outputs.available == 'true'
+        run: |
+          echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
 
       - name: Build GDExtension
         if: steps.source.outputs.available == 'true'

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -95,7 +95,7 @@ jobs:
         working-directory: fennara-cpp
         env:
           SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
-        run: scons platform=${{ matrix.platform }} target=editor
+        run: scons platform=${{ matrix.platform }} target=editor --debug=explain --cache-show
 
       - name: Build local tools
         working-directory: local

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -56,6 +56,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache SCons and godot-cpp outputs
+        id: godot_cpp_cache
         uses: actions/cache@v4
         with:
           path: |
@@ -68,7 +69,13 @@ jobs:
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
 
+      - name: Report godot-cpp cache
+        run: |
+          echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+
       - name: Cache Cargo artifacts
+        id: cargo_cache
         uses: actions/cache@v4
         with:
           path: |
@@ -78,6 +85,11 @@ jobs:
           key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}
           restore-keys: |
             local-cargo-${{ runner.os }}-
+
+      - name: Report Cargo cache
+        run: |
+          echo "cache-hit: ${{ steps.cargo_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}"
 
       - name: Build GDExtension
         working-directory: fennara-cpp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         working-directory: fennara-cpp
         env:
           SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
-        run: scons platform=${{ matrix.platform }} target=editor
+        run: scons platform=${{ matrix.platform }} target=editor --debug=explain --cache-show
 
       - name: Build local tools
         working-directory: local

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache SCons and godot-cpp outputs
+        id: godot_cpp_cache
         uses: actions/cache@v4
         with:
           path: |
@@ -97,7 +98,13 @@ jobs:
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
 
+      - name: Report godot-cpp cache
+        run: |
+          echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+
       - name: Cache Cargo artifacts
+        id: cargo_cache
         uses: actions/cache@v4
         with:
           path: |
@@ -107,6 +114,11 @@ jobs:
           key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}
           restore-keys: |
             local-cargo-${{ runner.os }}-
+
+      - name: Report Cargo cache
+        run: |
+          echo "cache-hit: ${{ steps.cargo_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}"
 
       - name: Build GDExtension
         working-directory: fennara-cpp

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -26,7 +26,7 @@ for (const manifest of [
 for (const name of ["fennara-daemon", "fennara-mcp"]) {
   expect(
     "local/Cargo.lock",
-    new RegExp(`name = "${escapeRegExp(name)}"\\nversion = "${escapeRegExp(version)}"`),
+    new RegExp(`name = "${escapeRegExp(name)}"\\r?\\nversion = "${escapeRegExp(version)}"`),
     `${name} lockfile version must be ${version}`,
   );
 }


### PR DESCRIPTION
## Summary
- make version sync checks accept Windows CRLF line endings in Cargo.lock
- report godot-cpp cache hit status and primary key after cache restore
- report Cargo cache hit status and primary key in package/release workflows

## Verification
- node scripts/check-version.mjs
- node --check scripts/package-preview.mjs
- git diff --check

## Notes
The Release workflow failed only on Windows because the version checker expected LF between Cargo.lock name/version lines. Windows checkout can use CRLF, so the lockfile versions were correct but the regex missed them.