### PR TITLE
ci: refresh gdextension cache keys

### DIFF
--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -74,6 +74,26 @@ jobs:
         if: steps.source.outputs.available == 'true' && matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install -y build-essential
 
+      - name: Compute godot-cpp cache key
+        if: steps.source.outputs.available == 'true'
+        id: godot_cpp_cache_key
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_hash="${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          image_id="${ImageOS:-${RUNNER_OS:-unknown}}-${ImageVersion:-unknown}"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            toolchain_id="$(powershell -NoProfile -Command '$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"; if (Test-Path $vswhere) { $install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath; if ($install) { $versions = Get-ChildItem (Join-Path $install "VC\Tools\MSVC") -Directory | Sort-Object Name -Descending; if ($versions) { $versions[0].Name } } }' | tr -d '\r')"
+          else
+            toolchain_id="$(c++ --version | head -n 1)"
+          fi
+          toolchain_id="$(printf "%s" "${toolchain_id:-unknown}" | tr -c 'A-Za-z0-9_.-' '-')"
+          base="godot-cpp-v2-${{ runner.os }}-${{ matrix.platform }}-editor-${source_hash}-${image_id}-${toolchain_id}"
+          echo "primary=${base}-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          echo "restore=${base}-" >> "$GITHUB_OUTPUT"
+          echo "image-id=${image_id}" >> "$GITHUB_OUTPUT"
+          echo "toolchain-id=${toolchain_id}" >> "$GITHUB_OUTPUT"
+
       - name: Cache SCons and godot-cpp outputs
         if: steps.source.outputs.available == 'true'
         id: godot_cpp_cache
@@ -86,16 +106,18 @@ jobs:
             fennara-cpp/godot-cpp/gen/
             fennara-cpp/godot-cpp/src/**/*.obj
             fennara-cpp/godot-cpp/src/**/*.pdb
-          key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
+          key: ${{ steps.godot_cpp_cache_key.outputs.primary }}
           restore-keys: |
-            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
-            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
+            ${{ steps.godot_cpp_cache_key.outputs.restore }}
 
       - name: Report godot-cpp cache
         if: steps.source.outputs.available == 'true'
         run: |
           echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
-          echo "cache-primary-key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          echo "cache-primary-key: ${{ steps.godot_cpp_cache_key.outputs.primary }}"
+          echo "cache-restore-prefix: ${{ steps.godot_cpp_cache_key.outputs.restore }}"
+          echo "runner-image: ${{ steps.godot_cpp_cache_key.outputs.image-id }}"
+          echo "toolchain-id: ${{ steps.godot_cpp_cache_key.outputs.toolchain-id }}"
 
       - name: Build GDExtension
         if: steps.source.outputs.available == 'true'

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -55,6 +55,25 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Compute godot-cpp cache key
+        id: godot_cpp_cache_key
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_hash="${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          image_id="${ImageOS:-${RUNNER_OS:-unknown}}-${ImageVersion:-unknown}"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            toolchain_id="$(powershell -NoProfile -Command '$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"; if (Test-Path $vswhere) { $install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath; if ($install) { $versions = Get-ChildItem (Join-Path $install "VC\Tools\MSVC") -Directory | Sort-Object Name -Descending; if ($versions) { $versions[0].Name } } }' | tr -d '\r')"
+          else
+            toolchain_id="$(c++ --version | head -n 1)"
+          fi
+          toolchain_id="$(printf "%s" "${toolchain_id:-unknown}" | tr -c 'A-Za-z0-9_.-' '-')"
+          base="godot-cpp-v2-${{ runner.os }}-${{ matrix.platform }}-editor-${source_hash}-${image_id}-${toolchain_id}"
+          echo "primary=${base}-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          echo "restore=${base}-" >> "$GITHUB_OUTPUT"
+          echo "image-id=${image_id}" >> "$GITHUB_OUTPUT"
+          echo "toolchain-id=${toolchain_id}" >> "$GITHUB_OUTPUT"
+
       - name: Cache SCons and godot-cpp outputs
         id: godot_cpp_cache
         uses: actions/cache@v4
@@ -66,15 +85,17 @@ jobs:
             fennara-cpp/godot-cpp/gen/
             fennara-cpp/godot-cpp/src/**/*.obj
             fennara-cpp/godot-cpp/src/**/*.pdb
