### PR TITLE
docs: expand OSS tool reference

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,20 +1,38 @@
 # Fennara Context
 
-This file defines common terms used in Fennara documentation and issues.
+This file defines common terms used in Fennara documentation, issues, release notes, and agent-facing guidance.
 
-## Terms
+## Product Terms
+
+**Fennara**
+
+The Godot-aware agent environment in this repository. Fennara connects AI tools to real Godot feedback such as diagnostics, scene validation, runtime errors, screenshots, and project guidance.
+
+**Godot Addon**
+
+The installable plugin copied into a user's Godot project under `res://addons/fennara/`. It owns the dock UI, Godot-facing inspection tools, native GDExtension library, packaged chat UI assets, runtime helper scripts, and project-local addon version.
+
+**Fennara CLI**
+
+The `fennara` command installed on the user's machine. It handles install, update, CLI self-update, doctor checks, MCP app setup, webview prerequisite warnings, C# setup checks, and generated project guidance.
+
+**Local Package**
+
+The release zip containing local Fennara executables such as the MCP server, daemon, runtime binaries, and launcher binaries for one platform/architecture.
+
+**Project Guidance**
+
+Generated guidance files placed in a Godot project, mainly `AGENTS.md` and `.fennara/ai/guidelines.md`, so AI coding agents know when and how to use Fennara.
+
+## MCP Terms
 
 **Fennara MCP Server**
 
-The local stdio MCP server launched by an AI coding app.
+The local stdio MCP server launched by an AI coding app such as Claude Code, Cursor, Cline, Gemini CLI, or another MCP client. It exposes Fennara tools to that external app.
 
-**Fennara Daemon**
+**MCP App**
 
-The local service that connects MCP calls to the Godot plugin and manages local Godot-facing work.
-
-**Godot Plugin**
-
-The Godot addon installed in a user's project. It provides Godot-aware inspection, diagnostics, validation, screenshots, and editor/runtime feedback.
+An external AI app configured by `fennara mcp-setup`. MCP app setup controls which external app can call Fennara tools; it does not select the model used by Fennara's built-in chat.
 
 **MCP Target**
 
@@ -22,16 +40,70 @@ The Godot project currently selected to receive Fennara MCP calls.
 
 **Tool Schema**
 
-The model-facing description of a Fennara tool, including arguments, limits, and workflow notes.
+The model-facing description of a Fennara MCP tool, including arguments, limits, and workflow notes.
 
 **Tool Result Envelope**
 
 The concise model-facing result returned after a tool call. Fennara results should explain status, important findings, and next useful context without dumping unnecessary raw data.
 
+## Built-In Chat Terms
+
+**Built-In Chat**
+
+Fennara's own chat surface inside the Godot addon or system browser. It is separate from external MCP apps. A user can configure Claude Code for MCP and still choose a different provider/model for built-in chat.
+
+**Chat Surface**
+
+The display mode for built-in chat. Embedded mode uses the native Godot dock webview. Browser mode serves the same UI from the local daemon and opens it in the system browser.
+
+**Chat Provider**
+
+A backend that can generate built-in chat responses, such as OpenRouter, Ollama Cloud, DeepSeek, Z.AI, local Ollama, or LM Studio.
+
+**Model Ref**
+
+The provider-qualified model identifier selected in built-in chat. Slash commands such as `/provider` and `/model` help users connect providers and choose model refs.
+
+**Provider Connection**
+
+Daemon-managed local settings and auth state for a chat provider, including API keys or local base URLs. Provider secrets should stay in local daemon-managed storage, not inside the Godot project.
+
+**Generation Trace**
+
+Stored metadata for a built-in chat generation, tying assistant messages, tool calls, provider/model choice, usage, and cost logs back to the generation that produced them.
+
+## Runtime And Webview Terms
+
+**Fennara Daemon**
+
+The local service that connects MCP calls and built-in chat requests to the Godot addon, stores local runtime state, and serves daemon-hosted chat routes such as `/chat/`.
+
 **Runtime Session**
 
