### PR TITLE
fix: make CLI installs verbose and bounded

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -292,6 +292,16 @@ When release packaging builds the CLI, those templates are compiled into the bin
 
 Use `promote_latest: false` only when publishing a version that should not become the default user install.
 
+Installers and release downloads should print release metadata, asset download,
+extract, install, and verification steps. Network fetches should use bounded
+timeouts so GitHub/CDN stalls fail with a diagnostic instead of looking frozen.
+On Windows, `install.ps1` must check the CLI verification exit code before
+printing success. Exit code `-1073741515` (`0xC0000135`) means the CLI executable
+was written but Windows could not start it because a required DLL is missing;
+tell the user to install Microsoft Visual C++ Redistributable 2015-2022 x64 and
+then rerun `fennara --version`, `fennara doctor`, and `fennara install`.
+Download URL: `https://aka.ms/vs/17/release/vc_redist.x64.exe`.
+
 ## Smoke Test After Release
 
 On Windows:

--- a/install.ps1
+++ b/install.ps1
@@ -27,6 +27,34 @@ Options:
 $repo = "fennaraOfficial/fennara-godot-ai"
 $platform = "windows"
 $arch = "x86_64"
+$networkTimeoutSeconds = 120
+
+function Format-Bytes([long] $Bytes) {
+  if ($Bytes -ge 1MB) {
+    return "{0:n1} MB" -f ($Bytes / 1MB)
+  }
+  if ($Bytes -ge 1KB) {
+    return "{0:n1} KB" -f ($Bytes / 1KB)
+  }
+  return "$Bytes B"
+}
+
+function Show-MissingRuntimeHelp {
+  Write-Host ""
+  Write-Host "Your Fennara CLI installed, but Windows cannot start it."
+  Write-Host "The exit code -1073741515 means a required Windows DLL is missing."
+  Write-Host "Please install Microsoft Visual C++ Redistributable 2015-2022 x64, then reopen PowerShell and run:"
+  Write-Host ""
+  Write-Host "  fennara --version"
+  Write-Host "  fennara doctor"
+  Write-Host "  fennara install"
+  Write-Host ""
+  Write-Host "Download:"
+  Write-Host "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+  Write-Host ""
+  Write-Host "Expected first line:"
+  Write-Host "  fennara <version>"
+}
 
 if (-not $InstallDir -and -not $env:LOCALAPPDATA) {
   throw "LOCALAPPDATA is not set."
@@ -39,7 +67,9 @@ $releaseApi = if ($Version -eq "latest") {
 }
 
 Write-Host "Fetching Fennara release metadata..."
-$release = Invoke-RestMethod -Uri $releaseApi -Headers @{ "User-Agent" = "fennara-install" }
+Write-Host "release api: $releaseApi"
+$release = Invoke-RestMethod -Uri $releaseApi -Headers @{ "User-Agent" = "fennara-install" } -TimeoutSec $networkTimeoutSeconds
+Write-Host "release: $($release.tag_name)"
 $asset = $release.assets |
   Where-Object { $_.name -like "fennara-cli-$platform-$arch-v*.zip" } |
   Select-Object -First 1
@@ -58,7 +88,11 @@ New-Item -ItemType Directory -Force -Path $tempDir, $extractDir, $binDir | Out-N
 
 try {
   Write-Host "Downloading $($asset.name)..."
-  Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -Headers @{ "User-Agent" = "fennara-install" }
+  Write-Host "from: $($asset.browser_download_url)"
+  Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -Headers @{ "User-Agent" = "fennara-install" } -TimeoutSec $networkTimeoutSeconds
+  $download = Get-Item -LiteralPath $zipPath
+  Write-Host "downloaded: $($asset.name) ($(Format-Bytes $download.Length))"
+  Write-Host "Extracting Fennara CLI..."
   Expand-Archive -LiteralPath $zipPath -DestinationPath $extractDir -Force
 
   $source = Join-Path $extractDir "bin\fennara.exe"
@@ -67,6 +101,7 @@ try {
   }
 
   $target = Join-Path $binDir "fennara.exe"
+  Write-Host "Installing Fennara CLI to $target..."
   Copy-Item -LiteralPath $source -Destination $target -Force
 
   $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -91,7 +126,19 @@ try {
   }
 
   Write-Host "Verifying Fennara CLI..."
-  & $target --version
+  $versionOutput = & $target --version 2>&1
+  $verifyExitCode = $LASTEXITCODE
+  if ($verifyExitCode -ne 0) {
+    if (($verifyExitCode -eq -1073741515) -or ("$verifyExitCode" -eq "3221225781")) {
+      Show-MissingRuntimeHelp
+    }
+    if ($versionOutput) {
+      Write-Host "verification output:"
+      $versionOutput | ForEach-Object { Write-Host "  $_" }
+    }
+    throw "Fennara CLI verification failed with exit code $verifyExitCode."
+  }
+  $versionOutput | ForEach-Object { Write-Host $_ }
 
   if (Get-Command fennara -ErrorAction SilentlyContinue) {
     Write-Host "fennara command: available"

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,8 @@ REPO="fennaraOfficial/fennara-godot-ai"
 VERSION="latest"
 INSTALL_DIR="${FENNARA_INSTALL_DIR:-}"
 MODIFY_PATH=1
+CURL_CONNECT_TIMEOUT=20
+CURL_MAX_TIME=120
 
 usage() {
   cat <<'EOF'
@@ -77,6 +79,32 @@ need() {
 need curl
 need unzip
 
+curl_quiet() {
+  url="$1"
+  output="$2"
+  curl -fsSL \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+    --max-time "$CURL_MAX_TIME" \
+    --retry 2 \
+    --retry-delay 1 \
+    -H "User-Agent: fennara-install" \
+    "$url" \
+    -o "$output"
+}
+
+curl_download() {
+  url="$1"
+  output="$2"
+  curl -fL \
+    --connect-timeout "$CURL_CONNECT_TIMEOUT" \
+    --max-time "$CURL_MAX_TIME" \
+    --retry 2 \
+    --retry-delay 1 \
+    -H "User-Agent: fennara-install" \
+    "$url" \
+    -o "$output"
+}
+
 os="$(uname -s)"
 case "$os" in
   Darwin) platform="macos" ;;
@@ -115,8 +143,16 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 echo "Fetching Fennara release metadata..."
+echo "release api: $release_api"
 release_json="$tmp_dir/release.json"
-curl -fsSL -H "User-Agent: fennara-install" "$release_api" -o "$release_json"
+curl_quiet "$release_api" "$release_json"
+release_tag="$(
+  sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$release_json" |
+    head -n 1
+)"
+if [ -n "$release_tag" ]; then
+  echo "release: $release_tag"
+fi
 
 asset_url="$(
   sed -nE 's/.*"browser_download_url"[[:space:]]*:[[:space:]]*"([^"]*fennara-cli-'"$platform"'-'"$arch"'-v[^"]*\.zip)".*/\1/p' "$release_json" |
@@ -133,7 +169,11 @@ extract_dir="$tmp_dir/extract"
 mkdir -p "$extract_dir" "$bin_dir" "$link_dir"
 
 echo "Downloading $(basename "$asset_url")..."
-curl -fL -H "User-Agent: fennara-install" "$asset_url" -o "$zip_path"
+echo "from: $asset_url"
+curl_download "$asset_url" "$zip_path"
+zip_size="$(wc -c < "$zip_path" | tr -d ' ')"
+echo "downloaded: $(basename "$asset_url") ($zip_size bytes)"
+echo "Extracting Fennara CLI..."
 unzip -q "$zip_path" -d "$extract_dir"
 
 if [ ! -f "$extract_dir/bin/fennara" ]; then
@@ -146,7 +186,16 @@ chmod +x "$bin_dir/fennara"
 ln -sf "$bin_dir/fennara" "$link_dir/fennara"
 
 echo "Verifying Fennara CLI..."
-"$bin_dir/fennara" --version
+if version_output="$("$bin_dir/fennara" --version 2>&1)"; then
+  echo "$version_output"
+else
+  status="$?"
+  echo "error: Fennara CLI verification failed with exit code $status" >&2
+  if [ -n "$version_output" ]; then
+    echo "$version_output" >&2
+  fi
+  exit "$status"
+fi
 
 ensure_profile_path() {
   profile_path=""

--- a/local/crates/fennara-cli/src/project_install.rs
+++ b/local/crates/fennara-cli/src/project_install.rs
@@ -11,6 +11,8 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     let options = InstallOptions::parse(args)?;
     let project_dir = resolve_project_dir(options.project_dir)?;
     ensure_godot_project(&project_dir)?;
+    println!("Installing Fennara");
+    println!("project: {}", display_path(&project_dir));
 
     if project_addon_dir(&project_dir).exists() {
         return Err(format!(
@@ -20,15 +22,22 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     }
 
     let (version, source) = match options.source_dir {
-        Some(path) => ("local".to_string(), path),
+        Some(path) => {
+            println!("package: using local addon source {}", display_path(&path));
+            ("local".to_string(), path)
+        }
         None => {
+            println!("requested version: {}", options.version);
             let package = release_package::ensure_package(&options.version)?;
             (package.version, package.addon_dir)
         }
     };
+    println!("addon: copying from {}", display_path(&source));
     install_addon(&project_dir, &source)?;
+    println!("guidance: writing AGENTS.md and .fennara/ai/guidelines.md");
     project_guidance::write(&project_dir)?;
     if options.csharp {
+        println!("csharp: installing language server support");
         csharp_support::install()?;
     }
 

--- a/local/crates/fennara-cli/src/release_client.rs
+++ b/local/crates/fennara-cli/src/release_client.rs
@@ -5,9 +5,13 @@ use std::env;
 use std::fs;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use zip::ZipArchive;
 
 const REPO: &str = "fennaraOfficial/fennara-godot-ai";
+const HTTP_CONNECT_TIMEOUT_SECS: u64 = 20;
+const HTTP_READ_TIMEOUT_SECS: u64 = 120;
+const HTTP_WRITE_TIMEOUT_SECS: u64 = 30;
 
 #[derive(Clone)]
 pub struct ReleaseAsset {
@@ -74,22 +78,26 @@ pub fn fetch_release(version: &str) -> Result<Release, String> {
         format!("v{version}")
     };
     let url = format!("https://api.github.com/repos/{REPO}/releases/tags/{tag}");
-    let response = ureq::get(&url)
+    println!("release: fetching metadata from {url}");
+    let response = http_agent()
+        .get(&url)
         .set("User-Agent", "fennara-cli")
         .call()
-        .map_err(|err| format!("failed to fetch release metadata: {err}"))?;
+        .map_err(|err| format!("failed to fetch release metadata from {url}: {err}"))?;
     let value: Value = response
         .into_json()
         .map_err(|err| format!("failed to parse release metadata: {err}"))?;
 
-    Ok(Release {
+    let release = Release {
         tag: value
             .get("tag_name")
             .and_then(Value::as_str)
             .unwrap_or(&tag)
             .to_string(),
         assets: value.get("assets").cloned().unwrap_or(Value::Null),
-    })
+    };
+    println!("release: {}", release.tag);
+    Ok(release)
 }
 
 pub fn download_zip_to_dir(asset: &DownloadAsset<'_>, target: &Path) -> Result<(), String> {
@@ -104,26 +112,38 @@ pub fn download_zip_to_dir(asset: &DownloadAsset<'_>, target: &Path) -> Result<(
                 asset.label
             ));
         }
+        println!("sha256: verified {}", asset.label);
     }
 
+    println!("extracting: {} to {}", asset.label, display_path(target));
     let cursor = Cursor::new(bytes);
     let mut archive =
         ZipArchive::new(cursor).map_err(|err| format!("failed to open downloaded zip: {err}"))?;
     archive
         .extract(target)
-        .map_err(|err| format!("failed to extract zip into {}: {err}", display_path(target)))
+        .map_err(|err| format!("failed to extract zip into {}: {err}", display_path(target)))?;
+    println!("extracted: {}", asset.label);
+    Ok(())
 }
 
 pub fn download_bytes(url: &str, label: &str) -> Result<Vec<u8>, String> {
-    let response = ureq::get(url)
+    println!("download: {label}");
+    println!("from: {url}");
+    let response = http_agent()
+        .get(url)
         .set("User-Agent", "fennara-cli")
         .call()
-        .map_err(|err| format!("failed to download {label} from {url}: {err}"))?;
+        .map_err(|err| {
+            format!(
+                "failed to download {label} from {url} within connect/read timeouts ({HTTP_CONNECT_TIMEOUT_SECS}s/{HTTP_READ_TIMEOUT_SECS}s): {err}"
+            )
+        })?;
     let mut bytes = Vec::new();
     response
         .into_reader()
         .read_to_end(&mut bytes)
         .map_err(|err| format!("failed to read download for {label}: {err}"))?;
+    println!("downloaded: {label} ({})", format_bytes(bytes.len()));
     Ok(bytes)
 }
 
@@ -149,5 +169,27 @@ fn version_from_asset_name(name: &str) -> Option<String> {
         Some(version.to_string())
     } else {
         None
+    }
+}
+
+fn http_agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(HTTP_CONNECT_TIMEOUT_SECS))
+        .timeout_read(Duration::from_secs(HTTP_READ_TIMEOUT_SECS))
+        .timeout_write(Duration::from_secs(HTTP_WRITE_TIMEOUT_SECS))
+        .build()
+}
+
+fn format_bytes(bytes: usize) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = 1024.0 * 1024.0;
+
+    let bytes = bytes as f64;
+    if bytes >= MB {
+        format!("{:.1} MB", bytes / MB)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes / KB)
+    } else {
+        format!("{bytes:.0} B")
     }
 }

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -14,8 +14,10 @@ pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String>
     let layout = AppLayout::detect()?;
     layout.ensure_base_dirs()?;
 
