### PR TITLE
chore: improve schema description readability

### DIFF
--- a/local/schemas/tools/exec_command.json
+++ b/local/schemas/tools/exec_command.json
@@ -1,6 +1,11 @@
 {
   "name": "exec_command",
-  "description": "Run one non-interactive shell command on the host from the Fennara daemon. Defaults to the active Godot project root as cwd. Shell commands use real filesystem paths, not res:// paths. Phase one has no PTY, no background sessions, no stdin, and no custom environment.",
+  "description_lines": [
+    "Run one non-interactive shell command on the host from the Fennara daemon.",
+    "Defaults to the active Godot project root as cwd.",
+    "Shell commands use real filesystem paths, not res:// paths.",
+    "Phase one has no PTY, no background sessions, no stdin, and no custom environment."
+  ],
   "parameters": {
     "type": "object",
     "additionalProperties": false,

--- a/local/schemas/tools/file_ops.json
+++ b/local/schemas/tools/file_ops.json
@@ -1,6 +1,17 @@
 {
   "name": "file_ops",
-  "description": "Manage and explore project files using one consistent shape: each operation has only `operation` and `args`. Use forward-slash Godot paths (`res://...` preferred) for Windows, macOS, and Linux compatibility. Read-only list/glob/rg operations may inspect `res://...` project files and any `user://...` path in the current project's Godot user data folder, including logs, runtime artifacts, screenshots, saves, cache files, and saved result JSON. Write operations (copy, move, delete, create_dir) stay project-scoped; do not use them for `user://...` artifacts. Supports list, glob, rg, copy, move, delete, and create_dir. Read-only operations can be batched and may run in parallel; write operations always run sequentially. `rg` uses bundled ripgrep directly with an argument array, not a shell. The wrapper automatically adds safe output flags: `--no-messages`, `--with-filename`, `--no-heading`, `--path-separator /`, and metadata exclusion globs for `*.uid`, `*.import`, and `*.remap`. Hard limit: include at most 5 operations per call.",
+  "description_lines": [
+    "Manage and explore project files using one consistent shape: each operation has only `operation` and `args`.",
+    "Use forward-slash Godot paths (`res://...` preferred) for Windows, macOS, and Linux compatibility.",
+    "Read-only list/glob/rg operations may inspect `res://...` project files and any `user://...` path in the current project Godot user data folder.",
+    "User-data reads include logs, runtime artifacts, screenshots, saves, cache files, and saved result JSON.",
+    "Write operations (copy, move, delete, create_dir) stay project-scoped; do not use them for `user://...` artifacts.",
+    "Supports list, glob, rg, copy, move, delete, and create_dir.",
+    "Read-only operations can be batched and may run in parallel; write operations always run sequentially.",
+    "`rg` uses bundled ripgrep directly with an argument array, not a shell.",
+    "The wrapper automatically adds safe output flags and metadata exclusion globs for `*.uid`, `*.import`, and `*.remap`.",
+    "Hard limit: include at most 5 operations per call."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/get_node_properties.json
+++ b/local/schemas/tools/get_node_properties.json
@@ -1,6 +1,14 @@
 {
   "name": "get_node_properties",
-  "description": "Get the changed properties of one or more specific nodes in scene files. Only shows properties that differ from defaults. Embedded SubResources are expanded recursively; large or opaque resources such as TileSet, TileMapLayer data, GridMap data, MeshLibrary resources, Theme resources, AnimationTree graphs, AnimationLibrary, Animation, and SpriteFrames are summarized into readable API-oriented output. Use get_scene_tree first to find node paths. Use get_class_info to inspect the full API surface before editing with run_scene_edit_script. Hard limit: at most 5 targets per call.",
+  "description_lines": [
+    "Get changed properties of one or more specific nodes in scene files.",
+    "Only shows properties that differ from defaults.",
+    "Embedded SubResources are expanded recursively.",
+    "Large or opaque resources such as TileSet, TileMapLayer data, GridMap data, MeshLibrary resources, Theme resources, AnimationTree graphs, AnimationLibrary, Animation, and SpriteFrames are summarized into readable API-oriented output.",
+    "Use get_scene_tree first to find node paths.",
+    "Use get_class_info to inspect the full API surface before editing with run_scene_edit_script.",
+    "Hard limit: at most 5 targets per call."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/get_scene_tree.json
+++ b/local/schemas/tools/get_scene_tree.json
@@ -1,6 +1,11 @@
 {
   "name": "get_scene_tree",
-  "description": "Inspect one or more scene files and get a tree structure of all nodes with their types, scripts, and instanced scenes. Automatically groups consecutive numbered nodes (e.g., Bush1, Bush2, Bush3 becomes 'Bush1-3') for cleaner output. Use this for structured .tscn scene inspection. Hard limit: at most 5 scenes per call.",
+  "description_lines": [
+    "Inspect one or more scene files and get a tree structure of all nodes with their types, scripts, and instanced scenes.",
+    "Automatically groups consecutive numbered nodes for cleaner output, e.g. Bush1, Bush2, Bush3 becomes Bush1-3.",
+    "Use this for structured .tscn scene inspection.",
+    "Hard limit: at most 5 scenes per call."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/project_settings.json
+++ b/local/schemas/tools/project_settings.json
@@ -1,6 +1,11 @@
 {
   "name": "project_settings",
-  "description": "Read, write, remove, or inspect Godot project settings. Use 'list' to inspect settings actually saved/changed in this project's project.godot, including compact values and InputMap event summaries. Use 'find_setting' to discover available Godot ProjectSettings keys by prefix or query before get/set. For input actions, pass 'events' array instead of 'value' to build proper InputEvent objects.",
+  "description_lines": [
+    "Read, write, remove, or inspect Godot project settings.",
+    "Use `list` to inspect settings actually saved/changed in this project project.godot, including compact values and InputMap event summaries.",
+    "Use `find_setting` to discover available Godot ProjectSettings keys by prefix or query before get/set.",
+    "For input actions, pass an `events` array instead of `value` to build proper InputEvent objects."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/read_file.json
+++ b/local/schemas/tools/read_file.json
@@ -1,6 +1,14 @@
 {
   "name": "read_file",
-  "description": "Read one or more files from the Godot project or the project's Godot user data folder. Supports res:// project paths and any user:// path for the current project, including logs, screenshots, runtime artifacts, saves, cache files, and tool result JSON. Use start_line/end_line for a specific range when reading large text files. Scene files (.tscn) are not readable; use get_scene_tree instead. Supported image files are sent to the model as vision inputs while the visible tool text shows only metadata, dimensions, and byte size. BLOCKED PATHS under res://: res://.godot/ (editor cache), res://.git/, res://addons/fennara/ (plugin internals), except the generated read-only agent guidance file res://addons/fennara/ai/guidelines.md. Hard limit: at most 5 files per call.",
+  "description_lines": [
+    "Read one or more files from the Godot project or the project Godot user data folder.",
+    "Supports res:// project paths and any user:// path for the current project, including logs, screenshots, runtime artifacts, saves, cache files, and tool result JSON.",
+    "Use start_line/end_line for a specific range when reading large text files.",
+    "Scene files (.tscn) are not readable; use get_scene_tree instead.",
+    "Supported image files are sent to the model as vision inputs while visible tool text shows only metadata, dimensions, and byte size.",
+    "Blocked res:// paths: res://.godot/, res://.git/, and res://addons/fennara/, except res://addons/fennara/ai/guidelines.md.",
+    "Hard limit: at most 5 files per call."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/save_custom_resource.json
+++ b/local/schemas/tools/save_custom_resource.json
@@ -1,6 +1,11 @@
 {
   "name": "save_custom_resource",
-  "description": "Create and save a custom .tres resource file. CRITICAL: For custom resource scripts (like UpgradeData, BusinessData, etc.), you MUST pass the full script path (res://path/to/script.gd) in resource_type, NOT just the class_name. Only use class names for built-in Godot types like 'Resource'.",
+  "description_lines": [
+    "Create and save a custom .tres resource file.",
+    "For custom resource scripts, pass the full script path in resource_type, e.g. res://path/to/script.gd.",
+    "Only use class names for built-in Godot types such as Resource.",
+    "Never pass just a custom class_name like UpgradeData; use the full res:// script path."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/scrape_editor.json
+++ b/local/schemas/tools/scrape_editor.json
@@ -1,6 +1,13 @@
 {
   "name": "scrape_editor",
-  "description": "Scrape a narrow part of the currently open Godot editor UI. For now the only supported target is `debugger`, which reads the editor debugger/errors tree snapshot without starting a scene, stopping a scene, running validation, reading runtime_session.log, or taking screenshots. The model-facing result is compacted: repeated debugger issues are grouped with counts, only the top grouped issues and a few detail lines are shown, and raw UI spam is not returned inline. Use this only when the user says they manually ran a scene in Godot/the editor and got a runtime error, or when they explicitly ask what the editor debugger currently shows. Do not use it for scenes you started through runtime_session; for managed runtime sessions, inspect runtime_session.log instead.",
+  "description_lines": [
+    "Scrape a narrow part of the currently open Godot editor UI.",
+    "For now the only supported target is `debugger`, which reads the editor debugger/errors tree snapshot.",
+    "This tool does not start a scene, stop a scene, run validation, read runtime_session.log, or take screenshots.",
+    "The model-facing result is compacted: repeated debugger issues are grouped with counts, only top grouped issues and a few detail lines are shown, and raw UI spam is omitted.",
+    "Use this only when the user says they manually ran a scene in Godot/the editor and got a runtime error, or explicitly asks what the editor debugger currently shows.",
+    "Do not use it for scenes started through runtime_session; inspect runtime_session.log instead."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/screenshot_scene.json
+++ b/local/schemas/tools/screenshot_scene.json
@@ -1,6 +1,16 @@
 {
   "name": "screenshot_scene",
-  "description": "Open a scene file and capture a PNG image. Use camera_path to render from a specific Camera2D or Camera3D in the scene through a temporary SubViewport when authored camera framing matters. For 2D scenes, optionally specify a world-coordinate view_rect for editor viewport capture; camera_path overrides view_rect and uses the Camera2D view. For 3D scenes, optionally specify view (front, back, left, right, top, perspective, or all) and target_node_path to frame a specific node/subtree in the editor viewport with surrounding context; camera_path overrides view/target framing and uses the Camera3D view. Defaults to perspective. Internally the primary image is image_base64: for one view it is that view, for multi-view it is the full-resolution no-downscale labeled collage. Every generated screenshot is saved under user://.fennara/screenshots and returned as image_res_path plus cross-platform absolute image_path. In local MCP responses, base64 is stripped; use the returned image_path values, or read the image later with a file/image-capable tool. Multi-view responses include per-view image_path entries.",
+  "description_lines": [
+    "Open a scene file and capture a PNG image.",
+    "Use camera_path to render from a specific Camera2D or Camera3D through a temporary SubViewport when authored camera framing matters.",
+    "For 2D scenes, optionally specify a world-coordinate view_rect for editor viewport capture; camera_path overrides view_rect and uses the Camera2D view.",
+    "For 3D scenes, optionally specify view and target_node_path to frame a specific node/subtree in the editor viewport with surrounding context; camera_path overrides view/target framing and uses the Camera3D view.",
+    "Defaults to perspective.",
+    "Internally the primary image is image_base64: for one view it is that view, for multi-view it is the full-resolution no-downscale labeled collage.",
+    "Every generated screenshot is saved under user://.fennara/screenshots and returned as image_res_path plus cross-platform absolute image_path.",
+    "In local MCP responses, base64 is stripped; use returned image_path values, or read the image later with a file/image-capable tool.",
+    "Multi-view responses include per-view image_path entries."
+  ],
   "parameters": {
     "type": "object",
     "properties": {

--- a/local/schemas/tools/script_diagnostics.json
+++ b/local/schemas/tools/script_diagnostics.json
@@ -1,6 +1,16 @@
 {
     "name": "script_diagnostics",
-    "description": "Fetch script and shader errors, warnings, info, and hints from the active Godot diagnostics sources. Targeted file_paths support .gd, .cs, and .gdshader files. scan_project: true scans all project .gd, .cs, and .gdshader files under res://. For targeted .gd and .cs files, this also loads and instantiates project .tscn scenes in memory on the Godot main thread with Godot logging captured, then attaches script-related scene-load errors back to the script file with source='scene_load' and scene_path. This scene-load pass is diagnostic only: it does not open the editor UI, run gameplay, or validate arbitrary scene/resource state. With scan_project: true, scene instantiation is skipped and the result reports scene_load_skipped plus the class of scene-attached errors that may be missed. Use this after editing scripts or shaders outside a tool path that already ran diagnostics, or when diagnosing parser/type/reference/shader errors that only appear when scenes are opened. Do not use script_diagnostics to debug general scene/resource configuration; use scene/resource tools for that. Targeted calls support at most 5 files; use scan_project for broad script/shader health checks.",
+    "description_lines": [
+      "Fetch script and shader errors, warnings, info, and hints from the active Godot diagnostics sources.",
+      "Targeted file_paths support .gd, .cs, and .gdshader files.",
+      "scan_project: true scans all project .gd, .cs, and .gdshader files under res://.",
+      "For targeted .gd and .cs files, this also loads and instantiates project .tscn scenes in memory on the Godot main thread with Godot logging captured, then attaches script-related scene-load errors back to the script file with source=scene_load and scene_path.",
+      "This scene-load pass is diagnostic only: it does not open the editor UI, run gameplay, or validate arbitrary scene/resource state.",
+      "With scan_project: true, scene instantiation is skipped and the result reports scene_load_skipped plus the class of scene-attached errors that may be missed.",
+      "Use this after editing scripts or shaders outside a tool path that already ran diagnostics, or when diagnosing parser/type/reference/shader errors that only appear when scenes are opened.",
+      "Do not use script_diagnostics to debug general scene/resource configuration; use scene/resource tools for that.",
+      "Targeted calls support at most 5 files; use scan_project for broad script/shader health checks."
+    ],
     "parameters": {
         "type": "object",
         "properties": {

--- a/local/schemas/tools/validate_scene.json
+++ b/local/schemas/tools/validate_scene.json
@@ -1,6 +1,16 @@
 {
     "name": "validate_scene",
-    "description": "Validate one or more scene files for common issues: missing scripts/resources, script extends mismatch, invalid NodePath properties, invalid script $Node/get_node() references, duplicate sibling names, cyclic scene dependencies, and unset exported Resource/Object vars. Declaration-only unset exports are notes because they may be optional or assigned at runtime; unset exports referenced elsewhere in the script are warnings to verify/null-guard or assign. For scenes with no structural errors, Fennara also runs each scene headlessly for 3 seconds through the local daemon using up to 3 memory-throttled workers, then returns each scene's runtime status, crash/error/warning flags, compacted runtime output, and paths to the full result JSON and raw runtime logs. The daemon intentionally stops the process after the validation window, so a non-zero exit code from that stop is not by itself a scene failure; use the crash/error/warning flags and logs as the health signal. It does not open scenes in the editor or scrape the editor Output panel. Use after scene edits when you want structural and brief startup/runtime verification. Hard limit: at most 10 scenes per call.",
+    "description_lines": [
+      "Validate one or more scene files for common issues.",
+      "Structural checks include missing scripts/resources, script extends mismatch, invalid NodePath properties, invalid script $Node/get_node() references, duplicate sibling names, cyclic scene dependencies, and unset exported Resource/Object vars.",
+      "Declaration-only unset exports are notes because they may be optional or assigned at runtime; unset exports referenced elsewhere in the script are warnings to verify/null-guard or assign.",
+      "For scenes with no structural errors, Fennara also runs each scene headlessly for 3 seconds through the local daemon using up to 3 memory-throttled workers.",
+      "The result includes each scene runtime status, crash/error/warning flags, compacted runtime output, and paths to the full result JSON and raw runtime logs.",
+      "The daemon intentionally stops the process after the validation window, so a non-zero exit code from that stop is not by itself a scene failure; use crash/error/warning flags and logs as the health signal.",
+      "It does not open scenes in the editor or scrape the editor Output panel.",
+      "Use after scene edits when you want structural and brief startup/runtime verification.",
+      "Hard limit: at most 10 scenes per call."
+    ],
     "parameters": {
         "type": "object",
         "properties": {

--- a/local/schemas/tools/write_or_update_file.json
+++ b/local/schemas/tools/write_or_update_file.json
@@ -1,6 +1,15 @@
 {
   "name": "write_or_update_file",
-  "description": "Write a new file, completely rewrite an existing file, or update specific sections of a file. Use mode='write' to create/overwrite entire files. Use mode='update' to replace specific code sections in existing files. NOTE: Modifying .gd, .cs, or .gdshader files automatically runs diagnostics on the edited file and appends syntax/type/reference or shader parser diagnostics to the result. Modifying a .gdshader also scans .tscn and .tres files that reference that shader and reserializes those owners through Godot so stale embedded ShaderMaterial data is rewritten; the result includes reserialized_resources, reserialize_warnings, and reserialize_skipped. BLOCKED PATHS: res://project.godot, res://.godot/, res://.git/, res://addons/fennara/, any plugin.cfg. Only write to user project files.",
+  "description_lines": [
+    "Write a new file, completely rewrite an existing file, or update specific sections of a file.",
+    "Use mode=write to create/overwrite entire files.",
+    "Use mode=update to replace specific code sections in existing files.",
+    "Modifying .gd, .cs, or .gdshader files automatically runs diagnostics on the edited file and appends syntax/type/reference or shader parser diagnostics to the result.",
+    "Modifying a .gdshader also scans .tscn and .tres files that reference that shader and reserializes those owners through Godot so stale embedded ShaderMaterial data is rewritten.",
+    "The result includes reserialized_resources, reserialize_warnings, and reserialize_skipped.",
+    "Blocked paths: res://project.godot, res://.godot/, res://.git/, res://addons/fennara/, and any plugin.cfg.",
+    "Only write to user project files."
+  ],
   "parameters": {
     "type": "object",
     "properties": {


### PR DESCRIPTION
## Summary
- Convert long single-line tool schema descriptions to `description_lines` arrays.
- Keep the change scoped to the selected MCP tool schema files.
- Leave `runtime_script.json` and `runtime_session.json` out of this PR.

## Validation
- Validated tool schema JSON with `ConvertFrom-Json`.
- Ran `cargo test -p fennara-mcp`.

Closes #55