-A daemon-managed Godot runtime session used for runtime inspection, logs, validation, and screenshot workflows.
+A daemon-managed Godot runtime session used for runtime inspection, logs, validation, screenshots, and future running-scene workflows.
 
-**Project Guidance**
+**Godot Snapshot**
 
-Generated guidance files placed in a Godot project so AI coding agents know when and how to use Fennara.
+A reversible project state snapshot taken before a Fennara-assisted turn that may modify files. Snapshot setup should complete before persisting the user turn so failed setup does not leave dangling prompts.
+
+**Webview Runtime**
+
+Platform support needed to display built-in chat in or near Godot. Windows uses WebView2, macOS uses WebKit/WKWebView, and Linux uses a shared CEF runtime installed under Fennara app data.
+
+**Shared Linux CEF Runtime**
+
+The external Linux CEF runtime payload used by the Linux chat webview. It is installed once under the user's Fennara app-data directory and must not be bundled into every Godot addon zip.
+
+## Release Terms
+
+**Release Manifest**
+
+The JSON asset named `fennara-release-manifest-v<version>.json`. It maps release assets to platforms, records SHA-256 hashes, declares shared runtime assets, and sets `minimum_cli_version`.
+
+**Minimum CLI Version**
+
+The lowest `fennara` CLI version allowed to consume a release manifest. If a release needs newer install/update logic, this value must be raised in the generated manifest and in the release workflow that writes it.
+
+**Latest Release**
+
+The moving GitHub release/tag used by installers and default updates. Updating source files after publishing does not change release assets; already-published manifest assets must be replaced explicitly.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ For a C# project:
 fennara install --csharp
 ```
 
+`--csharp` installs Fennara's managed `csharp-ls` language server support so
+`script_diagnostics`, runtime preflight checks, and C# feedback can report real
+C# parser/type issues.
+
 Then open the project in Godot.
 
 `fennara install` also writes project guidance for AI coding agents:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,8 +158,9 @@ For C# projects:
 fennara install --csharp
 ```
 
-adds the same addon plus the C# support files needed by Fennara's diagnostics
-path.
+adds the same addon plus Fennara's managed `csharp-ls` language server support.
+The addon uses that server for `.cs` `script_diagnostics` results and runtime
+preflight checks.
 
 ## MCP Setup
 

--- a/docs/github-metadata.md
+++ b/docs/github-metadata.md
@@ -8,7 +8,7 @@ Godot MCP workflow for AI agents using Fennara: diagnostics, scene validation, r
 
 ## Website
 
-https://www.fennara.io/godot-mcp
+https://www.fennara.io
 
 ## Topics
 

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -255,6 +255,9 @@ cd path/to/your-godot-project
 fennara install --csharp
 ```
 
+`--csharp` installs Fennara's managed `csharp-ls` language server support, which
+the addon uses for `.cs` diagnostics and runtime preflight checks.
+
 The CLI also writes project guidance for AI coding agents:
 
 ```text

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -61,6 +61,10 @@ cd path/to/your-godot-project
 fennara install --csharp
 ```
 
+`--csharp` installs Fennara's managed `csharp-ls` language server support. The
+addon uses it for `.cs` results from `script_diagnostics` and for runtime
+preflight checks before managed scenes are launched.
+
 `fennara install` copies the Godot addon into:
 
 ```text
@@ -235,7 +239,8 @@ Open the intended Godot project and use the Fennara dock to set it as the MCP ta
 
 ### C# Diagnostics Are Missing
 
