### PR TITLE
ci: cache godot-cpp object files

### DIFF
--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -84,6 +84,8 @@ jobs:
             fennara-cpp/.sconsign.dblite
             fennara-cpp/godot-cpp/bin/
             fennara-cpp/godot-cpp/gen/
+            fennara-cpp/godot-cpp/src/**/*.obj
+            fennara-cpp/godot-cpp/src/**/*.pdb
           key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
           restore-keys: |
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -64,6 +64,8 @@ jobs:
             fennara-cpp/.sconsign.dblite
             fennara-cpp/godot-cpp/bin/
             fennara-cpp/godot-cpp/gen/
+            fennara-cpp/godot-cpp/src/**/*.obj
+            fennara-cpp/godot-cpp/src/**/*.pdb
           key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
           restore-keys: |
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
             fennara-cpp/.sconsign.dblite
             fennara-cpp/godot-cpp/bin/
             fennara-cpp/godot-cpp/gen/
+            fennara-cpp/godot-cpp/src/**/*.obj
+            fennara-cpp/godot-cpp/src/**/*.pdb
           key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
           restore-keys: |
             godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-


### PR DESCRIPTION
## Summary
- include godot-cpp src object/debug outputs in the shared GDExtension cache
- apply the same cache path update to GDExtension Build, Package Preview, and Release workflows

## Why
SCons debug logs showed Windows rebuilding godot-cpp source objects because files such as godot-cpp/src/*.obj did not exist after cache restore. The cache already included bin and gen outputs, but not direct src object outputs.

## Verification
- git diff --check

## Follow-up
If Windows still reports rebuilds because cl.EXE changed, the next fix should key the Windows cache by detected MSVC version.