### PR TITLE
fix: preserve socket stdio in mcp launcher

### DIFF
--- a/local/crates/fennara-mcp/src/main.rs
+++ b/local/crates/fennara-mcp/src/main.rs
@@ -1,9 +1,13 @@
 use serde_json::Value;
 use std::env;
 use std::fs;
+#[cfg(not(unix))]
 use std::io;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(not(unix))]
+use std::process::Stdio;
+#[cfg(not(unix))]
 use std::thread;
 
 fn main() {
@@ -15,6 +19,24 @@ fn main() {
 
 fn run() -> Result<(), String> {
     let runtime_path = runtime_path("mcp_runtime")?;
+    run_runtime(runtime_path)
+}
+
+#[cfg(unix)]
+fn run_runtime(runtime_path: PathBuf) -> Result<(), String> {
+    use std::os::unix::process::CommandExt;
+
+    let error = Command::new(&runtime_path)
+        .args(env::args_os().skip(1))
+        .exec();
+    Err(format!(
+        "failed to exec {}: {error}",
+        runtime_path.display()
+    ))
+}
+
+#[cfg(not(unix))]
+fn run_runtime(runtime_path: PathBuf) -> Result<(), String> {
     let mut child = Command::new(&runtime_path)
         .args(env::args_os().skip(1))
         .stdin(Stdio::piped())

--- a/local/crates/fennara-mcp/tests/socketpair_stdio.rs
+++ b/local/crates/fennara-mcp/tests/socketpair_stdio.rs
@@ -36,7 +36,7 @@ fn launcher_answers_initialize_when_stdio_uses_socketpairs() {
     let mut child = Command::new(&launcher)
         .stdin(unsafe { Stdio::from_raw_fd(stdin_child.into_raw_fd()) })
         .stdout(unsafe { Stdio::from_raw_fd(stdout_child.into_raw_fd()) })
-        .stderr(Stdio::piped())
+        .stderr(Stdio::inherit())
         .spawn()
         .expect("spawn launcher with socket stdio");
 

--- a/local/crates/fennara-mcp/tests/socketpair_stdio.rs
+++ b/local/crates/fennara-mcp/tests/socketpair_stdio.rs
@@ -1,0 +1,71 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::os::fd::{FromRawFd, IntoRawFd};
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[test]
+fn launcher_answers_initialize_when_stdio_uses_socketpairs() {
+    let app_dir = temp_app_dir();
+    let bin_dir = app_dir.join("bin");
+    fs::create_dir_all(&bin_dir).expect("create fake app bin dir");
+
+    let launcher = bin_dir.join("fennara-mcp");
+    fs::copy(env!("CARGO_BIN_EXE_fennara-mcp"), &launcher).expect("copy launcher");
+    fs::set_permissions(&launcher, fs::Permissions::from_mode(0o755))
+        .expect("make launcher executable");
+
+    let runtime = env!("CARGO_BIN_EXE_fennara-mcp-runtime").replace('\\', "\\\\");
+    fs::write(
+        app_dir.join("current.json"),
+        format!(r#"{{"mcp_runtime":"{runtime}"}}"#),
+    )
+    .expect("write fake current manifest");
+
+    let (mut stdin_parent, stdin_child) = UnixStream::pair().expect("stdin socketpair");
+    let (stdout_parent, stdout_child) = UnixStream::pair().expect("stdout socketpair");
+    stdout_parent
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set stdout read timeout");
+
+    let mut child = Command::new(&launcher)
+        .stdin(unsafe { Stdio::from_raw_fd(stdin_child.into_raw_fd()) })
+        .stdout(unsafe { Stdio::from_raw_fd(stdout_child.into_raw_fd()) })
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn launcher with socket stdio");
+
+    let request = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"socketpair-test","version":"0"}}}"#;
+    writeln!(stdin_parent, "{request}").expect("write initialize request");
+
+    let mut line = String::new();
+    let mut reader = BufReader::new(stdout_parent);
+    reader
+        .read_line(&mut line)
+        .expect("read initialize response from socket stdout");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = fs::remove_dir_all(&app_dir);
+
+    assert!(
+        line.contains(r#""id":1"#) && line.contains(r#""result""#),
+        "expected initialize result, got: {line:?}"
+    );
+}
+
+fn temp_app_dir() -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "fennara-mcp-socketpair-test-{}-{unique}",
+        std::process::id()
+    ))
+}


### PR DESCRIPTION
## Summary

Fixes #54.

This changes the Unix `fennara-mcp` launcher to `exec` the versioned `fennara-mcp-runtime` directly instead of proxying stdin/stdout through relay threads. That preserves the MCP client's original fd 0/1/2, including AF_UNIX socketpair stdin from Node/libuv-based clients such as Claude Code interactive sessions.

The Windows/non-Unix path keeps the existing relay behavior.

## Root Cause

The stable launcher spawned the runtime with pipe stdio and used `io::copy` threads to relay client stdin/stdout. On Linux, when the launcher itself received stdin as an AF_UNIX socketpair, the stdin pump never forwarded the MCP `initialize` line into the runtime pipe, so the runtime blocked forever waiting for input.

## Changes

- Use `CommandExt::exec()` on Unix so the runtime replaces the launcher process and inherits client stdio directly.
- Keep the existing child-process relay path for non-Unix platforms.
- Add a Unix integration test that launches the installed-style wrapper through socketpair stdin/stdout and verifies the MCP `initialize` response.

## Validation

- `cargo fmt -p fennara-mcp --check`
- `cargo test -p fennara-mcp` on Windows
- Fresh `fennara-reviewer` pre-commit pass: no actionable findings

## Notes

The new socketpair regression test is `#[cfg(unix)]`, so it will run in PR CI on Ubuntu/macOS. It does not execute on the local Windows host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launcher startup across platforms with more reliable handoff behavior on Unix and non-Unix systems.
  * Fixed runtime launch issues when standard input/output are connected via pipes or socket-based stdio.
  * Ensured JSON-RPC initialization works correctly in socketpair-backed stdio setups.
* **Tests**
  * Added a Unix-only integration test covering launcher-to-runtime communication to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->