-Install C# support:
+Install C# support. This installs the managed `csharp-ls` language server used
+by Fennara's C# diagnostics:
 
 ```bash
 cd path/to/your-godot-project

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,34 +2,36 @@
 
 Fennara tools are built around Godot feedback.
 
-The MCP client should still use its normal file search and file reading tools.
-Fennara is for the parts that need Godot itself: scenes, resources, diagnostics,
-runtime output, screenshots, and editor state.
+The MCP client should still use its normal repository search, read, and diff
+tools for broad code navigation. Fennara is for the parts that need Godot
+itself: scenes, resources, diagnostics, runtime output, screenshots, editor
+state, and Godot-aware project settings.
 
 When installed into a project, Fennara writes `.fennara/ai/guidelines.md` and a
 generated Fennara block in `AGENTS.md`. Agents should read that project guidance
-before doing Godot-specific work.
+before doing Godot-specific work. The live MCP tool schemas remain the exact
+source of truth for arguments, limits, and result fields.
 
 ## External MCP Tools
 
 | Tool | Use It For |
 | --- | --- |
-| `fennara_status` | Check which Godot project is connected and whether the local bridge is reachable. |
-| `read_file` | Read project-scoped files and selected image files through Godot-side path normalization. |
-| `file_ops` | List, glob, search with bundled ripgrep, and perform scoped copy/move/delete/create-dir file operations. |
-| `get_scene_tree` | Inspect scene node structure before using node paths. |
-| `get_node_properties` | Read changed node/resource properties in a scene. |
-| `get_class_info` | Look up real Godot class APIs before writing scene edit scripts. |
-| `write_or_update_file` | Create or patch project files, with diagnostics for scripts and shaders. |
-| `run_scene_edit_script` | Make procedural scene/resource edits through Godot APIs. |
-| `save_custom_resource` | Create `.tres` resources, including resources backed by custom scripts. |
-| `project_settings` | Read or change `project.godot` settings and input actions. |
-| `script_diagnostics` | Check `.gd`, `.cs`, and `.gdshader` files after edits. |
-| `validate_scene` | Validate scene structure and run a brief headless startup check. |
-| `screenshot_scene` | Capture a scene image for visual feedback. |
-| `runtime_session` | Start, inspect, or stop a managed running scene. |
-| `runtime_script` | Run a small probe or input-driver script inside a managed runtime session. |
-| `scrape_editor` | Read the Godot editor debugger when the user manually ran a scene. |
+| `fennara_status` | Check the active Godot project, daemon bridge, app-data paths, local runtime state, chat/webview support, and available MCP tools. |
+| `read_file` | Read project-scoped text files and selected images through Godot path normalization and project boundaries. |
+| `file_ops` | List, glob, search with bundled ripgrep, and perform scoped copy/move/delete/create-dir operations inside the project. |
+| `get_scene_tree` | Inspect real scene node structure, node types, scripts, and instanced subscenes before using node paths. |
+| `get_node_properties` | Read properties changed from defaults for up to 5 scene nodes, including recursive SubResource summaries. |
+| `get_class_info` | Look up real Godot class methods, properties, signals, enums, constants, inheritance, and docs before writing Godot API code. |
+| `write_or_update_file` | Create, rewrite, or exact-replace project files. `.gd`, `.cs`, and `.gdshader` edits automatically run diagnostics. |
+| `run_scene_edit_script` | Run one editor-time Godot worker script against exactly one scene/resource graph and save through Godot serialization. |
+| `save_custom_resource` | Create `.tres` resources, including resources backed by custom Resource scripts. |
+| `project_settings` | Read or change `project.godot` settings, autoloads, and input actions through structured operations. |
+| `script_diagnostics` | Check `.gd`, `.cs`, and `.gdshader` files using Godot diagnostics, Godot scene-load checks, and `csharp-ls` for C#. |
+| `validate_scene` | Validate scene structure and, when structural checks pass, run a brief headless startup pass. |
+| `screenshot_scene` | Capture a scene image for layout, camera, rendering, material, and UI feedback. |
+| `runtime_session` | Start, inspect, or stop one daemon-managed running Godot scene with live logs and runtime artifacts. |
+| `runtime_script` | Run a small GDScript probe or input-driver inside an active managed runtime session. |
+| `scrape_editor` | Read a narrow Godot editor debugger snapshot when the user manually ran a scene in the editor. |
 
 These are the tools exposed to external MCP clients through the local
 `fennara-mcp` process.
@@ -73,6 +75,8 @@ use runtime tools or screenshots when behavior/visuals matter
 ### `fennara_status`
 
 Use this first when the MCP client is not sure which Godot project is connected.
+It reports the active project, Godot/addon bridge reachability, app-data paths,
+daemon/runtime state, local chat/webview support, and available Fennara tools.
 
 Example prompt:
 
@@ -82,10 +86,24 @@ Use Fennara MCP to run fennara_status and tell me which Godot project is connect
 
 ## Inspection
 
+### `read_file`
+
+Use this when Godot-side path normalization or image handling matters. It is
+project-scoped and accepts Godot-style paths such as `res://scripts/player.gd`.
+For broad source reading, use the MCP client's normal file reader.
+
+### `file_ops`
+
+Use this for project-scoped listing, globbing, bundled ripgrep search, and
+simple file operations when Godot path boundaries matter. Keep large repository
+navigation on the MCP client's normal search tools unless you specifically need
+Fennara's project-scoped behavior.
+
 ### `get_scene_tree`
 
 Use this before guessing node paths in a `.tscn` file. It returns nodes, types,
