### PR TITLE
build: add stable latest addon package

### DIFF
--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -174,5 +174,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fennara-package-preview-addon
-          path: dist/fennara-addon-v*.zip
+          path: dist/fennara-addon-*.zip
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,7 +203,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fennara-release-addon
-          path: dist/fennara-addon-v*.zip
+          path: dist/fennara-addon-*.zip
           if-no-files-found: error
   publish:
     name: publish GitHub release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,7 @@ Each public release publishes separate assets so installs can stay modular:
 | --- | --- |
 | `fennara-cli-<platform>-<arch>.zip` | CLI and stable launchers. |
 | `fennara-local-<platform>-<arch>.zip` | Versioned MCP and daemon runtimes. |
-| `fennara-addon-v<version>.zip` | All-platform Godot addon payload with every built GDExtension binary referenced by `fennara.gdextension`. |
+| `fennara-addon-v<version>.zip` / `fennara-addon-latest.zip` | All-platform Godot addon payload with every built GDExtension binary referenced by `fennara.gdextension`. |
 
 The moving `latest` release is what normal users should install from. Versioned
 releases such as `v0.2.8` stay available for pinning and debugging.

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -45,6 +45,12 @@ Shared addon:
 fennara-addon-v<version>.zip
 ```
 
+For Godot Asset Library links, use the stable latest asset:
+
+```text
+fennara-addon-latest.zip
+```
+
 ## 2. Install The CLI
 
 Extract the `fennara-cli` zip.

--- a/docs/release.md
+++ b/docs/release.md
@@ -113,13 +113,15 @@ Shared addon:
 
 ```text
 fennara-addon-v<version>.zip
+fennara-addon-latest.zip
 ```
 
 Package roles:
 
 - `fennara-cli-*`: install script payload; contains only the `fennara` CLI for one platform.
 - `fennara-local-*`: local MCP and daemon launchers plus versioned runtime binaries for one platform.
-- `fennara-addon-v*`: all-platform Godot addon payload copied into projects and used by the Godot Asset Library.
+- `fennara-addon-v*`: versioned all-platform Godot addon payload copied into projects by the CLI.
+- `fennara-addon-latest.zip`: stable all-platform addon URL for the Godot Asset Library and docs links.
 
 The shared addon zip contains every built GDExtension binary referenced by `godot/addons/fennara/fennara.gdextension`. Godot loads the matching library for the user's OS and ignores the others.
 

--- a/scripts/package-addon-all.mjs
+++ b/scripts/package-addon-all.mjs
@@ -10,6 +10,7 @@ const partsDir = path.resolve(root, args["parts-dir"] ?? "dist");
 const distDir = path.join(root, "dist");
 const stageDir = path.join(root, ".package-preview", "addon-all");
 const archive = path.join(distDir, `fennara-addon-v${version}.zip`);
+const latestArchive = path.join(distDir, "fennara-addon-latest.zip");
 
 rmSync(stageDir, { recursive: true, force: true });
 mkdirSync(stageDir, { recursive: true });
@@ -24,7 +25,9 @@ for (const partRoot of partRoots) {
 }
 
 zipDirectory(stageDir, archive);
+copyFileSync(archive, latestArchive);
 console.log(`Created ${path.relative(root, archive)}`);
+console.log(`Created ${path.relative(root, latestArchive)}`);
 
 function findAddonParts(source) {
   const results = [];


### PR DESCRIPTION
## Summary
- emit fennara-addon-latest.zip alongside the versioned all-platform addon zip
- upload both addon zip names from package preview and release workflows
- document the stable addon asset for Godot Asset Library links

## Verification
- node --check scripts/package-addon-all.mjs
- git diff --check origin/main..HEAD