### PR TITLE
fix: detect windows installer architecture

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,10 +26,11 @@ Options:
 
 $repo = "fennaraOfficial/fennara-godot-mcp"
 $platform = "windows"
-$arch = switch ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture) {
-  "X64" { "x86_64" }
-  "Arm64" { "arm64" }
-  default { throw "Unsupported architecture: $([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)" }
+$osArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+$arch = switch ($osArchitecture) {
+  "x64" { "x86_64" }
+  "arm64" { "arm64" }
+  default { throw "Unsupported architecture: $osArchitecture" }
 }
 
 if (-not $InstallDir -and -not $env:LOCALAPPDATA) {


### PR DESCRIPTION
## Summary
- normalize `RuntimeInformation.OSArchitecture` before matching installer architecture
- fixes `Unsupported architecture:` from `irm .../install.ps1 | iex`

## Validation
- parsed `install.ps1` as a scriptblock
- ran `./install.ps1 -Version 0.2.8 -InstallDir <temp> -NoModifyPath`
- verified downloaded CLI reports `fennara 0.2.8`