-attached scripts, and instanced scenes.
+attached scripts, and instanced scenes. Node paths are relative to the scene
+root when passed to other tools.
 
 Example prompt:
 
@@ -96,8 +114,13 @@ Use get_scene_tree on res://scenes/player.tscn and summarize the important nodes
 ### `get_node_properties`
 
 Use this after `get_scene_tree` when you need to understand existing node or
-resource configuration. It shows properties changed from defaults and summarizes
-important embedded resources.
+resource configuration. It shows properties changed from defaults and expands
+embedded SubResources recursively.
+
+Large or opaque resources are summarized into readable API-oriented output,
+including TileSet, TileMapLayer data, GridMap data, MeshLibrary resources,
+Theme resources, AnimationTree graphs, AnimationLibrary, Animation, and
+SpriteFrames. A call can inspect up to 5 targets.
 
 Example prompt:
 
@@ -108,7 +131,8 @@ Use get_node_properties for the Player node in res://scenes/player.tscn before e
 ### `get_class_info`
 
 Use this before `run_scene_edit_script` when touching Godot nodes/resources. It
-helps avoid invented method names, wrong properties, and wrong enum usage.
+helps avoid invented method names, wrong properties, wrong enum usage, and wrong
+constructor assumptions by returning the real Godot API surface for a class.
 
 Example prompt:
 
@@ -120,11 +144,27 @@ Use get_class_info for CharacterBody2D and AnimationPlayer before writing the sc
 
 ### `write_or_update_file`
 
-Use this for normal project files. It can write a full file or replace an exact
-section. For `.gd`, `.cs`, and `.gdshader` files, Fennara runs diagnostics after
-the edit.
+Use this for normal project text files when a Fennara-aware edit is appropriate.
+It supports two modes:
 
-It must not write Fennara's own addon files or `project.godot`.
+- `write`: create or completely rewrite a file.
+- `update`: replace an exact `old_string` with `new_string`; include enough
+  surrounding text to make the match unique.
+
+For `.gd`, `.cs`, and `.gdshader` files, Fennara automatically runs diagnostics
+after the edit and returns syntax/type/reference or shader parser feedback.
+C# diagnostics use the `csharp-ls` language server installed by
+`fennara install --csharp`.
+
+For `.gdshader` edits, Fennara also scans referencing `.tscn` and `.tres` owners
+and reserializes them through Godot when possible so stale embedded
+`ShaderMaterial` data can be rewritten. Check `reserialized_resources`,
+`reserialize_warnings`, and `reserialize_skipped` in the result.
+
+Blocked paths include `res://project.godot`, `res://.godot/`, `res://.git/`,
+`res://addons/fennara/`, and any `plugin.cfg`. Do not use this tool or generic
+file edits for `.tscn`, `.tres`, or `.res` surgery; use Godot-aware structured
+tools instead.
 
 Example prompt:
 
@@ -135,17 +175,50 @@ Use write_or_update_file to patch res://scripts/player.gd, then report any diagn
 ### `run_scene_edit_script`
 
 Use this for scene/resource edits that are safer through Godot APIs than raw
