### PR TITLE
build: package addon as all-platform zip

### DIFF
--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -133,3 +133,46 @@ jobs:
           name: fennara-package-preview-${{ matrix.platform }}-${{ matrix.arch }}
           path: dist/*.zip
           if-no-files-found: error
+
+      - name: Upload addon part
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-addon-part-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/addon-part-${{ matrix.platform }}-${{ matrix.arch }}/
+          if-no-files-found: error
+
+  addon:
+    name: package all-platform addon
+    runs-on: ubuntu-latest
+    needs: package
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download addon parts
+        uses: actions/download-artifact@v4
+        with:
+          path: addon-parts
+          pattern: fennara-addon-part-*
+          merge-multiple: true
+
+      - name: Assemble all-platform addon archive
+        run: node scripts/package-addon-all.mjs --parts-dir addon-parts
+
+      - name: Upload all-platform addon archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-package-preview-addon
+          path: dist/fennara-addon-v*.zip
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,10 +163,52 @@ jobs:
           path: dist/*.zip
           if-no-files-found: error
 
+      - name: Upload addon part
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-addon-part-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/addon-part-${{ matrix.platform }}-${{ matrix.arch }}/
+          if-no-files-found: error
+
+  addon:
+    name: package all-platform addon
+    runs-on: ubuntu-latest
+    needs: package
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download addon parts
+        uses: actions/download-artifact@v4
+        with:
+          path: addon-parts
+          pattern: fennara-addon-part-*
+          merge-multiple: true
+
+      - name: Assemble all-platform addon archive
+        run: node scripts/package-addon-all.mjs --parts-dir addon-parts
+
+      - name: Upload all-platform addon archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-release-addon
+          path: dist/fennara-addon-v*.zip
+          if-no-files-found: error
   publish:
     name: publish GitHub release
     runs-on: ubuntu-latest
-    needs: package
+    needs: [package, addon]
 
     steps:
       - name: Checkout

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@ Each public release publishes separate assets so installs can stay modular:
 | --- | --- |
 | `fennara-cli-<platform>-<arch>.zip` | CLI and stable launchers. |
 | `fennara-local-<platform>-<arch>.zip` | Versioned MCP and daemon runtimes. |
-| `fennara-addon-<platform>-<arch>.zip` | Godot addon payload with the GDExtension binary. |
+| `fennara-addon-v<version>.zip` | All-platform Godot addon payload with every built GDExtension binary referenced by `fennara.gdextension`. |
 
 The moving `latest` release is what normal users should install from. Versioned
 releases such as `v0.2.8` stay available for pinning and debugging.

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -16,14 +16,13 @@ Open the latest GitHub release:
 
 https://github.com/fennaraOfficial/fennara-godot-mcp/releases/latest
 
-Download the files for your platform.
+Download the CLI and local runtime files for your platform, plus the shared addon zip.
 
 Windows:
 
 ```text
 fennara-cli-windows-x86_64-v<version>.zip
 fennara-local-windows-x86_64-v<version>.zip
-fennara-addon-windows-x86_64-v<version>.zip
 ```
 
 Linux:
@@ -31,7 +30,6 @@ Linux:
 ```text
 fennara-cli-linux-x86_64-v<version>.zip
 fennara-local-linux-x86_64-v<version>.zip
-fennara-addon-linux-x86_64-v<version>.zip
 ```
 
 macOS:
@@ -39,7 +37,12 @@ macOS:
 ```text
 fennara-cli-macos-arm64-v<version>.zip
 fennara-local-macos-arm64-v<version>.zip
-fennara-addon-macos-arm64-v<version>.zip
+```
+
+Shared addon:
+
+```text
+fennara-addon-v<version>.zip
 ```
 
 ## 2. Install The CLI

--- a/docs/release.md
+++ b/docs/release.md
@@ -86,14 +86,13 @@ The workflow publishes:
 
 ## Release Assets
 
-Each release should contain three package types per platform.
+Each release should contain per-platform CLI/local runtime packages and one shared all-platform addon package.
 
 Windows:
 
 ```text
 fennara-cli-windows-x86_64-v<version>.zip
 fennara-local-windows-x86_64-v<version>.zip
-fennara-addon-windows-x86_64-v<version>.zip
 ```
 
 Linux:
@@ -101,7 +100,6 @@ Linux:
 ```text
 fennara-cli-linux-x86_64-v<version>.zip
 fennara-local-linux-x86_64-v<version>.zip
-fennara-addon-linux-x86_64-v<version>.zip
 ```
 
 macOS:
@@ -109,18 +107,24 @@ macOS:
 ```text
 fennara-cli-macos-arm64-v<version>.zip
 fennara-local-macos-arm64-v<version>.zip
-fennara-addon-macos-arm64-v<version>.zip
+```
+
+Shared addon:
+
+```text
+fennara-addon-v<version>.zip
 ```
 
 Package roles:
 
-- `fennara-cli-*`: install script payload; contains only the `fennara` CLI.
-- `fennara-local-*`: local MCP and daemon launchers plus versioned runtime binaries.
-- `fennara-addon-*`: Godot addon payload copied into projects.
+- `fennara-cli-*`: install script payload; contains only the `fennara` CLI for one platform.
+- `fennara-local-*`: local MCP and daemon launchers plus versioned runtime binaries for one platform.
+- `fennara-addon-v*`: all-platform Godot addon payload copied into projects and used by the Godot Asset Library.
+
+The shared addon zip contains every built GDExtension binary referenced by `godot/addons/fennara/fennara.gdextension`. Godot loads the matching library for the user's OS and ignores the others.
 
 The CLI embeds the generated project guidance templates from `local/templates/`.
 When release packaging builds the CLI, those templates are compiled into the binary with the rest of the CLI code.
-
 ## What `latest` Means
 
 `latest` is the moving release used by normal install and update flows.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,7 @@ This guide walks through a normal Fennara setup from a clean machine to a connec
 
 ## Requirements
 
-- Godot 4 project
+- Godot 4.5+ project
 - An MCP client that can run local stdio MCP servers
 - Windows, macOS, or Linux
 - For C# projects: .NET SDK installed and available as `dotnet`

--- a/local/crates/fennara-cli/src/doctor.rs
+++ b/local/crates/fennara-cli/src/doctor.rs
@@ -55,11 +55,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
         platform_name(),
         arch_name()
     );
-    println!(
-        "addon asset hint: fennara-addon-{}-{}-v{VERSION}.zip",
-        platform_name(),
-        arch_name()
-    );
+    println!("addon asset hint: fennara-addon-v{VERSION}.zip");
 
     if repair {
         println!("repair: base directories ensured");

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -19,7 +19,7 @@ pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String>
 
     let release = fetch_release(version_request)?;
     let local_prefix = format!("fennara-local-{}-{}-v", platform_name(), arch_name());
-    let addon_prefix = format!("fennara-addon-{}-{}-v", platform_name(), arch_name());
+    let addon_prefix = "fennara-addon-v".to_string();
     let local_asset = release
         .asset(&local_prefix)
         .ok_or_else(|| format!("release {} is missing {local_prefix}*.zip", release.tag))?;

--- a/scripts/package-addon-all.mjs
+++ b/scripts/package-addon-all.mjs
@@ -1,0 +1,120 @@
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const args = parseArgs(process.argv.slice(2));
+const version = readVersion();
+const partsDir = path.resolve(root, args["parts-dir"] ?? "dist");
+const distDir = path.join(root, "dist");
+const stageDir = path.join(root, ".package-preview", "addon-all");
+const archive = path.join(distDir, `fennara-addon-v${version}.zip`);
+
+rmSync(stageDir, { recursive: true, force: true });
+mkdirSync(stageDir, { recursive: true });
+
+const partRoots = findAddonParts(partsDir);
+if (partRoots.length === 0) {
+  throw new Error(`No addon parts found in ${path.relative(root, partsDir)}`);
+}
+
+for (const partRoot of partRoots) {
+  copyDir(partRoot, stageDir);
+}
+
+zipDirectory(stageDir, archive);
+console.log(`Created ${path.relative(root, archive)}`);
+
+function findAddonParts(source) {
+  const results = [];
+  visit(source);
+  return results;
+
+  function visit(current) {
+    if (!exists(current) || !statSync(current).isDirectory()) {
+      return;
+    }
+
+    const addonRoot = path.join(current, "addons", "fennara");
+    if (exists(path.join(addonRoot, "fennara.gdextension"))) {
+      results.push(current);
+      return;
+    }
+
+    for (const entry of readdirSync(current)) {
+      visit(path.join(current, entry));
+    }
+  }
+}
+
+function zipDirectory(sourceDir, archivePath) {
+  rmSync(archivePath, { force: true });
+  mkdirSync(path.dirname(archivePath), { recursive: true });
+
+  const script = [
+    "import os, sys, zipfile",
+    "source, archive = sys.argv[1], sys.argv[2]",
+    "with zipfile.ZipFile(archive, 'w', zipfile.ZIP_DEFLATED) as zf:",
+    "    for root, _, files in os.walk(source):",
+    "        for name in files:",
+    "            path = os.path.join(root, name)",
+    "            arcname = os.path.relpath(path, source).replace(os.sep, '/')",
+    "            zf.write(path, arcname)",
+  ].join("\n");
+
+  run("python", ["-c", script, sourceDir, archivePath]);
+}
+
+function copyDir(source, target) {
+  for (const entry of readdirSync(source)) {
+    const sourcePath = path.join(source, entry);
+    const targetPath = path.join(target, entry);
+    if (statSync(sourcePath).isDirectory()) {
+      mkdirSync(targetPath, { recursive: true });
+      copyDir(sourcePath, targetPath);
+    } else {
+      mkdirSync(path.dirname(targetPath), { recursive: true });
+      copyFileSync(sourcePath, targetPath);
+    }
+  }
+}
+
+function run(command, commandArgs) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: root,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let i = 0; i < rawArgs.length; i += 1) {
+    const arg = rawArgs[i];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    if (!rawArgs[i + 1] || rawArgs[i + 1].startsWith("--")) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+    parsed[arg.slice(2)] = rawArgs[i + 1];
+    i += 1;
+  }
+  return parsed;
+}
+
+function readVersion() {
+  return readFileSync(path.join(root, "VERSION"), "utf8").trim();
+}
+
+function exists(filePath) {
+  try {
+    statSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/package-preview.mjs
+++ b/scripts/package-preview.mjs
@@ -14,19 +14,19 @@ const stageRoot = path.join(root, ".package-preview");
 rmSync(stageRoot, { recursive: true, force: true });
 mkdirSync(distDir, { recursive: true });
 
-const addonArchive = packageAddon();
+const addonPart = packageAddonPart();
 const cliArchive = packageCli();
 const localArchive = packageLocal();
 
-console.log(`Created ${path.relative(root, addonArchive)}`);
+console.log(`Created ${path.relative(root, addonPart)}`);
 console.log(`Created ${path.relative(root, cliArchive)}`);
 console.log(`Created ${path.relative(root, localArchive)}`);
 
-function packageAddon() {
-  const stage = path.join(stageRoot, "addon");
+function packageAddonPart() {
   const source = path.join(root, "godot", "addons", "fennara");
-  const target = path.join(stage, "addons", "fennara");
+  const target = path.join(distDir, `addon-part-${platform}-${arch}`, "addons", "fennara");
 
+  rmSync(path.dirname(path.dirname(target)), { recursive: true, force: true });
   mkdirSync(path.join(target, "bin"), { recursive: true });
   copyDir(source, target, (sourcePath) => {
     const relative = path.relative(source, sourcePath).replaceAll(path.sep, "/");
@@ -36,9 +36,7 @@ function packageAddon() {
     return true;
   });
 
-  const archive = path.join(distDir, `fennara-addon-${platform}-${arch}-v${version}.zip`);
-  zipDirectory(stage, archive);
-  return archive;
+  return path.dirname(path.dirname(target));
 }
 
 function packageCli() {


### PR DESCRIPTION
## Summary
- package the Godot addon as one all-platform zip containing Windows, Linux, and macOS GDExtension binaries
- keep CLI and local runtime packages platform-specific
- update the CLI addon asset lookup and release/package docs for the shared addon zip

## Verification
- node --check scripts/package-preview.mjs
- node --check scripts/package-addon-all.mjs
- cargo fmt
- cargo test -p fennara-cli
- git diff --check
- smoke-tested package-addon-all.mjs with fake Windows/Linux addon parts