### PR TITLE
fix: include runtime log excerpts in receipts

### DIFF
--- a/fennara-cpp/include/fennara/tool_results/runtime_log_excerpt.hpp
+++ b/fennara-cpp/include/fennara/tool_results/runtime_log_excerpt.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+
+namespace fennara::tool_results {
+
+void append_runtime_log_excerpt(godot::PackedStringArray &lines,
+                                const godot::Dictionary &raw_result);
+
+} // namespace fennara::tool_results

--- a/fennara-cpp/src/tool_results/runtime_log_excerpt.cpp
+++ b/fennara-cpp/src/tool_results/runtime_log_excerpt.cpp
@@ -1,0 +1,111 @@
+#include "fennara/tool_results/runtime_log_excerpt.hpp"
+
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+namespace fennara::tool_results {
+namespace {
+
+godot::String count_text(int count) {
+    return godot::String::num_int64(count) +
+           (count == 1 ? " line" : " lines");
+}
+
+godot::String shown_ranges_text(const godot::Array &ranges) {
+    godot::PackedStringArray parts;
+    for (int i = 0; i < ranges.size(); i++) {
+        godot::Dictionary range = ranges[i];
+        int first = static_cast<int>(range.get("first", 0));
+        int last = static_cast<int>(range.get("last", 0));
+        if (first <= 0 || last < first) {
+            continue;
+        }
+        if (first == last) {
+            parts.append(godot::String::num_int64(first));
+        } else {
+            parts.append(godot::String::num_int64(first) + "-" +
+                         godot::String::num_int64(last));
+        }
+    }
+    return godot::String(", ").join(parts);
+}
+
+} // namespace
+
+void append_runtime_log_excerpt(godot::PackedStringArray &lines,
+                                const godot::Dictionary &raw_result) {
+    godot::Dictionary runtime_log =
+        raw_result.get("runtime_log", godot::Dictionary());
+    if (runtime_log.is_empty()) {
+        return;
+    }
+
+    lines.append("");
+    lines.append("Runtime log update:");
+    if (!(bool)runtime_log.get("available", false)) {
+        godot::String error = runtime_log.get("error", "");
+        if (error.is_empty()) {
+            lines.append("- Log file was not readable yet for this receipt.");
+        } else {
+            lines.append("- Log file was not readable yet for this receipt: " + error);
+        }
+        return;
+    }
+
+    if ((bool)runtime_log.get("log_reset", false)) {
+        lines.append("- Log cursor reset because the log appeared shorter than before.");
+    }
+
+    int added = static_cast<int>(runtime_log.get("lines_added", 0));
+    int first_line = static_cast<int>(runtime_log.get("first_line", 0));
+    int last_line = static_cast<int>(runtime_log.get("last_line", 0));
+    int omitted = static_cast<int>(runtime_log.get("omitted_line_count", 0));
+    int truncated = static_cast<int>(runtime_log.get("truncated_line_count", 0));
+    int shown_first_line = static_cast<int>(runtime_log.get("shown_first_line", 0));
+    int shown_last_line = static_cast<int>(runtime_log.get("shown_last_line", 0));
+    if (added <= 0) {
+        lines.append("- No new runtime log lines since the previous runtime receipt.");
+    } else {
+        godot::String range;
+        if (first_line > 0 && last_line >= first_line) {
+            range = godot::String(" (log lines ") +
+                    godot::String::num_int64(first_line) + "-" +
+                    godot::String::num_int64(last_line) + ")";
+        }
+        lines.append("- New runtime log lines since previous receipt: " +
+                     count_text(added) + range);
+        godot::String shown_ranges =
+            shown_ranges_text(runtime_log.get("shown_ranges", godot::Array()));
+        if (!shown_ranges.is_empty()) {
+            lines.append("- Showing log lines " + shown_ranges + ".");
+        } else if (shown_first_line > 0 && shown_last_line >= shown_first_line) {
+            lines.append("- Showing log lines " +
+                         godot::String::num_int64(shown_first_line) + "-" +
+                         godot::String::num_int64(shown_last_line) + ".");
+        }
+        lines.append("```text");
+        godot::Array new_lines = runtime_log.get("lines", godot::Array());
+        for (int i = 0; i < new_lines.size(); i++) {
+            lines.append(godot::String(new_lines[i]));
+        }
+        lines.append("```");
+        if (omitted > 0) {
+            lines.append("- " + count_text(omitted) +
+                         " omitted from this receipt; read the full log file for the complete text.");
+        }
+        if (truncated > 0) {
+            lines.append("- " + count_text(truncated) +
+                         " truncated in this receipt; read the full log file for complete lines.");
+        }
+    }
+
+    int cursor_after = static_cast<int>(runtime_log.get("cursor_after_line", -1));
+    if (cursor_after >= 0) {
+        lines.append("Runtime log cursor is now at line " +
+                     godot::String::num_int64(cursor_after) + ".");
+    }
+}
+
+} // namespace fennara::tool_results

--- a/fennara-cpp/src/tool_results/runtime_script.cpp
+++ b/fennara-cpp/src/tool_results/runtime_script.cpp
@@ -1,6 +1,7 @@
 #include "fennara/tool_results/runtime_script.hpp"
 
 #include "fennara/tool_results/envelope.hpp"
+#include "fennara/tool_results/runtime_log_excerpt.hpp"
 
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/variant/array.hpp>
@@ -59,6 +60,8 @@ godot::Dictionary format_runtime_script(const godot::Dictionary &raw_result) {
     godot::Dictionary script_result = raw_result.get("result", godot::Dictionary());
     godot::Dictionary runtime_findings =
         raw_result.get("runtime_findings", godot::Dictionary());
+    godot::Dictionary runtime_log =
+        raw_result.get("runtime_log", godot::Dictionary());
     if (!session_id.is_empty()) lines.append("Session id: " + session_id);
     if (!script_run_id.is_empty()) lines.append("Script run id: " + script_run_id);
     if (!script_path.is_empty()) lines.append("Script path: " + script_path);
@@ -123,6 +126,7 @@ godot::Dictionary format_runtime_script(const godot::Dictionary &raw_result) {
                          ": " + image_path);
         }
     }
+    append_runtime_log_excerpt(lines, raw_result);
     if ((bool)runtime_findings.get("has_findings", false)) {
         lines.append("");
         lines.append("## Runtime findings during script");
@@ -141,7 +145,7 @@ godot::Dictionary format_runtime_script(const godot::Dictionary &raw_result) {
     }
     if (!log_path.is_empty()) {
         lines.append(
-            "This result is a script receipt, not a full scene-health verdict. Read the session log for script logs, runtime errors, and follow-up state.");
+            "This result is a script receipt, not a full scene-health verdict. Use the runtime log update above for new log lines since the previous runtime receipt, and read the full session log when older history matters.");
     }
 
     godot::Dictionary metadata =