-text editing. The worker script runs once against a target scene.
+text editing. The tool runs one editor-time worker script against exactly one
+target scene. It gives the script an instantiated scene object graph, not a full
+running gameplay scene.
 
 Good uses:
 
-- add or rename nodes
-- assign resources
+- add, rename, remove, or reparent nodes
+- assign resources and scene-owned SubResources
 - update exported properties
 - create a new scene
+- edit Control layout, cameras, collision shapes, materials, AnimationPlayer
+  setup, signals, and groups
 - inspect scene-owned resources and log a concise summary
 
 Before using it, inspect relevant classes with `get_class_info`.
+
+The worker script must be `@tool`, extend `RefCounted`, and define
+`func run(ctx) -> void`. Inline `code` is saved under
+`res://.fennara/tmp/editor_scripts/`; every result includes the effective
+`script_path`. If a long or failed script needs a retry, patch that returned
+`script_path` with `write_or_update_file` and rerun with `scene_path` plus
+`script_path` instead of pasting a fresh full script.
+
+Useful context methods include `ctx.get_scene_root()`, `ctx.set_scene_root()`,
+`ctx.own()`, `ctx.instance_scene()`, `ctx.get_node_or_null()`,
+`ctx.find_nodes_by_name()`, `ctx.remove_node()`, `ctx.clear_children()`,
+`ctx.mark_modified()`, `ctx.log()`, and `ctx.error()`.
+
+New raw nodes must be given meaningful names and owned with `ctx.own(node)` so
+Godot serializes them. PackedScene instances should be added with
+`ctx.instance_scene(parent, "res://path/to/scene.tscn", "DesiredName")`; do not
+recursively own instance internals.
+
+For inherited scenes, the tool tries to preserve inherited roots and save only
+valid overrides/additions. If Godot would flatten the inherited root, the tool
+restores the original scene and returns a failure instead of silently saving a
+bad scene. In that case, patch the returned script or choose a narrower edit.
+
+Read-only inspection scripts should only log. They should not call
+`ctx.mark_modified()` or mutating helpers. Unmodified inspection runs return
+logs without rewriting the `.tscn`.
+
+`run_scene_edit_script` automatically runs script diagnostics and scene
+validation after edits. Treat those results as part of the edit result.
 
 Example prompt:
 
@@ -155,8 +228,9 @@ Use get_class_info first, then run_scene_edit_script to add a named HealthBar no
 
 ### `save_custom_resource`
 
-Use this to create `.tres` files. For custom resource scripts, pass the full
-script path such as `res://data/UpgradeData.gd`, not only the class name.
+Use this to create `.tres` files through Godot's resource system. For custom
+resource scripts, pass the full script path such as `res://data/UpgradeData.gd`,
+not only the class name.
 
 Example prompt:
 
@@ -166,8 +240,10 @@ Use save_custom_resource to create res://data/upgrades/double_income.tres from r
 
 ### `project_settings`
 
-Use this for Godot project settings, autoloads, and input actions. For input
-actions, use structured events instead of editing `project.godot` manually.
+Use this for Godot project settings, autoloads, display/window settings,
+rendering settings, physics settings, application metadata, addon configuration,
+and input actions. For input actions, use structured events instead of editing
+`project.godot` manually.
 
 Example prompt:
 
@@ -182,6 +258,23 @@ Use project_settings to inspect existing input actions, then add a jump action b
 Use this after editing `.gd`, `.cs`, or `.gdshader` files, especially when the
 edit did not go through `write_or_update_file`.
 
