### PR TITLE
fix: keep runtime helper safe in exports

### DIFF
--- a/fennara-cpp/src/ui/fennara_plugin.cpp
+++ b/fennara-cpp/src/ui/fennara_plugin.cpp
@@ -181,8 +181,17 @@ void FennaraPlugin::_ensure_export_presets_exclude_fennara() {
         return;
     }
 
-    static const char *required_filters[] = {
+    static const char *obsolete_filters[] = {
         "addons/fennara/*",
+    };
+    static const char *required_filters[] = {
+        "addons/fennara/ai/*",
+        "addons/fennara/bin/*",
+        "addons/fennara/dist/*",
+        "addons/fennara/*.gdextension",
+        "addons/fennara/*.gdextension.uid",
+        "addons/fennara/*.md",
+        "addons/fennara/VERSION",
         ".fennara/*",
     };
 
@@ -198,6 +207,14 @@ void FennaraPlugin::_ensure_export_presets_exclude_fennara() {
         godot::PackedStringArray filters =
             _split_export_filter(config->get_value(section, "exclude_filter", ""));
         bool section_changed = false;
+        for (const char *filter : obsolete_filters) {
+            godot::String pattern(filter);
+            int existing_index = filters.find(pattern);
+            if (existing_index >= 0) {
+                filters.remove_at(existing_index);
+                section_changed = true;
+            }
+        }
         for (const char *filter : required_filters) {
             godot::String pattern(filter);
             if (!filters.has(pattern)) {

--- a/godot_demo/addons/fennara/runtime/game_capture_helper.gd
+++ b/godot_demo/addons/fennara/runtime/game_capture_helper.gd
@@ -27,14 +27,17 @@ func _safe_file_component(value: String, fallback: String) -> String:
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
-	_ensure_runtime_helpers()
 	var runtime_spec := OS.get_environment(RUNTIME_SPEC_ENV)
-	if not runtime_spec.strip_edges().is_empty():
-		var request := _read_json_file(runtime_spec)
-		if str(request.get("mode", "")) == "runtime_session":
-			_run_env_runtime_session.call_deferred(request)
-		else:
-			_check_runner.call_deferred("run_env_runtime_check", runtime_spec)
+	if runtime_spec.strip_edges().is_empty():
+		queue_free()
+		return
+
+	_ensure_runtime_helpers()
+	var request := _read_json_file(runtime_spec)
+	if str(request.get("mode", "")) == "runtime_session":
+		_run_env_runtime_session.call_deferred(request)
+	else:
+		_check_runner.call_deferred("run_env_runtime_check", runtime_spec)
 
 func _run_runtime_script(data: Array) -> void:
 	_ensure_runtime_helpers()

--- a/runtime/game_capture_helper.gd
+++ b/runtime/game_capture_helper.gd
@@ -27,14 +27,17 @@ func _safe_file_component(value: String, fallback: String) -> String:
 func _ready() -> void:
 	if Engine.is_editor_hint():
 		return
-	_ensure_runtime_helpers()
 	var runtime_spec := OS.get_environment(RUNTIME_SPEC_ENV)
-	if not runtime_spec.strip_edges().is_empty():
-		var request := _read_json_file(runtime_spec)
-		if str(request.get("mode", "")) == "runtime_session":
-			_run_env_runtime_session.call_deferred(request)
-		else:
-			_check_runner.call_deferred("run_env_runtime_check", runtime_spec)
+	if runtime_spec.strip_edges().is_empty():
+		queue_free()
+		return
+
+	_ensure_runtime_helpers()
+	var request := _read_json_file(runtime_spec)
+	if str(request.get("mode", "")) == "runtime_session":
+		_run_env_runtime_session.call_deferred(request)
+	else:
+		_check_runner.call_deferred("run_env_runtime_check", runtime_spec)
 
 func _run_runtime_script(data: Array) -> void:
 	_ensure_runtime_helpers()


### PR DESCRIPTION
## Summary

Fixes #69.

This PR prevents exported games from entering the broken state where `project.godot` still contains Fennara's runtime-helper autoload, but export filters remove the script it points at.

## What Changed

- Updates Fennara's export preset guard to remove the old broad `addons/fennara/*` filter.
- Adds targeted excludes for editor/native/UI/addon metadata files while keeping `addons/fennara/runtime/*` exportable for the autoload dependency.
- Makes `_fennara_game_capture` immediately free itself when `FENNARA_RT_SPEC` is absent, so normal exported games do not run Fennara runtime tooling.
- Syncs the generated addon runtime helper copy.

## Validation

- `scons platform=windows target=editor` from `fennara-cpp/`
- `git diff --check`
- `node scripts\sync-runtime.mjs`
- Headless Godot startup with a project containing `_fennara_game_capture` and no `FENNARA_RT_SPEC`
- Fresh bounded review subagent reported no findings on the final diff

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export preset cleanup so only the needed files and folders are excluded, reducing the chance of shipping unwanted project assets.
  * Runtime startup now exits cleanly when the required environment setting is missing, preventing unnecessary node activity.
  * When the environment setting is present, startup checks and session handling continue as expected with clearer initialization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->