@@ -157,6 +161,7 @@ godot::Dictionary format_runtime_script(const godot::Dictionary &raw_result) {
     metadata["captures_dir"] = visible_captures_dir;
     metadata["raw_captures_dir"] = captures_dir;
     metadata["captures"] = captures;
+    metadata["runtime_log"] = runtime_log;
     metadata["runtime_findings"] = runtime_findings;
     return make_envelope(godot::String("\n").join(lines),
                          metadata,

--- a/fennara-cpp/src/tool_results/runtime_session.cpp
+++ b/fennara-cpp/src/tool_results/runtime_session.cpp
@@ -1,6 +1,7 @@
 #include "fennara/tool_results/runtime_session.hpp"
 
 #include "fennara/tool_results/envelope.hpp"
+#include "fennara/tool_results/runtime_log_excerpt.hpp"
 
 #include <godot_cpp/classes/project_settings.hpp>
 #include <godot_cpp/variant/array.hpp>
@@ -94,8 +95,9 @@ godot::Dictionary format_runtime_session(const godot::Dictionary &raw_result) {
     append_if_present(lines, "Captures dir", raw_result, "captures_dir");
     if (!godot::String(raw_result.get("log_path", "")).is_empty()) {
         lines.append(
-            "Session log is the source of truth for runtime progress, debugger issues, script logs, captures, and whether the scene actually failed.");
+            "Session log remains the full source of truth; this receipt includes new log lines since the previous runtime receipt when available.");
     }
+    append_runtime_log_excerpt(lines, raw_result);
 
     if (raw_result.has("running")) {
         lines.append(
@@ -114,6 +116,17 @@ godot::Dictionary format_runtime_session(const godot::Dictionary &raw_result) {
             godot::String((bool)raw_result.get("script_running", false)
                               ? "true"
                               : "false"));
+    }
+    if (raw_result.has("startup_log_wait_ms")) {
+        lines.append(
+            "Startup log wait: " +
+            godot::String::num_int64(
+                static_cast<int64_t>(raw_result.get("startup_log_wait_ms", 0))) +
+            " ms");
+        if (!(bool)raw_result.get("startup_ready_seen", false)) {
+            lines.append(
+                "Runtime helper did not report scene ready during this startup wait. Use runtime_session.status or read runtime_session.log to see whether the scene became ready afterward.");
+        }
     }
     if (raw_result.has("max_run_seconds")) {
         double seconds = static_cast<double>(
@@ -358,6 +371,8 @@ godot::Dictionary format_runtime_session(const godot::Dictionary &raw_result) {
     metadata["log_path"] = raw_result.get("log_path", "");
     metadata["captures_dir"] = raw_result.get("captures_dir", "");
     metadata["script_running"] = raw_result.get("script_running", false);
+    metadata["startup_log_wait_ms"] = raw_result.get("startup_log_wait_ms", 0);
+    metadata["startup_ready_seen"] = raw_result.get("startup_ready_seen", false);
     metadata["runtime_issue_count"] = raw_result.get("runtime_issue_count", 0);
     metadata["latest_runtime_issues"] = latest_runtime_issues;
     metadata["latest_runtime_summary"] = raw_result.get("latest_runtime_summary", godot::Dictionary());
@@ -375,6 +390,7 @@ godot::Dictionary format_runtime_session(const godot::Dictionary &raw_result) {
     metadata["msbuild_issue_count"] = raw_result.get("msbuild_issue_count", msbuild_issues.size());
     metadata["msbuild_issues_path"] = raw_result.get("msbuild_issues_path", "");
     metadata["msbuild_log_path"] = raw_result.get("msbuild_log_path", "");
+    metadata["runtime_log"] = raw_result.get("runtime_log", godot::Dictionary());
 
     godot::Dictionary envelope = make_envelope(
         godot::String("\n").join(lines),

--- a/fennara-cpp/src/tool_results/runtime_session.cpp
+++ b/fennara-cpp/src/tool_results/runtime_session.cpp
@@ -125,7 +125,7 @@ godot::Dictionary format_runtime_session(const godot::Dictionary &raw_result) {
             " ms");
         if (!(bool)raw_result.get("startup_ready_seen", false)) {
             lines.append(
-                "Runtime helper did not report scene ready during this startup wait. Use runtime_session.status or read runtime_session.log to see whether the scene became ready afterward.");
+                "Runtime helper did not report scene ready during this startup wait. Use `runtime_session` action `status` or read the `runtime_session.log` log file to see whether the scene became ready afterward.");
         }
     }
     if (raw_result.has("max_run_seconds")) {

--- a/fennara-cpp/src/tools/runtime_script.cpp
+++ b/fennara-cpp/src/tools/runtime_script.cpp
@@ -11,6 +11,7 @@
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/classes/time.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <thread>
 
@@ -21,6 +22,10 @@ constexpr const char *kResultVersion = "runtime-script-result-v1";
 constexpr const char *kRuntimeScriptDir = "res://.fennara/tmp/runtime_scripts";
 constexpr const char *kLocalDaemonHost = "127.0.0.1";
 constexpr int kLocalDaemonPort = 41287;
+constexpr int64_t kDefaultScriptTimeoutMs = 30000;
+constexpr int64_t kMinScriptTimeoutMs = 500;
+constexpr int64_t kMaxScriptTimeoutMs = 120000;
+constexpr int64_t kHttpTimeoutMarginMs = 5000;
 
 godot::Dictionary make_error(const godot::String &message) {
     godot::Dictionary result;
@@ -77,141 +82,6 @@ godot::String read_script_text(const godot::String &script_path) {
     godot::Ref<godot::FileAccess> file =
         godot::FileAccess::open(script_path, godot::FileAccess::READ);
     return file.is_null() ? godot::String() : file->get_as_text();
-}
-
-godot::PackedStringArray split_lines(const godot::String &text) {
-    return text.replace("\r\n", "\n").replace("\r", "\n").split("\n");
-}
-
-bool line_has_script_id(const godot::String &line,
-                        const godot::String &script_run_id) {
-    return !script_run_id.is_empty() && line.find(script_run_id) >= 0;
-}
-
-bool is_issue_start(const godot::String &line) {
-    return line.begins_with("ERROR:") ||
-           line.begins_with("SCRIPT ERROR:") ||
-           line.begins_with("WARNING:") ||
-           line.find("CrashHandlerException") >= 0 ||
-           line.find("Program crashed with signal") >= 0;
-}
-
-bool is_issue_continuation(const godot::String &line) {
-    return line.begins_with("   at:") ||
-           line.begins_with("          at:") ||
-           line.begins_with("   GDScript backtrace") ||
-           line.begins_with("          GDScript backtrace") ||
-           line.begins_with("       [") ||
-           line.begins_with("              [") ||
-           line.begins_with("[") ||
-           line.begins_with("-- END OF");
-}
-
-godot::String issue_kind(const godot::PackedStringArray &block) {
-    if (block.is_empty()) {
-        return "log";
-    }
-    godot::String first = block[0];
-    if (first.begins_with("WARNING:")) {
-        return "warning";
-    }
-    if (first.find("CrashHandlerException") >= 0 ||
-        first.find("Program crashed with signal") >= 0) {
-        return "crash";
-    }
-    return "error";
-}
-
-godot::Dictionary runtime_findings_for_script(const godot::String &raw_log_path,
-                                              const godot::String &script_run_id) {
-    godot::Dictionary findings;
-    findings["has_findings"] = false;
-    findings["error_count"] = 0;
-    findings["warning_count"] = 0;
-    findings["crash_count"] = 0;
-    findings["blocks"] = godot::Array();
-    findings["compacted"] = godot::String();
-
-    if (raw_log_path.is_empty() || !godot::FileAccess::file_exists(raw_log_path)) {
-        findings["log_available"] = false;
-        return findings;
-    }
-    findings["log_available"] = true;
-    godot::Ref<godot::FileAccess> file =
-        godot::FileAccess::open(raw_log_path, godot::FileAccess::READ);
-    if (file.is_null()) {
-        findings["log_available"] = false;
-        return findings;
-    }
-
-    godot::PackedStringArray lines = split_lines(file->get_as_text());
-    bool in_slice = false;
-    godot::Array blocks;
-    godot::PackedStringArray current_block;
-
-    auto flush_block = [&]() {
-        if (current_block.is_empty()) {
-            return;
-        }
-        godot::String kind = issue_kind(current_block);
-        godot::Dictionary block;
-        block["kind"] = kind;
-        block["text"] = godot::String("\n").join(current_block);
-        blocks.append(block);
-        if (kind == "warning") {
-            findings["warning_count"] =
-                static_cast<int>(findings.get("warning_count", 0)) + 1;
-        } else if (kind == "crash") {
-            findings["crash_count"] =
-                static_cast<int>(findings.get("crash_count", 0)) + 1;
-            findings["error_count"] =
-                static_cast<int>(findings.get("error_count", 0)) + 1;
-        } else if (kind == "error") {
-            findings["error_count"] =
-                static_cast<int>(findings.get("error_count", 0)) + 1;
-        }
-        current_block.clear();
-    };
-
-    for (int i = 0; i < lines.size(); i++) {
-        godot::String line = lines[i];
-        if (!in_slice) {
-            if (line.begins_with("FENNARA_SCRIPT_STARTED:") &&
-                line_has_script_id(line, script_run_id)) {
-                in_slice = true;
-            }
-            continue;
-        }
-
-        if ((line.begins_with("FENNARA_SCRIPT_COMPLETED:") ||
-             line.begins_with("FENNARA_SCRIPT_FAILED:")) &&
-            line_has_script_id(line, script_run_id)) {
-            flush_block();
-            break;
-        }
-
-        if (is_issue_start(line)) {
-            flush_block();
-            current_block.append(line);
-        } else if (!current_block.is_empty() && is_issue_continuation(line)) {
-            current_block.append(line);
-        } else if (!current_block.is_empty() && line.strip_edges().is_empty()) {
-            current_block.append(line);
-        } else {
-            flush_block();
-        }
-    }
-    flush_block();
-
-    findings["blocks"] = blocks;
-    findings["has_findings"] = !blocks.is_empty();
-    godot::PackedStringArray compacted;
-    for (int i = 0; i < blocks.size() && i < 12; i++) {
-        godot::Dictionary block = blocks[i];
-        compacted.append(godot::String(block.get("text", "")));
-    }
-    findings["compacted"] = godot::String("\n\n").join(compacted);
-    return findings;
 }
 
 godot::Dictionary validate_contract(const godot::String &script_path) {
@@ -344,12 +214,21 @@ godot::Dictionary FennaraRuntimeScriptTool::submit(const godot::Dictionary &args
     }
 
     godot::String script_run_id = make_script_run_id();
+    int64_t requested_timeout_ms = static_cast<int64_t>(
+        args.get("timeout_ms", kDefaultScriptTimeoutMs));
+    requested_timeout_ms = std::clamp(
+        requested_timeout_ms, kMinScriptTimeoutMs, kMaxScriptTimeoutMs);
     godot::Dictionary payload;
     payload["session_id"] = requested_session_id;
     payload["script_run_id"] = script_run_id;
     payload["script_path"] = script_path;
-    payload["timeout_ms"] = static_cast<int64_t>(args.get("timeout_ms", 30000));
-    godot::Dictionary result = post_daemon("/runtime/session/script", payload, 35000);
+    payload["timeout_ms"] = requested_timeout_ms;
+
+    int http_timeout_ms = static_cast<int>(
+        std::min(requested_timeout_ms + kHttpTimeoutMarginMs,
+                 kMaxScriptTimeoutMs + kHttpTimeoutMarginMs));
+    godot::Dictionary result =
+        post_daemon("/runtime/session/script", payload, http_timeout_ms);
     result["tool_name"] = "runtime_script";
     result["format_version"] = kResultVersion;
     result["session_id"] = requested_session_id;
@@ -376,8 +255,6 @@ godot::Dictionary FennaraRuntimeScriptTool::submit(const godot::Dictionary &args
     godot::String raw_log_path = result.get("raw_log_path", "");
     if (!raw_log_path.is_empty()) {
         result["log_path"] = raw_log_path;
-        result["runtime_findings"] =
-            runtime_findings_for_script(raw_log_path, script_run_id);
     }
     runtime_script_diagnostics::apply_to_result(diagnostics, result);
     return result;

--- a/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod docs_cache;
 pub(crate) mod godot_bridge;
 pub(crate) mod permissions;
 pub(crate) mod process_helpers;
+pub(crate) mod runtime_log;
 pub(crate) mod runtime_sessions;
 pub(crate) mod scene_runner;
 pub(crate) mod state;

--- a/local/crates/fennara-daemon/src/runtime_daemon/runtime_log.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/runtime_log.rs
@@ -1,0 +1,359 @@
+use serde_json::{Value, json};
+use std::{io::SeekFrom, path::Path};
+use tokio::{
+    fs::File,
+    io::{AsyncReadExt, AsyncSeekExt},
+    process::Child,
+};
+
+use super::state::RuntimeLogCursor;
+
+const READY_MARKER: &str = "FENNARA_RUNTIME_SESSION_READY";
+const MAX_SHOWN_LINES: usize = 60;
+const HEAD_LINES: usize = 20;
+const MAX_SHOWN_CHARS: usize = 12_000;
+const MAX_LINE_CHARS: usize = 1_000;
+
+pub(crate) struct LogCapture {
+    pub(crate) receipt: Value,
+    pub(crate) lines: Vec<(u64, String)>,
+}
+
+pub(crate) async fn wait_for_ready(
+    child: &mut Child,
+    log_path: &Path,
+    from_byte: u64,
+    timeout_ms: u64,
+) -> Result<(bool, bool, u64), String> {
+    let started = std::time::Instant::now();
+    let deadline = started + std::time::Duration::from_millis(timeout_ms);
+    loop {
+        let process_exited = child
+            .try_wait()
+            .map_err(|err| format!("runtime session wait failed: {err}"))?
+            .is_some();
+        let ready_seen = log_contains(log_path, from_byte, READY_MARKER).await;
+        if ready_seen || process_exited || std::time::Instant::now() >= deadline {
+            return Ok((
+                ready_seen,
+                process_exited,
+                started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64,
+            ));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+}
+
+pub(crate) async fn capture_update(
+    session_id: &str,
+    log_path: &Path,
+    mode: &str,
+    cursor: &mut RuntimeLogCursor,
+) -> LogCapture {
+    let mut receipt = json!({
+        "available": false,
+        "mode": mode,
+        "session_id": session_id,
+        "log_path": log_path.to_string_lossy(),
+    });
+
+    let Ok(metadata) = tokio::fs::metadata(log_path).await else {
+        receipt["error"] = json!("Could not stat log file.");
+        return LogCapture {
+            receipt,
+            lines: vec![],
+        };
+    };
+    let file_size = metadata.len();
+    let log_reset = cursor.byte_offset > file_size;
+    if log_reset {
+        *cursor = RuntimeLogCursor::default();
+    }
+
+    let cursor_before = cursor.clone();
+    let Ok(bytes) = read_from(log_path, cursor_before.byte_offset).await else {
+        receipt["error"] = json!("Could not open or read log file.");
+        return LogCapture {
+            receipt,
+            lines: vec![],
+        };
+    };
+
+    let complete_len = complete_line_prefix_len(&bytes);
+    let pending_bytes = bytes.len().saturating_sub(complete_len);
+    let complete_bytes = &bytes[..complete_len];
+    let text = String::from_utf8_lossy(complete_bytes);
+    let raw_lines: Vec<String> = text.lines().map(trim_cr).collect();
+    let first_line = if raw_lines.is_empty() {
+        0
+    } else {
+        cursor_before.line + 1
+    };
+    let lines: Vec<(u64, String)> = raw_lines
+        .iter()
+        .enumerate()
+        .map(|(index, line)| (cursor_before.line + index as u64 + 1, line.clone()))
+        .collect();
+
+    let ready_line = lines
+        .iter()
+        .find_map(|(line_no, line)| line.contains(READY_MARKER).then_some(*line_no))
+        .unwrap_or(0);
+    let (shown_lines, omitted, truncated) = shown_excerpt(&lines);
+    let shown_ranges = line_ranges(&shown_lines);
+
+    cursor.byte_offset = cursor_before.byte_offset + complete_len as u64;
+    cursor.line = cursor_before.line + raw_lines.len() as u64;
+
+    receipt = json!({
+        "available": true,
+        "mode": mode,
+        "session_id": session_id,
+        "log_path": log_path.to_string_lossy(),
+        "log_reset": log_reset,
+        "cursor_before_line": cursor_before.line,
+        "cursor_after_line": cursor.line,
+        "byte_offset_before": cursor_before.byte_offset,
+        "byte_offset_after": cursor.byte_offset,
+        "bytes_added": complete_len,
+        "pending_partial_bytes": pending_bytes,
+        "lines_added": raw_lines.len(),
+        "shown_line_count": shown_lines.len(),
+        "omitted_line_count": omitted,
+        "truncated_line_count": truncated,
+        "first_line": first_line,
+        "last_line": if raw_lines.is_empty() { 0 } else { cursor.line },
+        "shown_first_line": shown_lines.first().map(|line| line.0).unwrap_or(0),
+        "shown_last_line": shown_lines.last().map(|line| line.0).unwrap_or(0),
+        "shown_ranges": shown_ranges,
+        "line_limit": MAX_SHOWN_LINES,
+        "char_limit": MAX_SHOWN_CHARS,
+        "line_char_limit": MAX_LINE_CHARS,
+        "runtime_session_ready_seen": ready_line > 0,
+        "runtime_session_ready_line": ready_line,
+        "lines": shown_lines.into_iter().map(|(_, line)| line).collect::<Vec<_>>(),
+    });
+    LogCapture { receipt, lines }
+}
+
+pub(crate) fn findings_for_script(lines: &[(u64, String)], script_run_id: &str) -> Value {
+    let mut blocks: Vec<Value> = Vec::new();
+    let mut current: Vec<String> = Vec::new();
+    let mut in_slice = false;
+
+    for (_, line) in lines {
+        if !in_slice {
+            if line.starts_with("FENNARA_SCRIPT_STARTED:") && line.contains(script_run_id) {
+                in_slice = true;
+            }
+            continue;
+        }
+        if (line.starts_with("FENNARA_SCRIPT_COMPLETED:")
+            || line.starts_with("FENNARA_SCRIPT_FAILED:"))
+            && line.contains(script_run_id)
+        {
+            flush_block(&mut blocks, &mut current);
+            break;
+        }
+        if is_issue_start(line) {
+            flush_block(&mut blocks, &mut current);
+            current.push(line.clone());
+        } else if !current.is_empty() && (is_issue_continuation(line) || line.trim().is_empty()) {
+            current.push(line.clone());
+        } else {
+            flush_block(&mut blocks, &mut current);
+        }
+    }
+    flush_block(&mut blocks, &mut current);
+
+    let warning_count = blocks
+        .iter()
+        .filter(|block| block["kind"] == "warning")
+        .count();
+    let crash_count = blocks
+        .iter()
+        .filter(|block| block["kind"] == "crash")
+        .count();
+    let error_count = blocks
+        .iter()
+        .filter(|block| block["kind"] == "error" || block["kind"] == "crash")
+        .count();
+    let compacted = blocks
+        .iter()
+        .take(12)
+        .filter_map(|block| block["text"].as_str())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    json!({
+        "log_available": true,
+        "has_findings": !blocks.is_empty(),
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "crash_count": crash_count,
+        "blocks": blocks,
+        "compacted": compacted,
+    })
+}
+
+async fn read_from(path: &Path, offset: u64) -> Result<Vec<u8>, std::io::Error> {
+    let mut file = File::open(path).await?;
+    file.seek(SeekFrom::Start(offset)).await?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).await?;
+    Ok(bytes)
+}
+
+async fn log_contains(path: &Path, offset: u64, pattern: &str) -> bool {
+    read_from(path, offset)
+        .await
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .is_some_and(|text| text.contains(pattern))
+}
+
+fn shown_excerpt(lines: &[(u64, String)]) -> (Vec<(u64, String)>, usize, usize) {
+    let tail_lines = MAX_SHOWN_LINES.saturating_sub(HEAD_LINES);
+    let mut selected = Vec::new();
+    if lines.len() <= MAX_SHOWN_LINES {
+        selected.extend(lines.iter().cloned());
+    } else {
+        selected.extend(lines.iter().take(HEAD_LINES).cloned());
+        selected.extend(lines.iter().skip(lines.len() - tail_lines).cloned());
+    }
+
+    let mut shown = Vec::new();
+    let mut chars = 0usize;
+    let mut truncated = 0usize;
+    if lines.len() <= MAX_SHOWN_LINES {
+        for (line_no, line) in selected {
+            push_shown_line(line_no, line, &mut shown, &mut chars, &mut truncated);
+        }
+    } else {
+        for (line_no, line) in lines.iter().skip(lines.len() - tail_lines).cloned() {
+            push_shown_line(line_no, line, &mut shown, &mut chars, &mut truncated);
+        }
+        for (line_no, line) in lines.iter().take(HEAD_LINES).cloned() {
+            push_shown_line(line_no, line, &mut shown, &mut chars, &mut truncated);
+        }
+        shown.sort_by_key(|(line_no, _)| *line_no);
+    }
+
+    let omitted = lines.len().saturating_sub(shown.len());
+    (shown, omitted, truncated)
+}
+
+fn push_shown_line(
+    line_no: u64,
+    line: String,
+    shown: &mut Vec<(u64, String)>,
+    chars: &mut usize,
+    truncated: &mut usize,
+) {
+    let (line, was_truncated) = truncate_line(line);
+    if was_truncated {
+        *truncated += 1;
+    }
+    let next_chars = *chars + line.len() + 1;
+    if *chars > 0 && next_chars > MAX_SHOWN_CHARS {
+        return;
+    }
+    *chars = next_chars;
+    shown.push((line_no, line));
+}
+
+fn complete_line_prefix_len(bytes: &[u8]) -> usize {
+    if bytes.is_empty() {
+        return 0;
+    }
+    if matches!(bytes.last(), Some(b'\n')) {
+        return bytes.len();
+    }
+    bytes
+        .iter()
+        .rposition(|byte| *byte == b'\n')
+        .map(|index| index + 1)
+        .unwrap_or(0)
+}
+
+fn line_ranges(lines: &[(u64, String)]) -> Vec<Value> {
+    let mut ranges = Vec::new();
+    let mut start = 0u64;
+    let mut previous = 0u64;
+    for (line_no, _) in lines {
+        if start == 0 {
+            start = *line_no;
+            previous = *line_no;
+        } else if *line_no == previous + 1 {
+            previous = *line_no;
+        } else {
+            ranges.push(json!({ "first": start, "last": previous }));
+            start = *line_no;
+            previous = *line_no;
+        }
+    }
+    if start > 0 {
+        ranges.push(json!({ "first": start, "last": previous }));
+    }
+    ranges
+}
+
+fn trim_cr(line: &str) -> String {
+    line.strip_suffix('\r').unwrap_or(line).to_string()
+}
+
+fn truncate_line(line: String) -> (String, bool) {
+    if line.chars().count() <= MAX_LINE_CHARS {
+        return (line, false);
+    }
+    (
+        line.chars().take(MAX_LINE_CHARS).collect::<String>() + " ... [line truncated]",
+        true,
+    )
+}
+
+fn flush_block(blocks: &mut Vec<Value>, current: &mut Vec<String>) {
+    if current.is_empty() {
+        return;
+    }
+    let kind = issue_kind(current);
+    blocks.push(json!({
+        "kind": kind,
+        "text": current.join("\n"),
+    }));
+    current.clear();
+}
+
+fn issue_kind(block: &[String]) -> &'static str {
+    let Some(first) = block.first() else {
+        return "log";
+    };
+    if first.starts_with("WARNING:") {
+        "warning"
+    } else if first.contains("CrashHandlerException")
+        || first.contains("Program crashed with signal")
+    {
+        "crash"
+    } else {
+        "error"
+    }
+}
+
+fn is_issue_start(line: &str) -> bool {
+    line.starts_with("ERROR:")
+        || line.starts_with("SCRIPT ERROR:")
+        || line.starts_with("WARNING:")
+        || line.contains("CrashHandlerException")
+        || line.contains("Program crashed with signal")
+}
+
+fn is_issue_continuation(line: &str) -> bool {
+    line.starts_with("   at:")
+        || line.starts_with("          at:")
+        || line.starts_with("   GDScript backtrace")
+        || line.starts_with("          GDScript backtrace")
+        || line.starts_with("       [")
+        || line.starts_with("              [")
+        || line.starts_with('[')
+        || line.starts_with("-- END OF")
+}

--- a/local/crates/fennara-daemon/src/runtime_daemon/runtime_log.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/runtime_log.rs
@@ -136,6 +136,19 @@ pub(crate) async fn capture_update(
     LogCapture { receipt, lines }
 }
 
+pub(crate) async fn capture_from_offset(
+    session_id: &str,
+    log_path: &Path,
+    mode: &str,
+    byte_offset: u64,
+) -> LogCapture {
+    let mut cursor = RuntimeLogCursor {
+        byte_offset,
+        line: 0,
+    };
+    capture_update(session_id, log_path, mode, &mut cursor).await
+}
+
 pub(crate) fn findings_for_script(lines: &[(u64, String)], script_run_id: &str) -> Value {
     let mut blocks: Vec<Value> = Vec::new();
     let mut current: Vec<String> = Vec::new();
@@ -214,18 +227,11 @@ async fn log_contains(path: &Path, offset: u64, pattern: &str) -> bool {
 
 fn shown_excerpt(lines: &[(u64, String)]) -> (Vec<(u64, String)>, usize, usize) {
     let tail_lines = MAX_SHOWN_LINES.saturating_sub(HEAD_LINES);
-    let mut selected = Vec::new();
-    if lines.len() <= MAX_SHOWN_LINES {
-        selected.extend(lines.iter().cloned());
-    } else {
-        selected.extend(lines.iter().take(HEAD_LINES).cloned());
-        selected.extend(lines.iter().skip(lines.len() - tail_lines).cloned());
-    }
-
     let mut shown = Vec::new();
     let mut chars = 0usize;
     let mut truncated = 0usize;
     if lines.len() <= MAX_SHOWN_LINES {
+        let selected: Vec<(u64, String)> = lines.iter().cloned().collect();
         for (line_no, line) in selected {
             push_shown_line(line_no, line, &mut shown, &mut chars, &mut truncated);
         }
@@ -356,4 +362,124 @@ fn is_issue_continuation(line: &str) -> bool {
         || line.starts_with("              [")
         || line.starts_with('[')
         || line.starts_with("-- END OF")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn numbered_lines(count: u64) -> Vec<(u64, String)> {
+        (1..=count)
+            .map(|line| (line, format!("line {line}")))
+            .collect()
+    }
+
+    #[test]
+    fn shown_excerpt_keeps_all_lines_when_under_limit() {
+        let lines = numbered_lines(3);
+
+        let (shown, omitted, truncated) = shown_excerpt(&lines);
+
+        assert_eq!(shown, lines);
+        assert_eq!(omitted, 0);
+        assert_eq!(truncated, 0);
+    }
+
+    #[test]
+    fn shown_excerpt_uses_head_and_tail_when_over_limit() {
+        let lines = numbered_lines(65);
+
+        let (shown, omitted, truncated) = shown_excerpt(&lines);
+
+        assert_eq!(shown.len(), MAX_SHOWN_LINES);
+        assert_eq!(shown.first().map(|line| line.0), Some(1));
+        assert_eq!(shown.get(HEAD_LINES - 1).map(|line| line.0), Some(20));
+        assert_eq!(shown.get(HEAD_LINES).map(|line| line.0), Some(26));
+        assert_eq!(shown.last().map(|line| line.0), Some(65));
+        assert_eq!(omitted, 5);
+        assert_eq!(truncated, 0);
+    }
+
+    #[test]
+    fn shown_excerpt_reports_line_and_character_truncation() {
+        let lines: Vec<(u64, String)> = (1..=20)
+            .map(|line| (line, "x".repeat(MAX_LINE_CHARS)))
+            .collect();
+
+        let (shown, omitted, truncated) = shown_excerpt(&lines);
+
+        assert!(shown.len() < lines.len());
+        assert_eq!(omitted, lines.len() - shown.len());
+        assert_eq!(truncated, 0);
+    }
+
+    #[test]
+    fn line_ranges_groups_contiguous_line_numbers() {
+        let lines = vec![
+            (2, "a".to_string()),
+            (3, "b".to_string()),
+            (5, "c".to_string()),
+            (8, "d".to_string()),
+            (9, "e".to_string()),
+        ];
+
+        assert_eq!(
+            line_ranges(&lines),
+            vec![
+                json!({ "first": 2, "last": 3 }),
+                json!({ "first": 5, "last": 5 }),
+                json!({ "first": 8, "last": 9 }),
+            ]
+        );
+    }
+
+    #[test]
+    fn complete_line_prefix_len_excludes_partial_tail() {
+        assert_eq!(complete_line_prefix_len(b""), 0);
+        assert_eq!(complete_line_prefix_len(b"partial"), 0);
+        assert_eq!(complete_line_prefix_len(b"one\npartial"), 4);
+        assert_eq!(complete_line_prefix_len(b"one\r\ntwo\n"), 9);
+    }
+
+    #[test]
+    fn truncate_line_preserves_short_lines_and_marks_long_lines() {
+        let (short, short_truncated) = truncate_line("short".to_string());
+        assert_eq!(short, "short");
+        assert!(!short_truncated);
+
+        let (long, long_truncated) = truncate_line("z".repeat(MAX_LINE_CHARS + 1));
+        assert!(long_truncated);
+        assert_eq!(long.chars().take(MAX_LINE_CHARS).count(), MAX_LINE_CHARS);
+        assert!(long.ends_with(" ... [line truncated]"));
+    }
+
+    #[test]
+    fn findings_for_script_extracts_errors_warnings_and_crashes_inside_script_slice() {
+        let lines = vec![
+            (1, "ERROR: before".to_string()),
+            (2, "FENNARA_SCRIPT_STARTED: run-1".to_string()),
+            (3, "WARNING: watch this".to_string()),
+            (4, "   at: res://foo.gd:10".to_string()),
+            (5, "ERROR: broken".to_string()),
+            (6, "CrashHandlerException: crashed".to_string()),
+            (7, "FENNARA_SCRIPT_COMPLETED: run-1".to_string()),
+            (8, "ERROR: after".to_string()),
+        ];
+
+        let findings = findings_for_script(&lines, "run-1");
+
+        assert_eq!(findings["log_available"], json!(true));
+        assert_eq!(findings["has_findings"], json!(true));
+        assert_eq!(findings["warning_count"], json!(1));
+        assert_eq!(findings["error_count"], json!(2));
+        assert_eq!(findings["crash_count"], json!(1));
+        assert!(
+            findings["compacted"]
+                .as_str()
+                .unwrap()
+                .contains("WARNING: watch this")
+        );
+        assert!(!findings["compacted"].as_str().unwrap().contains("before"));
+        assert!(!findings["compacted"].as_str().unwrap().contains("after"));
+    }
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/runtime_sessions.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/runtime_sessions.rs
@@ -168,6 +168,7 @@ async fn runtime_session_start_inner(
 
     #[cfg(target_os = "windows")]
     command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+    command.kill_on_drop(true);
 
     let mut child = command
         .spawn()
@@ -218,6 +219,7 @@ async fn runtime_session_start_inner(
         command_dir: command_dir.clone(),
         raw_log_path: raw_log_path.clone(),
         log_cursor,
+        script_log_start_offsets: Default::default(),
         child,
         started_ms: unix_millis(),
     };
@@ -403,6 +405,10 @@ async fn runtime_session_script_inner(
     let command_temp_path = command_dir.join(format!("{safe_script_run_id}.tmp"));
     let _ = tokio::fs::remove_file(&command_temp_path).await;
     let _ = tokio::fs::remove_file(&command_path).await;
+    let script_log_start_offset = tokio::fs::metadata(&raw_log_path)
+        .await
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
     let command = json!({
         "action": "run_runtime_script",
         "session_id": session_id,
@@ -418,6 +424,14 @@ async fn runtime_session_script_inner(
     tokio::fs::rename(&command_temp_path, &command_path)
         .await
         .map_err(|err| format!("publish script command failed: {err}"))?;
+    {
+        let mut sessions = state.runtime_sessions.lock().await;
+        if let Some(session) = sessions.get_mut(&session_id) {
+            session
+                .script_log_start_offsets
+                .insert(script_run_id.clone(), script_log_start_offset);
+        }
+    }
 
     let deadline = tokio::time::Instant::now()
         + Duration::from_millis(request.timeout_ms.unwrap_or(10_000).clamp(500, 120_000));
@@ -483,7 +497,19 @@ async fn attach_script_log(
         &mut session.log_cursor,
     )
     .await;
-    response["runtime_findings"] =
-        runtime_log::findings_for_script(&log_capture.lines, script_run_id);
+    let finding_lines =
+        if let Some(byte_offset) = session.script_log_start_offsets.remove(script_run_id) {
+            runtime_log::capture_from_offset(
+                &session.session_id,
+                &session.raw_log_path,
+                "runtime_script_findings",
+                byte_offset,
+            )
+            .await
+            .lines
+        } else {
+            log_capture.lines.clone()
+        };
+    response["runtime_findings"] = runtime_log::findings_for_script(&finding_lines, script_run_id);
     response["runtime_log"] = log_capture.receipt;
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/runtime_sessions.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/runtime_sessions.rs
@@ -6,12 +6,14 @@ use tokio::process::Command;
 
 use super::{
     process_helpers::resolve_godot_executable,
-    state::{AppState, RuntimeSession},
+    runtime_log,
+    state::{AppState, RuntimeLogCursor, RuntimeSession},
     util::{sanitize_path_component, unix_millis},
 };
 
 #[cfg(target_os = "windows")]
 const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
+const STARTUP_READY_TIMEOUT_MS: u64 = 5_000;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct RuntimeSessionStartRequest {
@@ -167,10 +169,47 @@ async fn runtime_session_start_inner(
     #[cfg(target_os = "windows")]
     command.creation_flags(CREATE_NEW_PROCESS_GROUP);
 
-    let child = command
+    let mut child = command
         .spawn()
         .map_err(|err| format!("failed to start runtime session: {err}"))?;
     let pid = child.id().unwrap_or_default();
+    let mut log_cursor = RuntimeLogCursor::default();
+    let (ready_seen, process_exited, startup_wait_ms) = runtime_log::wait_for_ready(
+        &mut child,
+        &raw_log_path,
+        log_cursor.byte_offset,
+        STARTUP_READY_TIMEOUT_MS,
+    )
+    .await?;
+    let log_capture =
+        runtime_log::capture_update(&session_id, &raw_log_path, "start", &mut log_cursor).await;
+    if process_exited && !ready_seen {
+        let exit_code = child
+            .try_wait()
+            .map_err(|err| format!("runtime session wait failed: {err}"))?
+            .and_then(|status| status.code());
+        return Ok(json!({
+            "ok": false,
+            "status": "exited_before_ready",
+            "scope": "global",
+            "scope_note": "Fennara currently allows one managed runtime session across all connected Godot editors.",
+            "session_id": session_id,
+            "pid": pid,
+            "scene_path": request.scene_path,
+            "artifact_dir": artifact_dir.to_string_lossy(),
+            "command_dir": command_dir.to_string_lossy(),
+            "raw_log_path": raw_log_path.to_string_lossy(),
+            "spec_path": spec_path.to_string_lossy(),
+            "executable": executable.to_string_lossy(),
+            "startup_log_wait_ms": startup_wait_ms,
+            "startup_ready_seen": ready_seen,
+            "startup_process_exited": process_exited,
+            "exit_code": exit_code,
+            "error": "Runtime process exited before the runtime helper reported scene ready.",
+            "runtime_log": log_capture.receipt,
+        }));
+    }
+
     let session = RuntimeSession {
         session_id: session_id.clone(),
         scene_path: request.scene_path.clone(),
@@ -178,28 +217,53 @@ async fn runtime_session_start_inner(
         artifact_dir: artifact_dir.clone(),
         command_dir: command_dir.clone(),
         raw_log_path: raw_log_path.clone(),
+        log_cursor,
         child,
         started_ms: unix_millis(),
     };
-    state
-        .runtime_sessions
-        .lock()
-        .await
-        .insert(session_id.clone(), session);
+    let mut sessions = state.runtime_sessions.lock().await;
+    let mut running_session_id = None;
+    for (existing_id, existing) in sessions.iter_mut() {
+        if existing
+            .child
+            .try_wait()
+            .map_err(|err| format!("runtime session wait failed: {err}"))?
+            .is_none()
+        {
+            running_session_id = Some(existing_id.clone());
+            break;
+        }
+    }
+    if let Some(existing_id) = running_session_id {
+        drop(sessions);
+        let mut session = session;
+        let _ = session.child.kill().await;
+        return Err(format!(
+            "Runtime session already running: {existing_id}. Fennara currently allows one managed runtime session across all connected Godot editors. Use runtime_session.status or runtime_session.stop before starting another scene."
+        ));
+    }
+    sessions.insert(session_id.clone(), session);
+    let session = sessions
+        .get_mut(&session_id)
+        .ok_or_else(|| format!("Runtime session disappeared after start: {session_id}"))?;
 
     Ok(json!({
         "ok": true,
         "status": "started",
         "scope": "global",
         "scope_note": "Fennara currently allows one managed runtime session across all connected Godot editors.",
-        "session_id": session_id,
+        "session_id": session.session_id,
         "pid": pid,
-        "scene_path": request.scene_path,
+        "scene_path": session.scene_path,
         "artifact_dir": artifact_dir.to_string_lossy(),
         "command_dir": command_dir.to_string_lossy(),
         "raw_log_path": raw_log_path.to_string_lossy(),
         "spec_path": spec_path.to_string_lossy(),
         "executable": executable.to_string_lossy(),
+        "startup_log_wait_ms": startup_wait_ms,
+        "startup_ready_seen": ready_seen,
+        "startup_process_exited": process_exited,
+        "runtime_log": log_capture.receipt,
     }))
 }
 
@@ -212,6 +276,13 @@ async fn runtime_session_status_inner(state: &AppState, session_id: &str) -> Res
         .child
         .try_wait()
         .map_err(|err| format!("runtime session wait failed: {err}"))?;
+    let log_capture = runtime_log::capture_update(
+        &session.session_id,
+        &session.raw_log_path,
+        "status",
+        &mut session.log_cursor,
+    )
+    .await;
     Ok(json!({
         "ok": true,
         "session_id": session.session_id,
@@ -225,6 +296,7 @@ async fn runtime_session_status_inner(state: &AppState, session_id: &str) -> Res
         "raw_log_path": session.raw_log_path.to_string_lossy(),
         "working_directory": session.working_directory.to_string_lossy(),
         "started_ms": session.started_ms,
+        "runtime_log": log_capture.receipt,
     }))
 }
 
@@ -248,6 +320,13 @@ async fn runtime_session_stop_inner(state: &AppState, session_id: &str) -> Resul
             exit_code = status.code();
         }
     }
+    let log_capture = runtime_log::capture_update(
+        &session.session_id,
+        &session.raw_log_path,
+        "stop",
+        &mut session.log_cursor,
+    )
+    .await;
     Ok(json!({
         "ok": true,
         "status": "stopped",
@@ -256,6 +335,7 @@ async fn runtime_session_stop_inner(state: &AppState, session_id: &str) -> Resul
         "exit_code": exit_code,
         "artifact_dir": session.artifact_dir.to_string_lossy(),
         "raw_log_path": session.raw_log_path.to_string_lossy(),
+        "runtime_log": log_capture.receipt,
     }))
 }
 
@@ -263,11 +343,46 @@ async fn runtime_session_script_inner(
     state: &AppState,
     request: RuntimeScriptRequest,
 ) -> Result<Value, String> {
+    let session_id = request.session_id.clone();
+    let script_run_id = request.script_run_id.clone();
     let (command_dir, artifact_dir, raw_log_path) = {
-        let sessions = state.runtime_sessions.lock().await;
+        let mut sessions = state.runtime_sessions.lock().await;
         let session = sessions
-            .get(&request.session_id)
-            .ok_or_else(|| format!("Runtime session not found: {}", request.session_id))?;
+            .get_mut(&session_id)
+            .ok_or_else(|| format!("Runtime session not found: {session_id}"))?;
+        let exit_status = session
+            .child
+            .try_wait()
+            .map_err(|err| format!("runtime session wait failed: {err}"))?;
+        if let Some(status) = exit_status {
+            let mut session = sessions
+                .remove(&session_id)
+                .ok_or_else(|| format!("Runtime session not found: {session_id}"))?;
+            drop(sessions);
+            let log_capture = runtime_log::capture_update(
+                &session.session_id,
+                &session.raw_log_path,
+                "runtime_script",
+                &mut session.log_cursor,
+            )
+            .await;
+            return Ok(json!({
+                "ok": false,
+                "status": "session_exited",
+                "scope": "global",
+                "session_id": session_id,
+                "script_run_id": script_run_id,
+                "artifact_dir": session.artifact_dir.to_string_lossy(),
+                "raw_log_path": session.raw_log_path.to_string_lossy(),
+                "exit_code": status.code(),
+                "error": "Runtime session process exited before the script command could be sent.",
+                "runtime_log": log_capture.receipt,
+                "runtime_findings": runtime_log::findings_for_script(&log_capture.lines, &script_run_id),
+            }));
+        }
+        let session = sessions
+            .get(&session_id)
+            .ok_or_else(|| format!("Runtime session not found: {session_id}"))?;
         (
             session.command_dir.clone(),
             session.artifact_dir.clone(),
@@ -281,46 +396,47 @@ async fn runtime_session_script_inner(
     tokio::fs::create_dir_all(&status_dir)
         .await
         .map_err(|err| format!("create runtime_script_results dir failed: {err}"))?;
-    let status_path = status_dir.join(format!(
-        "{}.json",
-        sanitize_path_component(&request.script_run_id)
-    ));
+    let safe_script_run_id = sanitize_path_component(&script_run_id);
+    let status_path = status_dir.join(format!("{safe_script_run_id}.json"));
     let _ = tokio::fs::remove_file(&status_path).await;
-    let command_path = command_dir.join(format!(
-        "{}.json",
-        sanitize_path_component(&request.script_run_id)
-    ));
+    let command_path = command_dir.join(format!("{safe_script_run_id}.json"));
+    let command_temp_path = command_dir.join(format!("{safe_script_run_id}.tmp"));
+    let _ = tokio::fs::remove_file(&command_temp_path).await;
+    let _ = tokio::fs::remove_file(&command_path).await;
     let command = json!({
         "action": "run_runtime_script",
-        "session_id": request.session_id,
-        "script_run_id": request.script_run_id,
+        "session_id": session_id,
+        "script_run_id": script_run_id,
         "script_path": request.script_path,
         "status_path": status_path.to_string_lossy(),
     });
-    tokio::fs::write(
-        &command_path,
-        serde_json::to_string_pretty(&command)
-            .map_err(|err| format!("serialize script command failed: {err}"))?,
-    )
-    .await
-    .map_err(|err| format!("write script command failed: {err}"))?;
+    let command_text = serde_json::to_string_pretty(&command)
+        .map_err(|err| format!("serialize script command failed: {err}"))?;
+    tokio::fs::write(&command_temp_path, command_text)
+        .await
+        .map_err(|err| format!("write script command temp file failed: {err}"))?;
+    tokio::fs::rename(&command_temp_path, &command_path)
+        .await
+        .map_err(|err| format!("publish script command failed: {err}"))?;
 
     let deadline = tokio::time::Instant::now()
         + Duration::from_millis(request.timeout_ms.unwrap_or(10_000).clamp(500, 120_000));
     loop {
         if tokio::time::Instant::now() >= deadline {
-            return Ok(json!({
+            let mut response = json!({
                 "ok": false,
                 "status": "timeout",
                 "scope": "global",
-                "session_id": request.session_id,
-                "script_run_id": request.script_run_id,
+                "session_id": session_id,
+                "script_run_id": script_run_id,
                 "command_path": command_path.to_string_lossy(),
                 "artifact_dir": artifact_dir.to_string_lossy(),
                 "status_path": status_path.to_string_lossy(),
                 "raw_log_path": raw_log_path.to_string_lossy(),
                 "error": "Runtime script result did not arrive before timeout.",
-            }));
+            });
+            attach_script_log(state, &session_id, &script_run_id, &mut response).await;
+            return Ok(response);
         }
         if status_path.is_file() {
             let text = tokio::fs::read_to_string(&status_path)
@@ -329,21 +445,45 @@ async fn runtime_session_script_inner(
             if let Ok(value) = serde_json::from_str::<Value>(&text) {
                 let status = value.get("status").and_then(Value::as_str).unwrap_or("");
                 if status == "completed" || status == "failed" {
-                    return Ok(json!({
+                    let mut response = json!({
                         "ok": status == "completed",
                         "status": status,
                         "scope": "global",
-                        "session_id": request.session_id,
-                        "script_run_id": request.script_run_id,
+                        "session_id": session_id,
+                        "script_run_id": script_run_id,
                         "command_path": command_path.to_string_lossy(),
                         "artifact_dir": artifact_dir.to_string_lossy(),
                         "status_path": status_path.to_string_lossy(),
                         "raw_log_path": raw_log_path.to_string_lossy(),
                         "result": value,
-                    }));
+                    });
+                    attach_script_log(state, &session_id, &script_run_id, &mut response).await;
+                    return Ok(response);
                 }
             }
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+async fn attach_script_log(
+    state: &AppState,
+    session_id: &str,
+    script_run_id: &str,
+    response: &mut Value,
+) {
+    let mut sessions = state.runtime_sessions.lock().await;
+    let Some(session) = sessions.get_mut(session_id) else {
+        return;
+    };
+    let log_capture = runtime_log::capture_update(
+        &session.session_id,
+        &session.raw_log_path,
+        "runtime_script",
+        &mut session.log_cursor,
+    )
+    .await;
+    response["runtime_findings"] =
+        runtime_log::findings_for_script(&log_capture.lines, script_run_id);
+    response["runtime_log"] = log_capture.receipt;
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/state.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/state.rs
@@ -95,6 +95,7 @@ pub(crate) struct RuntimeSession {
     pub(crate) command_dir: PathBuf,
     pub(crate) raw_log_path: PathBuf,
     pub(crate) log_cursor: RuntimeLogCursor,
+    pub(crate) script_log_start_offsets: HashMap<String, u64>,
     pub(crate) child: tokio::process::Child,
     pub(crate) started_ms: u128,
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/state.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/state.rs
@@ -94,6 +94,13 @@ pub(crate) struct RuntimeSession {
     pub(crate) artifact_dir: PathBuf,
     pub(crate) command_dir: PathBuf,
     pub(crate) raw_log_path: PathBuf,
+    pub(crate) log_cursor: RuntimeLogCursor,
     pub(crate) child: tokio::process::Child,
     pub(crate) started_ms: u128,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RuntimeLogCursor {
+    pub(crate) byte_offset: u64,
+    pub(crate) line: u64,
 }


### PR DESCRIPTION
## Summary
- Attach capped runtime log excerpts to `runtime_session` start/status/stop receipts.
- Attach capped runtime log excerpts and runtime findings to `runtime_script` receipts.
- Add shared C++ receipt formatting for runtime log updates so the model sees fresh log lines without a follow-up file read.

## Extra supporting changes
- Re-checks for an already-running session after the startup wait, so a delayed start cannot race another managed session into the daemon map.
- Enables `kill_on_drop(true)` for the startup child process so startup error paths do not orphan the spawned Godot process.
- Writes runtime script command files through a temporary file and rename, avoiding partially-read command JSON.
- Clamps runtime script timeout values and gives the HTTP request a matching timeout margin.
- Records a per-script log start byte offset so `runtime_findings` are extracted from the script's stable log range even if `runtime_session.status` advanced the main receipt cursor.

## Validation
- `git diff --check`
- `cargo fmt -p fennara-daemon --check`
- `cargo test -p fennara-mcp`
- `cargo test -p fennara-daemon`

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime log updates to session and script results, including clearer “Runtime log update” excerpts with line-range and truncation notices.
  * Session start now waits for a readiness marker and reports startup timing (plus warnings when readiness is missed).
* **Bug Fixes**
  * Improved handling for empty/missing/unreadable logs, log cursor resets, and truncated output.
  * Timeout requests are now clamped to configured min/max bounds.
* **Tests**
  * Added unit tests covering log excerpt selection, truncation, line grouping, and script-scoped finding extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->