+Targeted calls support at most 5 files. `scan_project: true` scans all `.gd`,
+`.cs`, and `.gdshader` files under `res://`.
+
+The diagnostic sources are language-specific:
+
+- `.gd`: Godot's GDScript diagnostics.
+- `.cs`: the managed `csharp-ls` language server installed by
+  `fennara install --csharp`, with C# project support checked by the addon.
+- `.gdshader`: Godot shader parser diagnostics.
+
+For requested `.gd` and `.cs` files, Fennara also loads and instantiates project
+`.tscn` scenes in memory with Godot logging captured. Script-related scene-load
+errors are attached back to the matching script with `source="scene_load"` and
+`scene_path`, so agents can see which scene triggered the script error. This is
+a diagnostic pass only; it does not open the editor UI, run gameplay, or
+validate arbitrary scene/resource state.
+
 Example prompt:
 
 ```text
@@ -190,10 +283,19 @@ Use script_diagnostics on res://scripts/player.gd and res://scripts/enemy.gd.
 
 ### `validate_scene`
 
-Use this after scene edits. It checks common scene issues such as missing
-resources, broken script references, invalid NodePaths, duplicate names, and
-cyclic dependencies. If the structure is clean, it also runs a short headless
-startup check.
+Use this after scene edits or when checking scene/resource integrity. It accepts
+1 to 10 scene paths.
+
+Structural checks include missing scripts/resources, script extends mismatch,
+unset exported variables, invalid NodePath properties, invalid script
+`$Node`/`get_node()` references, duplicate sibling names, and cyclic scene
+dependencies.
+
+For scenes with zero structural errors, Fennara also runs each scene headlessly
+for exactly 3 seconds through the local daemon using up to 3 memory-throttled
+workers. The result includes compact runtime output inline and points to the
+full result JSON and raw runtime logs. It does not open scenes in the editor or
+scrape the editor Output panel.
 
 Example prompt:
 
@@ -205,7 +307,8 @@ Use validate_scene on res://scenes/main.tscn and explain any errors or warnings.
 
 ### `screenshot_scene`
 
-Use this when layout, framing, camera view, or visual correctness matters.
+Use this when layout, framing, camera view, rendering, material/shader output,
+animation-visible state, or visual correctness matters.
 
 Example prompt:
 
@@ -215,13 +318,27 @@ Use screenshot_scene on res://scenes/main_menu.tscn and check whether the button
 
 ### `runtime_session`
 
-Use this to start, check, or stop a managed running scene. Start returns a
-`session_id` and a `runtime_session.log` path. Treat that log as the source of
-truth for startup output and runtime errors.
+Use this to start, check, or stop a managed running scene. A start request first
+runs scene-execution gates:
+
+- C# projects run `dotnet build`.
+- The requested scene gets a structural `validate_scene` preflight without the
+  headless runtime pass.
+- Fennara checks autoload and scene-attached scripts with targeted diagnostics.
+
+If any gate fails, Fennara does not open the scene. If the gates pass, Fennara
+launches the scene in a separate windowed Godot process with the runtime helper
+enabled.
 
 The daemon currently allows one managed runtime session globally across all
-connected Godot editors. If another managed scene is running, stop or inspect
-that session before starting a new one.
+connected Godot editors. If another managed scene is running, call
+`runtime_session.status` to inspect it or `runtime_session.stop` to close it
+before starting a new one.
+
+Start returns a `session_id` and a `runtime_session.log` path. Treat that log as
+the source of truth for startup output, raw Godot stdout/stderr, runtime errors,
+`FENNARA_SCRIPT_*` markers, `ctx.log(...)` messages, captures, and completion
+events.
 
 Example prompt:
 
@@ -234,8 +351,26 @@ Use runtime_session to start res://scenes/main.tscn, then inspect the session lo
 Use this inside an active `runtime_session` to inspect live state, press input
 actions, click UI, capture frames, or run small bounded probes.
 
-Do not guess a game's controls. Inspect `project_settings`, scripts, scene tree,
-and runtime state first.
+Runtime scripts are not editor tool scripts. Do not include `@tool`. The script
+must extend `RefCounted`, define `func run(ctx: Variant) -> void`, and use
+explicit local types for meaningful variables.
+
+Runtime scripts can finish while the scene stays open. Use follow-up
+`runtime_script` calls for incremental observe/experiment/verify loops, then
+close the scene with `runtime_session.stop` or a final script that calls
+`ctx.close_scene()`.
+
+Await yielding helpers such as `ctx.wait(...)`, `ctx.capture(...)`,
+`ctx.tap_action(...)`, `ctx.action(...)`, `ctx.action_sequence(...)`,
+`ctx.click_at(...)`, and `ctx.click_button(...)`. Synchronous helpers such as
+`ctx.log(...)`, `ctx.press_action(...)`, `ctx.release_action(...)`,
+`ctx.set_mouse_position(...)`, `ctx.release_all_actions()`, and getters do not
+need `await`.
+
+Do not guess a game's controls or objectives. Inspect `project_settings`,
+scripts, the scene tree, and runtime state first. Infer action effects from
+measured state changes, not from action names, attempted input, elapsed time, or
+proximity alone.
 
 Example prompt:
 
@@ -249,6 +384,9 @@ Use this only when the user manually ran a scene in Godot and wants to know what
 the editor debugger currently shows. For scenes started with `runtime_session`,
 read `runtime_session.log` instead.
 
+The result is intentionally narrow and compact: repeated issues are grouped,
+detail lines are capped, and raw editor UI noise is omitted.
+
 Example prompt:
 
 ```text
