### PR TITLE
fix: skip locked local launchers during update

### DIFF
--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -101,11 +101,11 @@ fn install_from_assets(
     fs::create_dir_all(&version_dir)
         .map_err(|err| format!("failed to create {}: {err}", display_path(&version_dir)))?;
 
-    copy_file(
+    copy_existing_launcher(
         &local_dir.join("bin").join(binary_name("fennara-mcp")),
         &layout.bin_dir.join(binary_name("fennara-mcp")),
     )?;
-    copy_file(
+    copy_existing_launcher(
         &local_dir.join("bin").join(binary_name("fennara-daemon")),
         &layout.bin_dir.join(binary_name("fennara-daemon")),
     )?;
@@ -271,6 +271,28 @@ fn copy_file(source: &Path, target: &Path) -> Result<(), String> {
         )
     })?;
     Ok(())
+}
+
+fn copy_existing_launcher(source: &Path, target: &Path) -> Result<(), String> {
+    if !source.is_file() {
+        return Err(format!("missing package file: {}", display_path(source)));
+    }
+
+    if !target.exists() {
+        return copy_file(source, target);
+    }
+
+    match copy_file(source, target) {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            println!(
+                "warning: kept existing launcher because it could not be replaced: {}",
+                display_path(target)
+            );
+            println!("warning: {error}");
+            Ok(())
+        }
+    }
 }
 
 fn copy_dir(source: &Path, target: &Path) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- treat existing local launcher replacement as best-effort during package install/update
- continue updating versioned runtime binaries and addon when `fennara-mcp.exe` or `fennara-daemon.exe` is already running
- still require launcher copy when the launcher is missing

## Why
On Windows, `fennara update` can fail if an MCP client is currently running `fennara-mcp.exe`. The launcher rarely changes; the versioned runtime payload under `versions/<version>/` is what needs to update.

## Validation
- `cargo fmt`
- `cargo check --locked -p fennara-cli`
- `cargo test --locked`
- `node scripts/check-version.mjs`
- `git diff --check`