### PR TITLE
fix: group unset export notes by script

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -326,11 +326,12 @@ invalid NodePath properties, invalid script `$Node`/`get_node()` references,
 duplicate sibling names, cyclic scene dependencies, and unset exported
 Resource/Object variables.
 
-Unset exported Resource/Object variables are split by signal strength.
-Declaration-only unset exports are reported as structural notes because they may
-be optional or assigned at runtime. Unset exports referenced elsewhere in the
-script are structural warnings to verify/null-guard or assign; they are not
-automatic proof that a placeholder resource should be created.
+Unset exported Resource/Object variables are reported as structural notes because
+they may be optional or assigned at runtime. Repeated unset exports are grouped
+once per script with the unique variable names and capped node samples per scene,
+so large scenes do not flood the receipt with one line per node/property pair.
+Ignore these notes when the references are intentionally optional or assigned at
+runtime.
 
 For scenes with zero structural errors, Fennara also runs each scene headlessly
 for exactly 3 seconds through the local daemon using up to 3 memory-throttled

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -328,7 +328,7 @@ Resource/Object variables.
 
 Unset exported Resource/Object variables are reported as structural notes because
 they may be optional or assigned at runtime. Repeated unset exports are grouped
-once per script with the unique variable names and capped node samples per scene,
+once per script with the unique variable names and capped affected scene counts,
 so large scenes do not flood the receipt with one line per node/property pair.
 Ignore these notes when the references are intentionally optional or assigned at
 runtime.

--- a/fennara-cpp/src/tool_results/validate_scene.cpp
+++ b/fennara-cpp/src/tool_results/validate_scene.cpp
@@ -75,14 +75,6 @@ godot::String count_label(int count, const godot::String &singular,
            (count == 1 ? singular : plural);
 }
 