@@ -259,9 +397,9 @@ Use scrape_editor with target debugger and summarize the current Godot debugger 
 
 Use the MCP client's own tools for:
 
-- reading ordinary files
-- searching code
-- listing folders
+- broad repository search and navigation
+- ordinary text file reading
+- diffs and version control inspection
 - editing files that do not need Godot feedback
 - running non-Godot shell commands
 

--- a/fennara-cpp/SConstruct
+++ b/fennara-cpp/SConstruct
@@ -79,6 +79,7 @@ if env["platform"] == "linux":
         "-fvisibility=hidden",
         "-fvisibility-inlines-hidden",
         "-Wno-deprecated-declarations",
+        "-Wno-attributes",
         "-Wno-missing-field-initializers",
         "-Wno-unused-parameter",
     ])

--- a/llms.txt
+++ b/llms.txt
@@ -3,13 +3,14 @@
 Fennara is a Godot MCP and AI plugin workflow for AI agents working inside real Godot projects.
 
 Canonical URLs:
-- Product: https://www.fennara.io
-- Godot MCP overview: https://www.fennara.io/godot-mcp
-- Godot AI plugin overview: https://www.fennara.io/godot-ai-plugin
-- Setup guide: https://www.fennara.io/docs/get-started
-- MCP docs: https://www.fennara.io/docs/mcp
-- Godot tools docs: https://www.fennara.io/docs/tools
+- Product/site: https://www.fennara.io
+- Repository: https://github.com/fennaraOfficial/fennara-godot-ai
+- Latest release: https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest
 - Demo video: https://www.youtube.com/watch?v=0Egu3S-9MM0
+
+Do not treat website subroutes as canonical unless they are intentionally
+re-added and maintained. For setup, MCP, tool, provider, and release details,
+prefer the repository docs listed below.
 
 Core positioning:
 - Traditional MCP gives an AI commands.


### PR DESCRIPTION
## Summary

This PR updates the OSS repository docs so the tool reference matches the current Fennara behavior more closely.

## Changes

- Expands `docs/tools.md` with technical descriptions for Fennara MCP tools, including `write_or_update_file`, `run_scene_edit_script`, `script_diagnostics`, `validate_scene`, `runtime_session`, and `runtime_script`.
- Clarifies that C# diagnostics use the managed `csharp-ls` language server installed by `fennara install --csharp`.
- Updates setup, manual install, architecture, context, and `llms.txt` wording so agents get clearer OSS docs and stable canonical links.
- Updates GitHub metadata to point at the root Fennara site.
- Suppresses noisy Linux CEF bridge attribute warnings with `-Wno-attributes`.

## Validation

- `git diff --check -- CONTEXT.md README.md docs/architecture.md docs/github-metadata.md docs/manual-install.md docs/setup.md docs/tools.md fennara-cpp/SConstruct llms.txt`
- `python -m py_compile fennara-cpp/SConstruct`
