### PR TITLE
fix: correct webview geometry and key updates

### DIFF
--- a/fennara-cpp/src/ui/dock.cpp
+++ b/fennara-cpp/src/ui/dock.cpp
@@ -456,7 +456,7 @@ void FennaraDock::_show_browser_fallback(const godot::String &message) {
 
 bool FennaraDock::_webview_region_is_stable() {
     godot::Control *owner = webview_region ? webview_region : this;
-    godot::Vector2 position = owner->get_screen_position();
+    godot::Vector2 position = owner->get_global_position();
     godot::Vector2 size = owner->get_size();
     bool changed =
         position.distance_to(last_region_position) > 1.0 ||

--- a/fennara-cpp/src/ui/webview_host_windows.cpp
+++ b/fennara-cpp/src/ui/webview_host_windows.cpp
@@ -49,10 +49,10 @@ WebviewGeometry compute_webview_geometry(godot::Control *owner) {
         return geometry;
     }
 
-    godot::Vector2 screen_position = owner->get_screen_position();
+    godot::Vector2 position = owner->get_global_position();
     geometry.visible = true;
-    geometry.x = static_cast<int>(screen_position.x);
-    geometry.y = static_cast<int>(screen_position.y);
+    geometry.x = static_cast<int>(position.x);
+    geometry.y = static_cast<int>(position.y);
     geometry.width = static_cast<int>(size.x);
     geometry.height = static_cast<int>(size.y);
     return geometry;
@@ -290,16 +290,8 @@ public:
             return;
         }
 
-        HWND parent_hwnd = reinterpret_cast<HWND>(parent_window);
-        POINT origin{
-            static_cast<LONG>(geometry.x),
-            static_cast<LONG>(geometry.y),
-        };
-        if (parent_hwnd != nullptr) {
-            ScreenToClient(parent_hwnd, &origin);
-        }
-        int x = static_cast<int>(origin.x);
-        int y = static_cast<int>(origin.y);
+        int x = geometry.x;
+        int y = geometry.y;
 
         SetWindowPos(
             hwnd,
@@ -310,8 +302,6 @@ public:
             geometry.height,
             SWP_NOACTIVATE | SWP_NOZORDER);
         ShowWindow(hwnd, SW_SHOW);
-        debug_log("Web chat Windows widget state after ShowWindow: " +
-                  window_state_string(hwnd));
 
         if (x != last_x || y != last_y || geometry.width != last_width ||
             geometry.height != last_height) {
@@ -323,6 +313,8 @@ public:
                        " y=" + godot::String::num_int64(y) +
                        " w=" + godot::String::num_int64(geometry.width) +
                        " h=" + godot::String::num_int64(geometry.height));
+            debug_log("Web chat Windows widget state after ShowWindow: " +
+                      window_state_string(hwnd));
         }
     }
 

--- a/godot/addons/fennara/dist/provider-popovers.js
+++ b/godot/addons/fennara/dist/provider-popovers.js
@@ -214,18 +214,28 @@
     }
 
     function renderProviderRow(provider) {
+      const canUpdateKey = provider.auth?.type === "api_key" && provider.connected;
+      const status = canUpdateKey ? "Connected - update key" : providerStatusLabel(provider);
       const row = document.createElement("button");
       row.className = "provider-row";
       row.type = "button";
       row.dataset.providerOption = provider.id;
+      row.title = canUpdateKey
+        ? `Update ${provider.name} API key`
+        : `Use ${provider.name}`;
       row.innerHTML = [
         "<span>",
         `<strong>${escapeHtml(provider.name)}</strong>`,
         "</span>",
-        `<b>${escapeHtml(providerStatusLabel(provider))}</b>`,
+        `<b>${escapeHtml(status)}</b>`,
       ].join("");
       row.addEventListener("click", (event) => {
         event.stopPropagation();
+        if (canUpdateKey) {
+          chooseProvider(provider.id);
+          openProviderKeyPrompt(provider.id);
+          return;
+        }
         chooseProvider(provider.id);
       });
       return row;

--- a/ui/chat/provider-popovers.js
+++ b/ui/chat/provider-popovers.js
@@ -214,18 +214,28 @@
     }
 
     function renderProviderRow(provider) {
+      const canUpdateKey = provider.auth?.type === "api_key" && provider.connected;
+      const status = canUpdateKey ? "Connected - update key" : providerStatusLabel(provider);
       const row = document.createElement("button");
       row.className = "provider-row";
       row.type = "button";
       row.dataset.providerOption = provider.id;
+      row.title = canUpdateKey
+        ? `Update ${provider.name} API key`
+        : `Use ${provider.name}`;
       row.innerHTML = [
         "<span>",
         `<strong>${escapeHtml(provider.name)}</strong>`,
         "</span>",
-        `<b>${escapeHtml(providerStatusLabel(provider))}</b>`,
+        `<b>${escapeHtml(status)}</b>`,
       ].join("");
       row.addEventListener("click", (event) => {
         event.stopPropagation();
+        if (canUpdateKey) {
+          chooseProvider(provider.id);
+          openProviderKeyPrompt(provider.id);
+          return;
+        }
         chooseProvider(provider.id);
       });
       return row;


### PR DESCRIPTION
## Summary
- fix Windows native WebView2 dock placement by using Godot window-local control coordinates for the child HWND
- reduce repeated Windows webview geometry debug spam
- let connected API-key providers, including OpenRouter, reopen the API key prompt to replace/resave keys

## Verification
- `node --check ui/chat/provider-popovers.js`
- `node --check godot/addons/fennara/dist/provider-popovers.js`
- `git diff --check`
- `scons platform=windows target=editor --debug=explain --cache-show`