-godot::String join_array_strings(const godot::Array &values) {
-    godot::PackedStringArray parts;
-    for (int i = 0; i < values.size(); i++) {
-        parts.append(values[i]);
-    }
-    return godot::String(", ").join(parts);
-}
-
 void add_unique_unset_property(godot::Dictionary &group,
                                const godot::String &name,
                                const godot::String &type) {
@@ -141,24 +133,6 @@ godot::String format_unset_properties(const godot::Array &properties) {
     return godot::String(", ").join(parts);
 }
 
-void add_unset_node_sample(godot::Dictionary &scene_group,
-                           const godot::String &node_path) {
-    if (node_path.is_empty()) {
-        return;
-    }
-    godot::Dictionary seen = scene_group.get("sample_seen", godot::Dictionary());
-    if (seen.has(node_path)) {
-        return;
-    }
-    seen[node_path] = true;
-    godot::Array samples = scene_group.get("samples", godot::Array());
-    if (samples.size() < 5) {
-        samples.append(node_path);
-        scene_group["samples"] = samples;
-    }
-    scene_group["sample_seen"] = seen;
-}
-
 void add_unset_issue_scene(godot::Dictionary &group,
                            const godot::String &scene_path,
                            const godot::Dictionary &issue) {
@@ -169,8 +143,6 @@ void add_unset_issue_scene(godot::Dictionary &group,
         scene_group = scenes[scene_path];
     } else {
         scene_group["count"] = 0;
-        scene_group["samples"] = godot::Array();
-        scene_group["sample_seen"] = godot::Dictionary();
         scene_order.append(scene_path);
     }
 
@@ -180,24 +152,12 @@ void add_unset_issue_scene(godot::Dictionary &group,
         issue.get("node_count", issue.get("unset_count", 1)));
     scene_group["count"] = count + issue_node_count;
 
-    godot::Variant samples_var = issue.get("samples", godot::Variant());
-    if (samples_var.get_type() == godot::Variant::ARRAY) {
-        godot::Array samples = samples_var;
-        for (int i = 0; i < samples.size(); i++) {
-            add_unset_node_sample(scene_group, samples[i]);
-        }
-    } else {
-        add_unset_node_sample(
-            scene_group,
-            issue.get("node_path", issue.get("node", "")));
-    }
-
     scenes[scene_path] = scene_group;
     group["scenes"] = scenes;
     group["scene_order"] = scene_order;
 }
 
-godot::String format_unset_scene_samples(const godot::Dictionary &group) {
+godot::String format_unset_scene_counts(const godot::Dictionary &group) {
     godot::Array scene_order = group.get("scene_order", godot::Array());
     godot::Dictionary scenes = group.get("scenes", godot::Dictionary());
     godot::PackedStringArray parts;
@@ -209,17 +169,8 @@ godot::String format_unset_scene_samples(const godot::Dictionary &group) {
         godot::String scene_path = scene_order[i];
         godot::Dictionary scene_group = scenes[scene_path];
         int count = static_cast<int>(scene_group.get("count", 0));
-        godot::Array samples = scene_group.get("samples", godot::Array());
-        godot::String text = scene_path + ": ";
-        if (samples.is_empty()) {
-            text += count_label(count, "node", "nodes");
-        } else {
-            text += join_array_strings(samples);
-            int omitted = count - samples.size();
-            if (omitted > 0) {
-                text += ", " + count_label(omitted, "omitted", "omitted");
-            }
-        }
+        godot::String text =
+            scene_path + " (" + count_label(count, "node", "nodes") + ")";
         parts.append(text);
     }
     int omitted_scenes = scene_order.size() - shown_scenes;
@@ -308,9 +259,9 @@ godot::String global_unset_export_section(
         }
         bullet += " on " + count_label(node_count, "node", "nodes") + ". ";
         bullet += "Ignore this note if these references are intentionally optional or assigned at runtime.";
-        godot::String node_text = format_unset_scene_samples(group);
-        if (!node_text.is_empty()) {
-            bullet += " Nodes: " + node_text;
+        godot::String scene_text = format_unset_scene_counts(group);
+        if (!scene_text.is_empty()) {
+            bullet += " Scenes: " + scene_text;
         }
         lines.append(bullet);
     }

--- a/fennara-cpp/src/tool_results/validate_scene.cpp
+++ b/fennara-cpp/src/tool_results/validate_scene.cpp
@@ -65,10 +65,268 @@ godot::Dictionary target_metadata(const godot::Dictionary &scene) {
     return target;
 }
 
+bool is_unset_export_issue(const godot::Dictionary &issue) {
+    return godot::String(issue.get("check", "")) == "unset_export_var";
+}
+
+godot::String count_label(int count, const godot::String &singular,
+                          const godot::String &plural) {
+    return godot::String::num_int64(count) + " " +
+           (count == 1 ? singular : plural);
+}
+
+godot::String join_array_strings(const godot::Array &values) {
+    godot::PackedStringArray parts;
+    for (int i = 0; i < values.size(); i++) {
+        parts.append(values[i]);
+    }
+    return godot::String(", ").join(parts);
+}
+
+void add_unique_unset_property(godot::Dictionary &group,
+                               const godot::String &name,
+                               const godot::String &type) {
+    if (name.is_empty()) {
+        return;
+    }
+    godot::String key = name + godot::String("\n") + type;
+    godot::Dictionary seen = group.get("property_seen", godot::Dictionary());
+    if (seen.has(key)) {
+        return;
+    }
+    seen[key] = true;
+    godot::Array properties = group.get("properties", godot::Array());
+    godot::Dictionary property;
+    property["name"] = name;
+    property["type"] = type;
+    properties.append(property);
+    group["properties"] = properties;
+    group["property_seen"] = seen;
+}
+
+void add_unset_issue_properties(godot::Dictionary &group,
+                                const godot::Dictionary &issue) {
+    godot::Variant props_var = issue.get("properties", godot::Variant());
+    if (props_var.get_type() == godot::Variant::ARRAY) {
+        godot::Array props = props_var;
+        for (int i = 0; i < props.size(); i++) {
+            if (props[i].get_type() != godot::Variant::DICTIONARY) {
+                continue;
+            }
+            godot::Dictionary prop = props[i];
+            add_unique_unset_property(group, prop.get("name", ""),
+                                      prop.get("type", ""));
+        }
+        return;
+    }
+
+    add_unique_unset_property(group, issue.get("property", ""),
+                              issue.get("type", ""));
+}
+
+godot::String format_unset_properties(const godot::Array &properties) {
+    godot::PackedStringArray parts;
+    for (int i = 0; i < properties.size(); i++) {
+        if (properties[i].get_type() != godot::Variant::DICTIONARY) {
+            continue;
+        }
+        godot::Dictionary prop = properties[i];
+        godot::String name = prop.get("name", "");
+        godot::String type = prop.get("type", "");
+        if (name.is_empty()) {
+            continue;
+        }
+        parts.append(type.is_empty() ? name : name + " (" + type + ")");
+    }
+    return godot::String(", ").join(parts);
+}
+
+void add_unset_node_sample(godot::Dictionary &scene_group,
+                           const godot::String &node_path) {
+    if (node_path.is_empty()) {
+        return;
+    }
+    godot::Dictionary seen = scene_group.get("sample_seen", godot::Dictionary());
+    if (seen.has(node_path)) {
+        return;
+    }
+    seen[node_path] = true;
+    godot::Array samples = scene_group.get("samples", godot::Array());
+    if (samples.size() < 5) {
+        samples.append(node_path);
+        scene_group["samples"] = samples;
+    }
+    scene_group["sample_seen"] = seen;
+}
+
+void add_unset_issue_scene(godot::Dictionary &group,
+                           const godot::String &scene_path,
+                           const godot::Dictionary &issue) {
+    godot::Dictionary scenes = group.get("scenes", godot::Dictionary());
+    godot::Array scene_order = group.get("scene_order", godot::Array());
+    godot::Dictionary scene_group;
+    if (scenes.has(scene_path)) {
+        scene_group = scenes[scene_path];
+    } else {
+        scene_group["count"] = 0;
+        scene_group["samples"] = godot::Array();
+        scene_group["sample_seen"] = godot::Dictionary();
+        scene_order.append(scene_path);
+    }
+
+    int count = static_cast<int>(
+        scene_group.get("count", 0));
+    int issue_node_count = static_cast<int>(
+        issue.get("node_count", issue.get("unset_count", 1)));
+    scene_group["count"] = count + issue_node_count;
+
+    godot::Variant samples_var = issue.get("samples", godot::Variant());
+    if (samples_var.get_type() == godot::Variant::ARRAY) {
+        godot::Array samples = samples_var;
+        for (int i = 0; i < samples.size(); i++) {
+            add_unset_node_sample(scene_group, samples[i]);
+        }
+    } else {
+        add_unset_node_sample(
+            scene_group,
+            issue.get("node_path", issue.get("node", "")));
+    }
+
+    scenes[scene_path] = scene_group;
+    group["scenes"] = scenes;
+    group["scene_order"] = scene_order;
+}
+
+godot::String format_unset_scene_samples(const godot::Dictionary &group) {
+    godot::Array scene_order = group.get("scene_order", godot::Array());
+    godot::Dictionary scenes = group.get("scenes", godot::Dictionary());
+    godot::PackedStringArray parts;
+    int scene_limit = 5;
+    int shown_scenes = scene_order.size() < scene_limit
+        ? scene_order.size()
+        : scene_limit;
+    for (int i = 0; i < shown_scenes; i++) {
+        godot::String scene_path = scene_order[i];
+        godot::Dictionary scene_group = scenes[scene_path];
+        int count = static_cast<int>(scene_group.get("count", 0));
+        godot::Array samples = scene_group.get("samples", godot::Array());
+        godot::String text = scene_path + ": ";
+        if (samples.is_empty()) {
+            text += count_label(count, "node", "nodes");
+        } else {
+            text += join_array_strings(samples);
+            int omitted = count - samples.size();
+            if (omitted > 0) {
+                text += ", " + count_label(omitted, "omitted", "omitted");
+            }
+        }
+        parts.append(text);
+    }
+    int omitted_scenes = scene_order.size() - shown_scenes;
+    if (omitted_scenes > 0) {
+        parts.append(count_label(omitted_scenes, "scene omitted",
+                                 "scenes omitted"));
+    }
+    return godot::String("; ").join(parts);
+}
+
+godot::String global_unset_export_section(
+    const godot::Array &scenes,
+    godot::Dictionary &scene_unset_counts) {
+    godot::Dictionary groups;
+    godot::Array group_order;
+
+    for (int i = 0; i < scenes.size(); i++) {
+        if (scenes[i].get_type() != godot::Variant::DICTIONARY) {
+            continue;
+        }
+        godot::Dictionary scene = scenes[i];
+        godot::String scene_path = scene_label(scene, i);
+        godot::Array issues = scene.get("issues", godot::Array());
+        for (int issue_index = 0; issue_index < issues.size(); issue_index++) {
+            if (issues[issue_index].get_type() != godot::Variant::DICTIONARY) {
+                continue;
+            }
+            godot::Dictionary issue = issues[issue_index];
+            if (!is_unset_export_issue(issue)) {
+                continue;
+            }
+
+            int scene_count = static_cast<int>(
+                scene_unset_counts.get(scene_path, 0));
+            scene_unset_counts[scene_path] = scene_count + 1;
+
+            godot::String script_path = issue.get("script_path", "");
+            godot::String key =
+                script_path.is_empty() ? godot::String(issue.get("message", ""))
+                                       : script_path;
+            godot::Dictionary group;
+            if (groups.has(key)) {
+                group = groups[key];
+            } else {
+                group["script_path"] = script_path;
+                group["properties"] = godot::Array();
+                group["property_seen"] = godot::Dictionary();
+                group["node_count"] = 0;
+                group["scenes"] = godot::Dictionary();
+                group["scene_order"] = godot::Array();
+                group_order.append(key);
+            }
+
+            add_unset_issue_properties(group, issue);
+            int node_count = static_cast<int>(group.get("node_count", 0));
+            group["node_count"] = node_count +
+                static_cast<int>(issue.get("node_count", issue.get("unset_count", 1)));
+            add_unset_issue_scene(group, scene_path, issue);
+            groups[key] = group;
+        }
+    }
+
+    if (group_order.is_empty()) {
+        return "";
+    }
+
+    godot::PackedStringArray lines;
+    lines.append("## Unset export notes");
+    for (int i = 0; i < group_order.size(); i++) {
+        godot::String key = group_order[i];
+        godot::Dictionary group = groups[key];
+        godot::String script_path = group.get("script_path", "");
+        godot::Array properties = group.get("properties", godot::Array());
+        int node_count = static_cast<int>(group.get("node_count", 0));
+        godot::String prop_text = format_unset_properties(properties);
+
+        godot::String bullet = "- info (unset_export_var) ";
+        bullet += script_path.is_empty()
+            ? godot::String("Script <unknown>")
+            : godot::String("Script ") + script_path;
+        bullet += ": " +
+            count_label(properties.size(), "unset exported Object/Resource var",
+                        "unset exported Object/Resource vars");
+        if (!prop_text.is_empty()) {
+            bullet += ": " + prop_text;
+        }
+        bullet += " on " + count_label(node_count, "node", "nodes") + ". ";
+        bullet += "Ignore this note if these references are intentionally optional or assigned at runtime.";
+        godot::String node_text = format_unset_scene_samples(group);
+        if (!node_text.is_empty()) {
+            bullet += " Nodes: " + node_text;
+        }
+        lines.append(bullet);
+    }
+
+    return godot::String("\n").join(lines);
+}
+
 godot::String issue_extra_text(const godot::Dictionary &issue) {
     static const char *skip_keys[] = {
         "node", "node_path", "check", "severity", "message"
     };
+    static const char *unset_export_skip_keys[] = {
+        "property", "type", "script_path", "unset_count", "instance_scene",
+        "properties", "node_count", "samples", "instance_scenes"
+    };
+    bool is_unset_export = is_unset_export_issue(issue);
 
     godot::PackedStringArray parts;
     godot::Array keys = issue.keys();
@@ -79,6 +337,14 @@ godot::String issue_extra_text(const godot::Dictionary &issue) {
             if (key == skip_key) {
                 skip = true;
                 break;
+            }
+        }
+        if (!skip && is_unset_export) {
+            for (const char *skip_key : unset_export_skip_keys) {
+                if (key == skip_key) {
+                    skip = true;
+                    break;
+                }
             }
         }
         if (!skip) {
@@ -110,7 +376,8 @@ godot::String issue_bullet(const godot::Dictionary &issue) {
 }
 
 godot::Array issues_for_severity(const godot::Dictionary &scene,
-                                 const godot::String &severity) {
+                                 const godot::String &severity,
+                                 bool include_unset_exports) {
     godot::Array out;
     godot::Array issues = scene.get("issues", godot::Array());
     for (int i = 0; i < issues.size(); i++) {
@@ -118,6 +385,9 @@ godot::Array issues_for_severity(const godot::Dictionary &scene,
             continue;
         }
         godot::Dictionary issue = issues[i];
+        if (!include_unset_exports && is_unset_export_issue(issue)) {
+            continue;
+        }
         if (godot::String(issue.get("severity", "")) == severity) {
             out.append(issue);
         }
@@ -397,6 +667,14 @@ godot::Dictionary format_validate_scene(const godot::Dictionary &raw_result) {
         per_scene_budget = 1;
     }
 
+    godot::Dictionary scene_unset_export_counts;
+    godot::String unset_export_section =
+        global_unset_export_section(scenes, scene_unset_export_counts);
+    bool summarized_unset_exports = !unset_export_section.is_empty();
+    if (summarized_unset_exports) {
+        sections.append(unset_export_section);
+    }
+
     for (int i = 0; i < scenes.size(); i++) {
         if (scenes[i].get_type() != godot::Variant::DICTIONARY) {
             continue;
@@ -448,11 +726,14 @@ godot::Dictionary format_validate_scene(const godot::Dictionary &raw_result) {
             detail_budget = 1;
         }
 
-        int shown = 0;
+        int shown = summarized_unset_exports
+            ? static_cast<int>(scene_unset_export_counts.get(scene_label(scene, i), 0))
+            : 0;
         for (int severity_index = 0; severity_index < 3; severity_index++) {
             godot::String severity = severity_index == 0 ? "error" :
                 (severity_index == 1 ? "warning" : "info");
-            godot::Array issues = issues_for_severity(scene, severity);
+            godot::Array issues =
+                issues_for_severity(scene, severity, !summarized_unset_exports);
             if (issues.is_empty()) {
                 continue;
             }

--- a/fennara-cpp/src/tools/validate_scene/script_checks.cpp
+++ b/fennara-cpp/src/tools/validate_scene/script_checks.cpp
@@ -133,7 +133,6 @@ void s_record_unset_export_group(
         group["properties"] = godot::Array();
         group["property_seen"] = godot::Dictionary();
         group["node_count"] = 0;
-        group["samples"] = godot::Array();
         group["sample_seen"] = godot::Dictionary();
         group["instance_scenes"] = godot::Array();
         group["instance_scene_seen"] = godot::Dictionary();
@@ -154,16 +153,11 @@ void s_record_unset_export_group(
         group["property_seen"] = property_seen;
     }
 
-    godot::Array samples = group.get("samples", godot::Array());
     godot::Dictionary sample_seen = group.get("sample_seen", godot::Dictionary());
     int node_count = static_cast<int>(group.get("node_count", 0));
     if (!sample_seen.has(node_path)) {
         sample_seen[node_path] = true;
         group["node_count"] = node_count + 1;
-        if (samples.size() < 5) {
-            samples.append(node_path);
-            group["samples"] = samples;
-        }
         group["sample_seen"] = sample_seen;
     }
 
@@ -292,7 +286,6 @@ void FennaraValidateSceneTool::_check_unset_export_vars(
         godot::String script_path = group.get("script_path", "");
         godot::Array properties = group.get("properties", godot::Array());
         int node_count = static_cast<int>(group.get("node_count", 0));
-        godot::Array samples = group.get("samples", godot::Array());
         godot::Array instance_scenes =
             group.get("instance_scenes", godot::Array());
 
@@ -320,24 +313,16 @@ void FennaraValidateSceneTool::_check_unset_export_vars(
                 instance_scenes.size());
         }
         message += ". Ignore this note if these references are intentionally optional or assigned at runtime";
-        if (!samples.is_empty()) {
-            message += ". Samples: " + s_join_samples(samples);
-            message += s_omitted_label(node_count, samples.size());
-        }
 
         godot::Dictionary extra;
         extra["properties"] = properties;
         extra["script_path"] = script_path;
         extra["node_count"] = node_count;
-        extra["samples"] = samples;
         if (!instance_scenes.is_empty()) {
             extra["instance_scenes"] = instance_scenes;
         }
 
-        godot::String node_path =
-            node_count > 1 ? godot::String("multiple nodes")
-                            : godot::String(samples.is_empty() ? "" : samples[0]);
-        _add_issue(issues, node_path, "unset_export_var", severity, message, extra);
+        _add_issue(issues, "", "unset_export_var", severity, message, extra);
     }
 }
 

--- a/fennara-cpp/src/tools/validate_scene/script_checks.cpp
+++ b/fennara-cpp/src/tools/validate_scene/script_checks.cpp
@@ -171,6 +171,11 @@ void s_record_unset_export_group(
         group.get("instance_scenes", godot::Array());
     godot::Dictionary instance_scene_seen =
         group.get("instance_scene_seen", godot::Dictionary());
+    if (!instance_scene_path.is_empty() &&
+        !instance_scene_seen.has(instance_scene_path)) {
+        int total = static_cast<int>(group.get("instance_scene_total", 0));
+        group["instance_scene_total"] = total + 1;
+    }
     s_append_unique_string(
         instance_scenes, instance_scene_seen, instance_scene_path, 5);
     group["instance_scenes"] = instance_scenes;

--- a/fennara-cpp/src/tools/validate_scene/script_checks.cpp
+++ b/fennara-cpp/src/tools/validate_scene/script_checks.cpp
@@ -76,52 +76,121 @@ godot::Dictionary s_scene_props_for_node(
     return scene_props;
 }
 
-bool s_is_identifier_char(char32_t c) {
-    return c == '_' ||
-           (c >= '0' && c <= '9') ||
-           (c >= 'A' && c <= 'Z') ||
-           (c >= 'a' && c <= 'z');
+godot::String s_join_samples(const godot::Array &samples) {
+    godot::PackedStringArray parts;
+    for (int i = 0; i < samples.size(); i++) {
+        parts.append(samples[i]);
+    }
+    return godot::String(", ").join(parts);
 }
 
-int s_count_identifier_mentions(const godot::String &text,
-                                const godot::String &identifier) {
-    if (text.is_empty() || identifier.is_empty()) {
-        return 0;
-    }
-
-    int count = 0;
-    int pos = 0;
-    while (true) {
-        pos = text.find(identifier, pos);
-        if (pos < 0) {
-            break;
+godot::String s_format_unset_properties(const godot::Array &properties) {
+    godot::PackedStringArray parts;
+    for (int i = 0; i < properties.size(); i++) {
+        if (properties[i].get_type() != godot::Variant::DICTIONARY) {
+            continue;
         }
-
-        int after_pos = pos + identifier.length();
-        bool has_identifier_before =
-            pos > 0 && s_is_identifier_char(text[pos - 1]);
-        bool has_identifier_after =
-            after_pos < text.length() && s_is_identifier_char(text[after_pos]);
-        if (!has_identifier_before && !has_identifier_after) {
-            count++;
+        godot::Dictionary prop = properties[i];
+        godot::String name = prop.get("name", "");
+        godot::String type = prop.get("type", "");
+        if (name.is_empty()) {
+            continue;
         }
-        pos = after_pos;
+        parts.append(type.is_empty() ? name : name + " (" + type + ")");
     }
-    return count;
+    return godot::String(", ").join(parts);
 }
 
-bool s_script_references_property_beyond_export(
+void s_append_unique_string(
+    godot::Array &values,
+    godot::Dictionary &seen,
+    const godot::String &value,
+    int limit) {
+    if (value.is_empty() || seen.has(value)) {
+        return;
+    }
+    seen[value] = true;
+    if (limit <= 0 || values.size() < limit) {
+        values.append(value);
+    }
+}
+
+void s_record_unset_export_group(
+    godot::Dictionary &groups,
+    godot::Array &group_order,
+    const godot::String &node_path,
     const godot::String &script_path,
-    const godot::String &property_name) {
-    godot::Ref<godot::FileAccess> file =
-        godot::FileAccess::open(script_path, godot::FileAccess::READ);
-    if (!file.is_valid()) {
-        return false;
+    const godot::String &instance_scene_path,
+    const godot::String &prop_name,
+    const godot::String &type_label) {
+    godot::String key = script_path;
+
+    godot::Dictionary group;
+    if (groups.has(key)) {
+        group = groups[key];
+    } else {
+        group["script_path"] = script_path;
+        group["properties"] = godot::Array();
+        group["property_seen"] = godot::Dictionary();
+        group["node_count"] = 0;
+        group["samples"] = godot::Array();
+        group["sample_seen"] = godot::Dictionary();
+        group["instance_scenes"] = godot::Array();
+        group["instance_scene_seen"] = godot::Dictionary();
+        group_order.append(key);
     }
 
-    // Cheap signal: one occurrence is normally the export declaration; more
-    // occurrences mean the script likely reads or writes the property.
-    return s_count_identifier_mentions(file->get_as_text(), property_name) > 1;
+    godot::String prop_key = prop_name + godot::String("\n") + type_label;
+    godot::Dictionary property_seen =
+        group.get("property_seen", godot::Dictionary());
+    if (!property_seen.has(prop_key)) {
+        property_seen[prop_key] = true;
+        godot::Dictionary prop;
+        prop["name"] = prop_name;
+        prop["type"] = type_label;
+        godot::Array properties = group.get("properties", godot::Array());
+        properties.append(prop);
+        group["properties"] = properties;
+        group["property_seen"] = property_seen;
+    }
+
+    godot::Array samples = group.get("samples", godot::Array());
+    godot::Dictionary sample_seen = group.get("sample_seen", godot::Dictionary());
+    int node_count = static_cast<int>(group.get("node_count", 0));
+    if (!sample_seen.has(node_path)) {
+        sample_seen[node_path] = true;
+        group["node_count"] = node_count + 1;
+        if (samples.size() < 5) {
+            samples.append(node_path);
+            group["samples"] = samples;
+        }
+        group["sample_seen"] = sample_seen;
+    }
+
+    godot::Array instance_scenes =
+        group.get("instance_scenes", godot::Array());
+    godot::Dictionary instance_scene_seen =
+        group.get("instance_scene_seen", godot::Dictionary());
+    s_append_unique_string(
+        instance_scenes, instance_scene_seen, instance_scene_path, 5);
+    group["instance_scenes"] = instance_scenes;
+    group["instance_scene_seen"] = instance_scene_seen;
+
+    groups[key] = group;
+}
+
+godot::String s_count_label(int count, const godot::String &singular,
+                            const godot::String &plural) {
+    return godot::String::num_int64(count) + " " +
+           (count == 1 ? singular : plural);
+}
+
+godot::String s_omitted_label(int total, int shown) {
+    int omitted = total - shown;
+    if (omitted <= 0) {
+        return "";
+    }
+    return ", " + s_count_label(omitted, "omitted", "omitted");
 }
 
 } // namespace
@@ -154,6 +223,9 @@ void FennaraValidateSceneTool::_check_script_extends_mismatch(
 void FennaraValidateSceneTool::_check_unset_export_vars(
     const godot::Ref<godot::SceneState> &state, godot::Array &issues) {
     int count = state->get_node_count();
+    godot::Dictionary groups;
+    godot::Array group_order;
+
     for (int i = 0; i < count; i++) {
         godot::String script_path = _get_script_path(state, i);
         godot::String instance_scene_path;
@@ -198,41 +270,69 @@ void FennaraValidateSceneTool::_check_unset_export_vars(
             godot::String type_label =
                 hint_string.is_empty() ? "Object" : hint_string;
 
-            godot::Dictionary extra;
-            extra["property"] = prop_name;
-            extra["type"] = type_label;
-            if (!instance_scene_path.is_empty()) {
-                extra["instance_scene"] = instance_scene_path;
-            }
-
-            bool referenced_in_script =
-                s_script_references_property_beyond_export(
-                    script_path, prop_name);
-            extra["referenced_in_script"] = referenced_in_script;
-
-            godot::String message;
-            godot::String severity = referenced_in_script ? "warning" : "info";
-            if (referenced_in_script) {
-                message = godot::String("Unset Resource export var '") +
-                    prop_name + "' (type: " + type_label + ")";
-            } else {
-                message = godot::String("Exported Resource var '") +
-                    prop_name + "' (type: " + type_label + ") is unset";
-            }
-            if (!instance_scene_path.is_empty()) {
-                message += " inherited from instance " + instance_scene_path;
-            }
-            if (referenced_in_script) {
-                message +=
-                    " and referenced by the script; verify it is optional/null-guarded or assign it in the scene";
-            } else {
-                message += ". This is OK if optional or assigned at runtime";
-            }
-            _add_issue(issues, _build_node_path(state, i),
-                       "unset_export_var", severity,
-                       message,
-                       extra);
+            s_record_unset_export_group(
+                groups,
+                group_order,
+                _build_node_path(state, i),
+                script_path,
+                instance_scene_path,
+                prop_name,
+                type_label);
         }
+    }
+
+    for (int i = 0; i < group_order.size(); i++) {
+        godot::String key = group_order[i];
+        godot::Dictionary group = groups[key];
+        godot::String script_path = group.get("script_path", "");
+        godot::Array properties = group.get("properties", godot::Array());
+        int node_count = static_cast<int>(group.get("node_count", 0));
+        godot::Array samples = group.get("samples", godot::Array());
+        godot::Array instance_scenes =
+            group.get("instance_scenes", godot::Array());
+
+        godot::String severity = "info";
+        godot::String message =
+            godot::String("Script ") +
+            (script_path.is_empty() ? godot::String("<unknown>") : script_path) +
+            " has " +
+            s_count_label(properties.size(), "unset exported Object/Resource var",
+                          "unset exported Object/Resource vars");
+        godot::String prop_text = s_format_unset_properties(properties);
+        if (!prop_text.is_empty()) {
+            message += ": " + prop_text;
+        }
+        message += " on " + s_count_label(node_count, "node", "nodes");
+        if (!script_path.is_empty()) {
+            message += " using this script";
+        }
+        if (!instance_scenes.is_empty()) {
+            message += ". Instanced scene samples: " +
+                       s_join_samples(instance_scenes);
+            message += s_omitted_label(
+                static_cast<int>(group.get("instance_scene_total",
+                                           instance_scenes.size())),
+                instance_scenes.size());
+        }
+        message += ". Ignore this note if these references are intentionally optional or assigned at runtime";
+        if (!samples.is_empty()) {
+            message += ". Samples: " + s_join_samples(samples);
+            message += s_omitted_label(node_count, samples.size());
+        }
+
+        godot::Dictionary extra;
+        extra["properties"] = properties;
+        extra["script_path"] = script_path;
+        extra["node_count"] = node_count;
+        extra["samples"] = samples;
+        if (!instance_scenes.is_empty()) {
+            extra["instance_scenes"] = instance_scenes;
+        }
+
+        godot::String node_path =
+            node_count > 1 ? godot::String("multiple nodes")
+                            : godot::String(samples.is_empty() ? "" : samples[0]);
+        _add_issue(issues, node_path, "unset_export_var", severity, message, extra);
     }
 }
 

--- a/local/prompts/plugin_chat_system.md
+++ b/local/prompts/plugin_chat_system.md
@@ -72,7 +72,7 @@ Scene editing workflow:
 - For subscene/PackedScene instances, use `ctx.instance_scene(parent, "res://path.tscn", "DesiredName")`; do not manually instantiate and recursively own children because that can flatten instances.
 - For inherited scenes, prefer narrow overrides and avoid root replacement or broad inherited subtree rewrites.
 - After scene edits, validate with `validate_scene` and use `screenshot_scene` when visual layout or framing matters.
-- In `validate_scene`, declaration-only unset exported Resource/Object vars are notes, not bugs. Only treat referenced unset exports as warnings to verify/null-guard or assign.
+- In `validate_scene`, unset exported Resource/Object vars are notes, not bugs. Repeated unset exports are grouped once per script with unique variable names and capped node samples per scene. Ignore the note if those references are intentionally optional or assigned at runtime; do not create placeholder resources or wire arbitrary values solely because the note exists.
 
 Runtime sessions and playtesting:
 - Use `runtime_session` to start one scene for one runtime inspection/control loop. `start` runs scene-execution gates before opening the scene. If blocked, fix the preflight issue first.

--- a/local/prompts/plugin_chat_system.md
+++ b/local/prompts/plugin_chat_system.md
@@ -72,7 +72,7 @@ Scene editing workflow:
 - For subscene/PackedScene instances, use `ctx.instance_scene(parent, "res://path.tscn", "DesiredName")`; do not manually instantiate and recursively own children because that can flatten instances.
 - For inherited scenes, prefer narrow overrides and avoid root replacement or broad inherited subtree rewrites.
 - After scene edits, validate with `validate_scene` and use `screenshot_scene` when visual layout or framing matters.
-- In `validate_scene`, unset exported Resource/Object vars are notes, not bugs. Repeated unset exports are grouped once per script with unique variable names and capped node samples per scene. Ignore the note if those references are intentionally optional or assigned at runtime; do not create placeholder resources or wire arbitrary values solely because the note exists.
+- In `validate_scene`, unset exported Resource/Object vars are notes, not bugs. Repeated unset exports are grouped once per script with unique variable names and capped affected scene counts. Ignore the note if those references are intentionally optional or assigned at runtime; do not create placeholder resources or wire arbitrary values solely because the note exists.
 
 Runtime sessions and playtesting:
 - Use `runtime_session` to start one scene for one runtime inspection/control loop. `start` runs scene-execution gates before opening the scene. If blocked, fix the preflight issue first.

--- a/local/schemas/tools/validate_scene.json
+++ b/local/schemas/tools/validate_scene.json
@@ -3,7 +3,7 @@
     "description_lines": [
       "Validate one or more scene files for common issues.",
       "Structural checks include missing scripts/resources, script extends mismatch, invalid NodePath properties, invalid script $Node/get_node() references, duplicate sibling names, cyclic scene dependencies, and unset exported Resource/Object vars.",
-      "Declaration-only unset exports are notes because they may be optional or assigned at runtime; unset exports referenced elsewhere in the script are warnings to verify/null-guard or assign.",
+      "Unset exported Resource/Object vars are grouped once per script with unique var names and capped node samples per scene; ignore the note if those references are intentionally optional or assigned at runtime.",
       "For scenes with no structural errors, Fennara also runs each scene headlessly for 3 seconds through the local daemon using up to 3 memory-throttled workers.",
       "The result includes each scene runtime status, crash/error/warning flags, compacted runtime output, and paths to the full result JSON and raw runtime logs.",
       "The daemon intentionally stops the process after the validation window, so a non-zero exit code from that stop is not by itself a scene failure; use crash/error/warning flags and logs as the health signal.",

--- a/local/schemas/tools/validate_scene.json
+++ b/local/schemas/tools/validate_scene.json
@@ -3,7 +3,7 @@
     "description_lines": [
       "Validate one or more scene files for common issues.",
       "Structural checks include missing scripts/resources, script extends mismatch, invalid NodePath properties, invalid script $Node/get_node() references, duplicate sibling names, cyclic scene dependencies, and unset exported Resource/Object vars.",
-      "Unset exported Resource/Object vars are grouped once per script with unique var names and capped node samples per scene; ignore the note if those references are intentionally optional or assigned at runtime.",
+      "Unset exported Resource/Object vars are grouped once per script with unique var names and capped affected scene counts; ignore the note if those references are intentionally optional or assigned at runtime.",
       "For scenes with no structural errors, Fennara also runs each scene headlessly for 3 seconds through the local daemon using up to 3 memory-throttled workers.",
       "The result includes each scene runtime status, crash/error/warning flags, compacted runtime output, and paths to the full result JSON and raw runtime logs.",
       "The daemon intentionally stops the process after the validation window, so a non-zero exit code from that stop is not by itself a scene failure; use crash/error/warning flags and logs as the health signal.",

--- a/local/templates/fennara-guidelines.md
+++ b/local/templates/fennara-guidelines.md
@@ -367,7 +367,7 @@ Use `validate_scene` when:
 
 `validate_scene` accepts 1-10 scene paths. It runs structural scene checks first. For scenes with zero structural errors, it also runs each scene headlessly for exactly 3 seconds through the local daemon using 3 memory-throttled workers, then returns each scene's runtime status, crash/error/warning flags, compacted runtime output inline, and paths to the full result JSON and raw runtime logs. Fennara intentionally stops the process after the validation window, so a non-zero exit code from that stop is not by itself a scene failure. It does not open scenes in the editor or scrape the editor Output panel.
 
-Unset exported Resource/Object variables in `validate_scene` are not all bugs. They are structural notes because they may be optional or assigned at runtime. Repeated unset exports are grouped once per script with unique variable names and capped node samples per scene. Ignore the note if those references are intentionally optional or assigned at runtime; do not create placeholder resources or wire arbitrary values solely because the note exists.
+Unset exported Resource/Object variables in `validate_scene` are not all bugs. They are structural notes because they may be optional or assigned at runtime. Repeated unset exports are grouped once per script with unique variable names and capped affected scene counts. Ignore the note if those references are intentionally optional or assigned at runtime; do not create placeholder resources or wire arbitrary values solely because the note exists.
 
 If `run_scene_edit_script` edited a scene/resource, it already ran scene validation after the edit. You may still run `validate_scene` separately for additional scenes or if the task requires broader coverage.
 

--- a/local/templates/fennara-guidelines.md
+++ b/local/templates/fennara-guidelines.md
@@ -367,7 +367,7 @@ Use `validate_scene` when:
 
 `validate_scene` accepts 1-10 scene paths. It runs structural scene checks first. For scenes with zero structural errors, it also runs each scene headlessly for exactly 3 seconds through the local daemon using 3 memory-throttled workers, then returns each scene's runtime status, crash/error/warning flags, compacted runtime output inline, and paths to the full result JSON and raw runtime logs. Fennara intentionally stops the process after the validation window, so a non-zero exit code from that stop is not by itself a scene failure. It does not open scenes in the editor or scrape the editor Output panel.
 
-Unset exported Resource/Object variables in `validate_scene` are not all bugs. Declaration-only unset exports are structural notes and may be optional or assigned at runtime. Unset exports referenced elsewhere in the script are warnings to verify/null-guard or assign. Do not create placeholder resources or wire arbitrary values solely because an unset export note exists.
+Unset exported Resource/Object variables in `validate_scene` are not all bugs. They are structural notes because they may be optional or assigned at runtime. Repeated unset exports are grouped once per script with unique variable names and capped node samples per scene. Ignore the note if those references are intentionally optional or assigned at runtime; do not create placeholder resources or wire arbitrary values solely because the note exists.
 
 If `run_scene_edit_script` edited a scene/resource, it already ran scene validation after the edit. You may still run `validate_scene` separately for additional scenes or if the task requires broader coverage.
 


### PR DESCRIPTION
## Summary

- Groups repeated `validate_scene` unset exported Object/Resource notes once per script instead of once per node/property pair.
- Lists unique unset variables in one compact note and caps affected node samples per scene with omitted counts.
- Keeps unset exported Object/Resource findings as structural notes with clearer wording for optional/runtime-assigned references.
- Updates tool docs, schema guidance, generated guidelines, and built-in chat prompt to match the new behavior.

## Root cause

Scenes using addon scripts with many optional exported Object/Resource references could produce hundreds of repeated `unset_export_var` lines. The detector was useful, but the receipt shape made one optional script look like many separate problems.

## Validation

- Ran `scons platform=windows target=editor` from `fennara-cpp`.
- Parsed `local/schemas/tools/validate_scene.json` with Node.
- Ran `git diff --check`.
- Ran a fresh review-agent pass and fixed the stale built-in prompt wording it found.

Fixes #60

Assisted by Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unset exported Resource/Object references are now reported in a clearer consolidated “notes” style, grouped once per script with unique variable names and capped node examples (including omission counts).
  * Validation output now emphasizes informational behavior and keeps summaries shorter and easier to scan.
* **Bug Fixes**
  * Reduced duplicate and fragmented reporting of the same unset export across scenes and scripts.
  * Improved messaging so intentional runtime assignment or optional references aren’t treated as issues.
* **Documentation**
  * Updated validate-scene guidance and schema/tool docs to match the new reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->