### PR TITLE
fix: make get_class_info respect editor version and addon classes

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -175,6 +175,14 @@ Use this before `run_scene_edit_script` when touching Godot nodes/resources. It
 helps avoid invented method names, wrong properties, wrong enum usage, and wrong
 constructor assumptions by returning the real Godot API surface for a class.
 
+For built-in Godot classes, Fennara reads official XML docs from the GitHub
+branch matching the connected editor's major/minor version, with an explicit
+`master` fallback if that version branch or class XML is unavailable. Runtime
+ClassDB information still comes from the connected editor.
+
+For GDExtension/native addon classes, Fennara skips official Godot XML docs
+lookup and returns runtime ClassDB/property information instead.
+
 Example prompt:
 
 ```text

--- a/fennara-cpp/include/fennara/tools/get_class_info/docs_branch.hpp
+++ b/fennara-cpp/include/fennara/tools/get_class_info/docs_branch.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace fennara::get_class_info {
+
+godot::String fallback_docs_branch();
+godot::String docs_branch_from_version_info(const godot::Dictionary &version_info);
+godot::String docs_branch_for_running_godot();
+
+} // namespace fennara::get_class_info

--- a/fennara-cpp/src/local_bridge/protocol.cpp
+++ b/fennara-cpp/src/local_bridge/protocol.cpp
@@ -2,6 +2,7 @@
 
 #include "fennara/lsp/csharp_support.hpp"
 #include "fennara/logger.hpp"
+#include "fennara/tools/get_class_info/docs_branch.hpp"
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/crypto.hpp>
@@ -231,7 +232,7 @@ void FennaraLocalBridge::_maybe_send_get_class_info_warmup() {
 
     godot::Dictionary payload;
     payload["type"] = "warm_get_class_info_docs";
-    payload["branch"] = "master";
+    payload["branch"] = get_class_info::docs_branch_for_running_godot();
 
     godot::Array class_names;
     class_names.append("Object");

--- a/fennara-cpp/src/tool_results/get_class_info.cpp
+++ b/fennara-cpp/src/tool_results/get_class_info.cpp
@@ -38,6 +38,9 @@ godot::Dictionary target_metadata(const godot::Dictionary &klass) {
     target["class_name"] = klass.get("class_name", "");
     target["status"] = klass.get("status", "");
     target["branch"] = klass.get("branch", "");
+    target["requested_branch"] = klass.get("requested_branch", "");
+    target["api_type"] = klass.get("api_type", "");
+    target["official_docs_lookup"] = klass.get("official_docs_lookup", "");
     target["local_only"] = klass.get("local_only", true);
     target["inherits"] = klass.get("inherits", "");
     target["property_count"] = klass.get("property_count", 0);
@@ -67,6 +70,18 @@ godot::String success_section(const godot::Dictionary &klass, int index) {
     godot::String branch = klass.get("branch", "");
     if (!branch.is_empty()) {
         lines.append("Docs branch: " + branch);
+    }
+    godot::String requested_branch = klass.get("requested_branch", "");
+    if (!requested_branch.is_empty() && requested_branch != branch) {
+        lines.append("Requested docs branch: " + requested_branch);
+    }
+    godot::String api_type = klass.get("api_type", "");
+    if (!api_type.is_empty()) {
+        lines.append("ClassDB API type: " + api_type);
+    }
+    godot::String docs_lookup = klass.get("official_docs_lookup", "");
+    if (!docs_lookup.is_empty()) {
+        lines.append("Official docs lookup: " + docs_lookup);
     }
     int64_t text_lines = static_cast<int64_t>(klass.get("text_line_count", 0));
     if (text_lines > 0) {

--- a/fennara-cpp/src/tools/get_class_info/docs_branch.cpp
+++ b/fennara-cpp/src/tools/get_class_info/docs_branch.cpp
@@ -1,0 +1,72 @@
+#include "fennara/tools/get_class_info/docs_branch.hpp"
+
+#include <godot_cpp/classes/engine.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+namespace fennara::get_class_info {
+
+namespace {
+
+constexpr const char *kFallbackDocsBranch = "master";
+
+bool variant_to_int(const godot::Variant &value, int64_t &out) {
+    const godot::Variant::Type type = value.get_type();
+    if (type != godot::Variant::INT && type != godot::Variant::FLOAT) {
+        return false;
+    }
+
+    out = static_cast<int64_t>(value);
+    return true;
+}
+
+godot::String branch_from_major_minor(int64_t major, int64_t minor) {
+    if (major <= 0 || minor < 0) {
+        return fallback_docs_branch();
+    }
+    return godot::String::num_int64(major) + "." + godot::String::num_int64(minor);
+}
+
+godot::String branch_from_version_string(const godot::String &version_string) {
+    const godot::String clean = version_string.strip_edges();
+    if (clean.is_empty()) {
+        return fallback_docs_branch();
+    }
+
+    godot::PackedStringArray parts = clean.split(".");
+    if (parts.size() < 2 || !parts[0].is_valid_int() ||
+        !parts[1].is_valid_int()) {
+        return fallback_docs_branch();
+    }
+
+    return branch_from_major_minor(parts[0].to_int(), parts[1].to_int());
+}
+
+} // namespace
+
+godot::String fallback_docs_branch() {
+    return kFallbackDocsBranch;
+}
+
+godot::String docs_branch_from_version_info(const godot::Dictionary &version_info) {
+    int64_t major = 0;
+    int64_t minor = -1;
+    if (variant_to_int(version_info.get("major", godot::Variant()), major) &&
+        variant_to_int(version_info.get("minor", godot::Variant()), minor) &&
+        major > 0 && minor >= 0) {
+        return branch_from_major_minor(major, minor);
+    }
+
+    return branch_from_version_string(version_info.get("string", ""));
+}
+
+godot::String docs_branch_for_running_godot() {
+    godot::Engine *engine = godot::Engine::get_singleton();
+    if (engine == nullptr) {
+        return fallback_docs_branch();
+    }
+
+    return docs_branch_from_version_info(engine->get_version_info());
+}
+
+} // namespace fennara::get_class_info

--- a/fennara-cpp/src/tools/get_class_info/docs_fetch.cpp
+++ b/fennara-cpp/src/tools/get_class_info/docs_fetch.cpp
@@ -1,4 +1,5 @@
 #include "fennara/app_paths.hpp"
+#include "fennara/tools/get_class_info/docs_branch.hpp"
 #include "fennara/tools/get_class_info/docs.hpp"
 #include "fennara/tools/get_class_info/docs_internal.hpp"
 
@@ -309,7 +310,7 @@ bool _fetch_class_xml(const godot::String &class_name,
 }
 
 } // namespace
-ClassDocumentation fetch_and_parse_class_documentation(
+ClassDocumentation fetch_and_parse_class_documentation_for_branch(
     const godot::String &class_name,
     const godot::String &branch) {
     const std::string key = _cache_key(class_name, branch);
@@ -354,6 +355,46 @@ ClassDocumentation fetch_and_parse_class_documentation(
     docs = parse_class_documentation_xml(class_name, branch, xml_text);
     docs.module_notice = module_notice;
     cache[key] = docs;
+    return docs;
+}
+
+ClassDocumentation fetch_and_parse_class_documentation(
+    const godot::String &class_name,
+    const godot::String &branch) {
+    godot::String primary_branch = branch.strip_edges();
+    if (primary_branch.is_empty()) {
+        primary_branch = fallback_docs_branch();
+    }
+
+    ClassDocumentation docs =
+        fetch_and_parse_class_documentation_for_branch(class_name, primary_branch);
+    const godot::String fallback_branch = fallback_docs_branch();
+    if (docs.found || primary_branch == fallback_branch) {
+        return docs;
+    }
+
+    ClassDocumentation fallback_docs =
+        fetch_and_parse_class_documentation_for_branch(class_name, fallback_branch);
+    if (fallback_docs.found) {
+        godot::String primary_message = docs.fetch_message;
+        if (primary_message.is_empty()) {
+            primary_message = "No docs were found on the primary branch.";
+        }
+        fallback_docs.fetch_message =
+            "Docs branch '" + primary_branch + "' was unavailable for '" +
+            class_name + "'; using fallback branch '" + fallback_branch +
+            "'. Primary lookup: " + primary_message;
+        return fallback_docs;
+    }
+
+    if (docs.fetch_message.is_empty()) {
+        docs.fetch_message =
+            "No docs were found on branch '" + primary_branch + "'.";
+    }
+    if (!fallback_docs.fetch_message.is_empty()) {
+        docs.fetch_message += " Fallback branch '" + fallback_branch +
+                              "' also failed: " + fallback_docs.fetch_message;
+    }
     return docs;
 }
 

--- a/fennara-cpp/src/tools/get_class_info/docs_render.cpp
+++ b/fennara-cpp/src/tools/get_class_info/docs_render.cpp
@@ -196,6 +196,13 @@ godot::String render_docs_text(const ClassDocumentation &docs) {
     }
     out += "\n";
 
+    if (!docs.module_notice.is_empty()) {
+        out += docs.module_notice + godot::String("\n");
+    }
+    if (!docs.fetch_message.is_empty()) {
+        out += "\n" + docs.fetch_message + godot::String("\n");
+    }
+
     if (!docs.brief_description.is_empty()) {
         out += "\n" + docs.brief_description + "\n";
     }
@@ -310,6 +317,51 @@ godot::String render_runtime_hierarchy_text(const godot::PackedStringArray &inhe
 
 godot::String render_runtime_properties_text(const godot::Array &properties,
                                              const ClassDocumentation &docs) {
+    if (!docs.found) {
+        godot::String out = "\n# RUNTIME PROPERTIES: " + docs.class_name +
+                            " (" + godot::String::num_int64(properties.size()) +
+                            ")\n";
+        for (int i = 0; i < properties.size(); i++) {
+            godot::Dictionary prop = properties[i];
+            godot::String name = prop.get("name", "");
+            if (name.is_empty()) {
+                continue;
+            }
+
+            godot::String line = "- " + name + ": " +
+                                 godot::String(prop.get("type", ""));
+            std::vector<godot::String> hints;
+            if (prop.has("default")) {
+                hints.push_back("default: " +
+                                format_variant_like_python(prop["default"]));
+            }
+            if (prop.has("hint")) {
+                hints.push_back("hint: " + godot::String(prop["hint"]));
+            }
+            if (prop.has("hint_string")) {
+                hints.push_back("hint_string: " +
+                                godot::String(prop["hint_string"]));
+            }
+            if (prop.has("class_name")) {
+                hints.push_back("class_name: " +
+                                godot::String(prop["class_name"]));
+            }
+            if (!hints.empty()) {
+                line += "  [";
+                for (size_t j = 0; j < hints.size(); j++) {
+                    if (j > 0) {
+                        line += ", ";
+                    }
+                    line += hints[j];
+                }
+                line += "]";
+            }
+
+            out += line + "\n";
+        }
+        return out;
+    }
+
     int shared_count = 0;
     for (int i = 0; i < properties.size(); i++) {
         godot::Dictionary prop = properties[i];

--- a/fennara-cpp/src/tools/get_class_info/get_class_info.cpp
+++ b/fennara-cpp/src/tools/get_class_info/get_class_info.cpp
@@ -1,5 +1,6 @@
 #include "fennara/tools/get_class_info/get_class_info.hpp"
 #include "fennara/logger.hpp"
+#include "fennara/tools/get_class_info/docs_branch.hpp"
 #include "fennara/tools/get_class_info/internal.hpp"
 
 #include <godot_cpp/classes/class_db_singleton.hpp>
@@ -10,7 +11,6 @@ namespace fennara {
 namespace {
 
 constexpr int kMaxBatchClasses = 3;
-constexpr const char *kDefaultDocsBranch = "master";
 
 int count_text_lines(const godot::String &text) {
     if (text.is_empty()) {
@@ -25,6 +25,28 @@ int count_text_lines(const godot::String &text) {
     return lines;
 }
 
+godot::String api_type_to_string(godot::ClassDBSingleton::APIType api_type) {
+    switch (api_type) {
+    case godot::ClassDBSingleton::API_CORE:
+        return "core";
+    case godot::ClassDBSingleton::API_EDITOR:
+        return "editor";
+    case godot::ClassDBSingleton::API_EXTENSION:
+        return "extension";
+    case godot::ClassDBSingleton::API_EDITOR_EXTENSION:
+        return "editor_extension";
+    case godot::ClassDBSingleton::API_NONE:
+        return "none";
+    default:
+        return "unknown";
+    }
+}
+
+bool is_extension_api_type(godot::ClassDBSingleton::APIType api_type) {
+    return api_type == godot::ClassDBSingleton::API_EXTENSION ||
+           api_type == godot::ClassDBSingleton::API_EDITOR_EXTENSION;
+}
+
 } // namespace
 
 void FennaraGetClassInfoTool::_bind_methods() {
@@ -36,10 +58,11 @@ void FennaraGetClassInfoTool::_bind_methods() {
 
 godot::Dictionary FennaraGetClassInfoTool::execute(
     const godot::Dictionary &args) {
-    godot::String branch =
-        godot::String(args.get("branch", kDefaultDocsBranch)).strip_edges();
+    godot::String branch = godot::String(
+        args.get("branch", get_class_info::docs_branch_for_running_godot()))
+        .strip_edges();
     if (branch.is_empty()) {
-        branch = kDefaultDocsBranch;
+        branch = get_class_info::fallback_docs_branch();
     }
 
     auto execute_single_class = [&](const godot::String &raw_class_name) {
@@ -65,19 +88,42 @@ godot::Dictionary FennaraGetClassInfoTool::execute(
             return result;
         }
 
+        godot::ClassDBSingleton::APIType api_type =
+            cdb->class_get_api_type(class_name);
+        const godot::String api_type_label = api_type_to_string(api_type);
+
         godot::Array properties = get_class_info::collect_runtime_properties(class_name);
         godot::PackedStringArray inherits_chain = get_class_info::collect_inherits_chain(class_name);
         godot::PackedStringArray inherited_by = get_class_info::collect_inherited_by(class_name);
-        get_class_info::ClassDocumentation docs =
-            get_class_info::collect_docs_for_class_info(class_name, branch, inherits_chain);
+        get_class_info::ClassDocumentation docs;
+        godot::String docs_lookup = "enabled";
+        if (is_extension_api_type(api_type)) {
+            docs.class_name = class_name;
+            docs.branch = branch;
+            docs.fetch_message =
+                "Official Godot XML docs lookup skipped because this class is "
+                "reported by ClassDB as a GDExtension/native addon class.";
+            docs_lookup = "skipped_extension_class";
+        } else {
+            docs = get_class_info::collect_docs_for_class_info(
+                class_name, branch, inherits_chain);
+            if (docs.found && !docs.branch.is_empty() && docs.branch != branch) {
+                docs_lookup = godot::String("fallback_") + docs.branch;
+            }
+        }
 
         godot::String text = get_class_info::render_docs_text(docs);
         text += get_class_info::render_runtime_hierarchy_text(inherits_chain, inherited_by);
         text += get_class_info::render_runtime_properties_text(properties, docs);
+        const godot::String docs_branch =
+            docs.branch.is_empty() ? branch : docs.branch;
 
         result["status"] = "success";
         result["class_name"] = class_name;
-        result["branch"] = branch;
+        result["branch"] = docs_branch;
+        result["requested_branch"] = branch;
+        result["api_type"] = api_type_label;
+        result["official_docs_lookup"] = docs_lookup;
         result["local_only"] = true;
         result["inherits"] = inherits_chain.size() > 0 ? godot::String(inherits_chain[0]) : godot::String();
         result["property_count"] = properties.size();

--- a/local/crates/fennara-daemon/src/runtime_daemon/docs_cache.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/docs_cache.rs
@@ -107,6 +107,26 @@ async fn warm_cached_doc(
     branch: &str,
     class_name: &str,
 ) -> Result<(), String> {
+    match warm_cached_doc_for_branch(client, branch, class_name).await {
+        Ok(()) => Ok(()),
+        Err(err) if branch != DOCS_BRANCH => {
+            warm_cached_doc_for_branch(client, DOCS_BRANCH, class_name)
+                .await
+                .map_err(|fallback_err| {
+                    format!(
+                        "branch {branch} failed: {err}; fallback branch {DOCS_BRANCH} failed: {fallback_err}"
+                    )
+                })
+        }
+        Err(err) => Err(err),
+    }
+}
+
+async fn warm_cached_doc_for_branch(
+    client: &reqwest::Client,
+    branch: &str,
+    class_name: &str,
+) -> Result<(), String> {
     let cache_path = cache_file_path(branch, class_name)?;
     if cache_path.is_file() && cache_file_is_fresh(&cache_path) {
         return Ok(());

--- a/local/schemas/tools/get_class_info.json
+++ b/local/schemas/tools/get_class_info.json
@@ -3,6 +3,8 @@
   "description_lines": [
     "Inspect one or more Godot classes and return the API surface you should read before using `run_scene_edit_script`.",
     "This tool returns documented properties, methods, signals, enums/constants, tutorials, the runtime parent chain, and direct children (`inherited_by`).",
+    "Official Godot XML docs are looked up from the GitHub branch matching the connected editor's major.minor version, with an explicit `master` fallback if that version branch or class XML is unavailable.",
+    "For GDExtension/native addon classes (`ClassDB.API_EXTENSION` or `ClassDB.API_EDITOR_EXTENSION`), Fennara skips official Godot XML docs lookup and returns runtime ClassDB/property information instead.",
     "For resource classes, it also includes inherited properties from resource parents up through `Resource`, with only the inspector-style `Resource` base fields (`resource_local_to_scene`, `resource_path`, `resource_name`). For node classes, properties stay direct-only.",
     "Before using `run_scene_edit_script` for scene or resource edits, you must use `get_class_info` first so you know the available API, which properties belong to the target class, and what parent/child classes exist.",
     "Pass `class_names` for all lookups, including a single class. Hard limit: batched calls may include at most 3 classes. Split larger requests into multiple calls."


### PR DESCRIPTION
## Summary
- derive Godot docs branch from connected editor major/minor version and fall back to master when unavailable
- skip official XML docs lookup for GDExtension/native addon classes while still returning runtime ClassDB/property info
- surface docs branch, requested branch, API type, and docs lookup status in get_class_info output

Closes #45

## Verification
- cargo check -p fennara-daemon
- scons target=editor
