### PR TITLE
fix: cast installer architecture to string

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,7 +26,7 @@ Options:
 
 $repo = "fennaraOfficial/fennara-godot-mcp"
 $platform = "windows"
-$osArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant()
+$osArchitecture = ([string][System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToLowerInvariant()
 $arch = switch ($osArchitecture) {
   "x64" { "x86_64" }
   "arm64" { "arm64" }


### PR DESCRIPTION
## Summary
- cast `RuntimeInformation.OSArchitecture` to string before lowercasing
- avoids PowerShell method-call parsing issues when running `irm ... | iex`

## Validation
- parsed `install.ps1` as a scriptblock
- ran `./install.ps1 -Version 0.2.8 -InstallDir <temp> -NoModifyPath`
- ran `Get-Content -Raw install.ps1 | Invoke-Expression`
- verified CLI reports `fennara 0.2.8`