### PR TITLE
fix: parse compact release asset json

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,7 @@ release_json="$tmp_dir/release.json"
 curl -fsSL -H "User-Agent: fennara-install" "$release_api" -o "$release_json"
 
 asset_url="$(
-  sed -nE 's/.*"browser_download_url": "([^"]*fennara-cli-'"$platform"'-'"$arch"'-v[^"]*\.zip)".*/\1/p' "$release_json" |
+  sed -nE 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"([^"]*fennara-cli-'"$platform"'-'"$arch"'-v[^"]*\.zip)".*/\1/p' "$release_json" |
     head -n 1
 )"
 


### PR DESCRIPTION
## What changed

Fixes `install.sh` release asset discovery for GitHub API responses where JSON is minified.

The shell installer previously searched for:

```text
"browser_download_url": "..."
```

But GitHub can return compact JSON like:

```text
"browser_download_url":"..."
```

The sed expression now allows optional whitespace around the colon.

## Why

macOS and Linux installs were failing with messages like:

```text
error: could not find fennara-cli-macos-arm64 asset
```

The release asset existed, but `install.sh` did not find it because it was parsing JSON with a whitespace-sensitive pattern. Windows was unaffected because `install.ps1` uses structured JSON parsing through `Invoke-RestMethod`.

## Verification

- Fetched the real unauthenticated `latest` release JSON from the GitHub API.
- Verified the updated pattern matches:
  - `fennara-cli-macos-arm64-v0.2.9.zip`
  - `fennara-cli-linux-x86_64-v0.2.9.zip`
- Ran `git diff --check`.

## Risk

Low. This only relaxes the existing shell installer asset URL pattern; it does not change installed paths, release names, download URLs, or Windows installer behavior.