-          key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
+          key: ${{ steps.godot_cpp_cache_key.outputs.primary }}
           restore-keys: |
-            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
-            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
+            ${{ steps.godot_cpp_cache_key.outputs.restore }}
 
       - name: Report godot-cpp cache
         run: |
           echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
-          echo "cache-primary-key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          echo "cache-primary-key: ${{ steps.godot_cpp_cache_key.outputs.primary }}"
+          echo "cache-restore-prefix: ${{ steps.godot_cpp_cache_key.outputs.restore }}"
+          echo "runner-image: ${{ steps.godot_cpp_cache_key.outputs.image-id }}"
+          echo "toolchain-id: ${{ steps.godot_cpp_cache_key.outputs.toolchain-id }}"
 
       - name: Cache Cargo artifacts
         id: cargo_cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,25 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Compute godot-cpp cache key
+        id: godot_cpp_cache_key
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_hash="${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          image_id="${ImageOS:-${RUNNER_OS:-unknown}}-${ImageVersion:-unknown}"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            toolchain_id="$(powershell -NoProfile -Command '$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"; if (Test-Path $vswhere) { $install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath; if ($install) { $versions = Get-ChildItem (Join-Path $install "VC\Tools\MSVC") -Directory | Sort-Object Name -Descending; if ($versions) { $versions[0].Name } } }' | tr -d '\r')"
+          else
+            toolchain_id="$(c++ --version | head -n 1)"
+          fi
+          toolchain_id="$(printf "%s" "${toolchain_id:-unknown}" | tr -c 'A-Za-z0-9_.-' '-')"
+          base="godot-cpp-v2-${{ runner.os }}-${{ matrix.platform }}-editor-${source_hash}-${image_id}-${toolchain_id}"
+          echo "primary=${base}-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          echo "restore=${base}-" >> "$GITHUB_OUTPUT"
+          echo "image-id=${image_id}" >> "$GITHUB_OUTPUT"
+          echo "toolchain-id=${toolchain_id}" >> "$GITHUB_OUTPUT"
+
       - name: Cache SCons and godot-cpp outputs
         id: godot_cpp_cache
         uses: actions/cache@v4
@@ -95,15 +114,17 @@ jobs:
             fennara-cpp/godot-cpp/gen/
             fennara-cpp/godot-cpp/src/**/*.obj
             fennara-cpp/godot-cpp/src/**/*.pdb
-          key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}
+          key: ${{ steps.godot_cpp_cache_key.outputs.primary }}
           restore-keys: |
-            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-
-            godot-cpp-${{ runner.os }}-${{ matrix.platform }}-
+            ${{ steps.godot_cpp_cache_key.outputs.restore }}
 
       - name: Report godot-cpp cache
         run: |
           echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
-          echo "cache-primary-key: godot-cpp-${{ runner.os }}-${{ matrix.platform }}-editor-${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          echo "cache-primary-key: ${{ steps.godot_cpp_cache_key.outputs.primary }}"
+          echo "cache-restore-prefix: ${{ steps.godot_cpp_cache_key.outputs.restore }}"
+          echo "runner-image: ${{ steps.godot_cpp_cache_key.outputs.image-id }}"
+          echo "toolchain-id: ${{ steps.godot_cpp_cache_key.outputs.toolchain-id }}"
 
       - name: Cache Cargo artifacts
         id: cargo_cache


### PR DESCRIPTION
## Summary
- add a computed godot-cpp cache key for GDExtension, package preview, and release workflows
- include runner image and compiler/toolchain identity in the cache prefix
- use a unique run id in the primary key so successful runs can save fresh compatible caches
- print the cache key, restore prefix, runner image, and toolchain id in logs

## Why
Windows builds were restoring a cache but SCons rebuilt godot-cpp because the MSVC `cl.exe` path/version changed. GitHub Actions caches are immutable for exact keys, so an old exact-key cache can keep restoring even after a rebuild. The rolling key keeps restoring the newest compatible cache while allowing successful runs to save a refreshed one.

## Validation
- checked workflow diffs
- `git diff --check`
- verified approach against GitHub Actions cache docs and SCons signature behavior