### PR TITLE
fix: use windows x64 installer asset

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -26,12 +26,7 @@ Options:
 
 $repo = "fennaraOfficial/fennara-godot-mcp"
 $platform = "windows"
-$osArchitecture = ([string][System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture).ToLowerInvariant()
-$arch = switch ($osArchitecture) {
-  "x64" { "x86_64" }
-  "arm64" { "arm64" }
-  default { throw "Unsupported architecture: $osArchitecture" }
-}
+$arch = "x86_64"
 
 if (-not $InstallDir -and -not $env:LOCALAPPDATA) {
   throw "LOCALAPPDATA is not set."


### PR DESCRIPTION
## Summary
- simplify `install.ps1` to always download the Windows x86_64 CLI asset
- remove unnecessary architecture detection while Windows only publishes x86_64

## Validation
- parsed `install.ps1` as a scriptblock
- ran `./install.ps1 -Version 0.2.8 -InstallDir <temp> -NoModifyPath`
- verified downloaded CLI reports `fennara 0.2.8`