+    println!("package: resolving release {version_request}");
     let release = release_client::fetch_release(version_request)?;
     if let Some(manifest_asset) = release.manifest_asset() {
+        println!("manifest: {}", manifest_asset.name);
         let bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
         let manifest = ReleaseManifest::parse(&bytes)?;
         manifest.validate_for_install()?;
@@ -31,6 +33,7 @@ fn ensure_manifest_package(
     manifest: &ReleaseManifest,
 ) -> Result<InstalledPackage, String> {
     let selection = manifest.select_for_current_platform()?;
+    println!("package: selected {}", selection.version);
     let local_asset = release
         .asset_by_name(&selection.local.name)
         .ok_or_else(|| {
@@ -78,6 +81,7 @@ fn ensure_legacy_package(
     layout: &AppLayout,
     release: &Release,
 ) -> Result<InstalledPackage, String> {
+    println!("package: using legacy release assets");
     let local_prefix = format!("fennara-local-{}-{}-v", platform_name(), arch_name());
     let addon_prefix = "fennara-addon-v".to_string();
     let local_asset = release
@@ -123,6 +127,10 @@ fn ensure_selected_package(
 ) -> Result<InstalledPackage, String> {
     if package_complete(layout, version) {
         write_manifest(layout, version)?;
+        println!(
+            "package: version {version} already installed at {}",
+            display_path(&layout.versions_dir.join(version))
+        );
         return Ok(InstalledPackage {
             version: version.to_string(),
             addon_dir: addon_dir(layout, version),
@@ -130,6 +138,7 @@ fn ensure_selected_package(
     }
 
     let temp_dir = release_client::create_temp_dir("fennara-package")?;
+    println!("package: staging downloads in {}", display_path(&temp_dir));
     let result = install_from_assets(layout, &temp_dir, version, local_asset, addon_asset);
     let _ = fs::remove_dir_all(&temp_dir);
     result
@@ -170,6 +179,7 @@ fn install_from_assets(
     release_client::download_zip_to_dir(&local_asset, &local_dir)?;
     release_client::download_zip_to_dir(&addon_asset, &addon_stage_dir)?;
 
+    println!("package: installing version {version}");
     let package_version = fs::read_to_string(local_dir.join("VERSION"))
         .map_err(|err| format!("downloaded local package is missing VERSION: {err}"))?
         .trim()
@@ -185,6 +195,7 @@ fn install_from_assets(
     fs::create_dir_all(&version_dir)
         .map_err(|err| format!("failed to create {}: {err}", display_path(&version_dir)))?;
 
+    println!("launchers: updating {}", display_path(&layout.bin_dir));
     copy_existing_launcher(
         &local_dir.join("bin").join(binary_name("fennara-mcp")),
         &layout.bin_dir.join(binary_name("fennara-mcp")),
@@ -193,6 +204,7 @@ fn install_from_assets(
         &local_dir.join("bin").join(binary_name("fennara-daemon")),
         &layout.bin_dir.join(binary_name("fennara-daemon")),
     )?;
+    println!("runtimes: installing to {}", display_path(&version_dir));
     copy_file(
         &local_dir
             .join("bin")
@@ -214,6 +226,10 @@ fn install_from_assets(
             )
         })?;
     }
+    println!(
+        "addon package: installing to {}",
+        display_path(&addon_target)
+    );
     copy_dir(&addon_stage_dir, &addon_target)?;
     write_manifest(layout, version)?;
 
@@ -224,6 +240,10 @@ fn install_from_assets(
 }
 
 fn write_manifest(layout: &AppLayout, version: &str) -> Result<(), String> {
+    println!(
+        "current manifest: writing {}",
+        display_path(&layout.current_manifest_path)
+    );
     let manifest = serde_json::json!({
         "version": version,
         "mcp_runtime": format!("versions/{version}/{}", binary_name("fennara-mcp-runtime")),

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -10,6 +10,9 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     let options = UpdateOptions::parse(args)?;
     let project_dir = project_install::resolve_project_dir(options.project_dir.clone())?;
     project_install::ensure_godot_project(&project_dir)?;
+    println!("Updating Fennara");
+    println!("project: {}", display_path(&project_dir));
+    println!("requested version: {}", options.version);
 
     if !project_install::has_fennara_addon(&project_dir) {
         return Err(format!(
@@ -19,16 +22,21 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     }
 
     if !options.no_self_update {
+        println!("self-update: checking installed CLI");
         match self_update::start(&options.version, options.continuation_args())? {
             StartResult::Started => return Ok(()),
-            StartResult::AlreadyCurrent => {}
+            StartResult::AlreadyCurrent => println!("self-update: CLI is current"),
             StartResult::Skipped(reason) => println!("warning: {reason}"),
         }
+    } else {
+        println!("self-update: skipped by --no-self-update");
     }
 
+    println!("package: resolving update package");
     let package = release_package::ensure_package(&options.version)?;
     let project_version = project_install::project_addon_version(&project_dir);
     if project_version.as_deref() == Some(package.version.as_str()) {
+        println!("guidance: refreshing AGENTS.md and .fennara/ai/guidelines.md");
         project_guidance::write(&project_dir)?;
         println!("Fennara is already up to date.");
         println!("version: {}", package.version);
@@ -38,7 +46,9 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
         return Ok(());
     }
 
+    println!("addon: copying from {}", display_path(&package.addon_dir));
     project_install::install_addon(&project_dir, &package.addon_dir)?;
+    println!("guidance: refreshing AGENTS.md and .fennara/ai/guidelines.md");
     project_guidance::write(&project_dir)?;
     println!("Updated Fennara");
     println!(

--- a/local/crates/fennara-cli/src/self_update.rs
+++ b/local/crates/fennara-cli/src/self_update.rs
@@ -38,6 +38,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
     let layout = AppLayout::detect()?;
     layout.ensure_base_dirs()?;
 
+    println!("self-update: resolving release {version_request}");
     let release = release_client::fetch_release(version_request)?;
     let Some(manifest_asset) = release.manifest_asset() else {
         return Ok(StartResult::Skipped(format!(
@@ -48,6 +49,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
     let manifest_bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
     let manifest = ReleaseManifest::parse(&manifest_bytes)?;
     let selection = manifest.select_cli_for_current_platform()?;
+    println!("self-update: selected CLI {}", selection.version);
 
     match compare_versions(VERSION, &selection.version) {
         Some(Ordering::Less) => {}
@@ -65,6 +67,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
         .ok_or_else(|| format!("release {} is missing {}", release.tag, selection.cli.name))?;
     let target = installed_cli_path(&layout)?;
     let stage_dir = create_stage_dir(&layout)?;
+    println!("self-update: staging CLI in {}", display_path(&stage_dir));
     let extract_dir = stage_dir.join("extract");
     release_client::download_zip_to_dir(
         &DownloadAsset {
@@ -83,6 +86,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
         ));
     }
     make_executable(&staged_cli)?;
+    println!("self-update: verifying staged CLI");
     validate_cli_version(&staged_cli, &selection.version)?;
 
     println!("Updating Fennara CLI");
@@ -98,6 +102,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
         .arg("--target")
         .arg(&target);
     if !continuation_args.is_empty() {
+        println!("continuation: fennara {}", continuation_args.join(" "));
         command.arg("--").args(continuation_args);
     }
     command
@@ -110,6 +115,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
 
 pub fn complete(args: Vec<String>) -> Result<(), String> {
     let options = CompleteOptions::parse(args)?;
+    println!("self-update: replacing {}", display_path(&options.target));
     replace_with_retry(&options.source, &options.target)?;
     let installed_version = cli_version_output(&options.target)?;
 
@@ -121,11 +127,16 @@ pub fn complete(args: Vec<String>) -> Result<(), String> {
         return Ok(());
     }
 
+    println!(
+        "continuation: fennara {}",
+        options.continuation_args.join(" ")
+    );
     let status = Command::new(&options.target)
         .args(&options.continuation_args)
         .status()
         .map_err(|err| format!("failed to continue update with new Fennara CLI: {err}"))?;
     if status.success() {
+        println!("continuation: completed");
         Ok(())
     } else {
         Err(format!("continued update command exited with {status}"))
@@ -297,12 +308,27 @@ fn cli_version_output(path: &Path) -> Result<String, String> {
         .map_err(|err| format!("failed to run {} --version: {err}", display_path(path)))?;
     if !output.status.success() {
         return Err(format!(
-            "{} --version exited with {}",
+            "{} --version exited with {}{}",
             display_path(path),
-            output.status
+            output.status,
+            cli_startup_hint(output.status.code())
         ));
     }
     Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(windows)]
+fn cli_startup_hint(exit_code: Option<i32>) -> &'static str {
+    if exit_code == Some(-1073741515) {
+        "\nWindows could not start Fennara because a required DLL is missing. Install Microsoft Visual C++ Redistributable 2015-2022 x64, then open a new PowerShell and run `fennara --version`, `fennara doctor`, and `fennara install`.\nDownload: https://aka.ms/vs/17/release/vc_redist.x64.exe"
+    } else {
+        ""
+    }
+}
+
+#[cfg(not(windows))]
+fn cli_startup_hint(_exit_code: Option<i32>) -> &'static str {
+    ""
 }
 
 #[cfg(unix)]

--- a/local/crates/fennara-cli/src/webview_runtime.rs
+++ b/local/crates/fennara-cli/src/webview_runtime.rs
@@ -1,9 +1,10 @@
 use crate::app_layout::{AppLayout, arch_name, display_path, platform_name};
+use crate::release_client;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::env;
 use std::fs;
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use zip::ZipArchive;
@@ -313,16 +314,9 @@ fn download_and_install_zip(
     target_dir: &Path,
     manifest: &Value,
 ) -> Result<(), String> {
-    let response = ureq::get(url)
-        .set("User-Agent", "fennara-cli")
-        .call()
-        .map_err(|err| format!("failed to download Linux CEF runtime {url}: {err}"))?;
-    let mut bytes = Vec::new();
-    response
-        .into_reader()
-        .read_to_end(&mut bytes)
-        .map_err(|err| format!("failed to read Linux CEF runtime download: {err}"))?;
+    let bytes = release_client::download_bytes(url, "Linux CEF runtime")?;
 
+    println!("webview runtime: verifying Linux CEF runtime");
     let actual_sha256 = format!("{:x}", Sha256::digest(&bytes));
     if !actual_sha256.eq_ignore_ascii_case(expected_sha256) {
         return Err(format!(
@@ -333,6 +327,10 @@ fn download_and_install_zip(
     let extract_dir = temp_dir.join("extract");
     fs::create_dir_all(&extract_dir)
         .map_err(|err| format!("failed to create {}: {err}", display_path(&extract_dir)))?;
+    println!(
+        "webview runtime: extracting Linux CEF runtime to {}",
+        display_path(&extract_dir)
+    );
     let mut archive = ZipArchive::new(Cursor::new(bytes))
         .map_err(|err| format!("failed to open Linux CEF runtime zip: {err}"))?;
     archive.extract(&extract_dir).map_err(|err| {
@@ -351,6 +349,10 @@ fn download_and_install_zip(
     fs::create_dir_all(platform_dir)
         .map_err(|err| format!("failed to create {}: {err}", display_path(platform_dir)))?;
     let staging_dir = create_unique_sibling_dir(platform_dir, ".install-cef")?;
+    println!(
+        "webview runtime: staging Linux CEF runtime in {}",
+        display_path(&staging_dir)
+    );
 
     let install_result = (|| {
         copy_dir(&extract_dir, &staging_dir)?;


### PR DESCRIPTION
## Summary
- Add visible release metadata, download, extract, install, and verification progress across `fennara install`, `fennara update`, `fennara self-update`, and Linux CEF runtime fetches.
- Add bounded HTTP timeouts for Rust release downloads plus curl/PowerShell bootstrap downloads so stalled GitHub/CDN requests fail instead of looking frozen.
- Make `install.ps1` fail verification when the installed CLI exits nonzero, with a specific `-1073741515` / `0xC0000135` VC++ Redistributable hint.
- Keep `install.sh` verification explicit and document the release/install diagnostic expectations.

## Verification
- `cargo fmt -p fennara-cli`
- `cargo test -p fennara-cli`
- `git diff --check`
- `sh -n install.sh`
- PowerShell parse check for `install.ps1`
- `powershell -NoProfile -File .\install.ps1 -Help`
- `sh install.sh --help`
- `cargo run -p fennara-cli -- --version`

## Notes
- Branch is based directly on current `origin/main` and contains one commit.
- This does not publish a release or alter GitHub release workflow behavior.