### PR TITLE
fix: polish update diagnostics and packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
+* text=auto eol=lf
+
 *.dll binary
 *.exe binary
 *.lib binary

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Fennara Godot AI
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Fennara-5865F2?logo=discord&logoColor=white)](https://discord.com/invite/3fF4ft9PTk)
+[![Demos](https://img.shields.io/badge/Demos-See%20all-red?logo=youtube&logoColor=white)](docs/demos.md)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 
 Used by Godot developers and teams, including [Somni Game Studios](https://somnigamestudios.com/).
@@ -17,8 +18,10 @@ Agents can inspect scenes, check scripts, capture screenshots, read runtime erro
       </a>
     </td>
     <td>
-      <strong>Watch: Comparing Fennara with other Godot MCPs</strong><br />
-      See how Fennara's Godot feedback loop compares with command-only MCP workflows.
+      <strong>Watch the featured demo</strong><br />
+      Comparing Fennara with other Godot MCPs.<br />
+      <a href="https://www.youtube.com/watch?v=2vSYP7GyA5U">Play this video</a><br />
+      <a href="docs/demos.md">Browse all demo videos</a>
     </td>
   </tr>
 </table>
@@ -83,6 +86,18 @@ Run this from the Godot project folder:
 cd path/to/your-godot-project
 fennara install
 ```
+
+You can also run install and update commands from a separate tooling folder by
+passing the Godot project explicitly:
+
+```bash
+fennara install --project path/to/your-godot-project
+fennara update --project path/to/your-godot-project
+```
+
+Your MCP app can point at the global Fennara launcher from anywhere. It does not
+need config files inside the Godot project. Fennara uses the Godot project you
+open in the editor.
 
 For a C# project:
 
@@ -166,6 +181,10 @@ fennara update
 ```
 
 `fennara update` reads the release manifest, updates the installed CLI when a newer release requires it, then refreshes the project addon, local runtime package, generated Fennara guidance files, and any release-managed shared webview runtime needed by the current platform. On Windows/macOS it also checks the platform webview prerequisite and warns if the built-in chat dock may not start. Rerun the install script only if CLI self-update is not available for the selected release or install location.
+
+When an update has to replace the running CLI before continuing, Fennara prints
+the updater log path so CI and agent runs can inspect the resumed project-update
+output.
 
 ## Tools
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -56,6 +56,18 @@ cd path/to/your-godot-project
 fennara install
 ```
 
+If you keep MCP or agent config in a separate tooling repo, pass the Godot
+project path explicitly instead:
+
+```bash
+fennara install --project path/to/your-godot-project
+fennara update --project path/to/your-godot-project
+```
+
+Your MCP app can point at the global Fennara launcher from anywhere. It does not
+need config files inside the Godot project. `--project` tells Fennara which
+Godot project to install or update.
+
 For a C# Godot project:
 
 ```bash
@@ -207,6 +219,10 @@ assets needed by your platform, and the generated Fennara guidance files.
 
 If an MCP app is currently running a Fennara launcher, `fennara update` may keep that launcher and continue. That is okay. The versioned runtime package is still updated.
 
+When an update has to replace the running CLI before continuing, Fennara prints
+the updater log path. Use that log to inspect the resumed project-update output
+in CI or agent-driven runs.
+
 ## Troubleshooting
 
 ### `fennara` Is Not Found
@@ -216,6 +232,10 @@ Open a new terminal and try again:
 ```bash
 fennara doctor
 ```
+
+`doctor` also reports when a running Fennara daemon or MCP runtime appears to be
+older than the version selected by `current.json`; restart Godot or the MCP app
+when it prints that warning.
 
 If it still fails, add the Fennara `bin` directory to PATH manually.
 

--- a/local/Cargo.lock
+++ b/local/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "json5",
  "serde_json",
  "sha2",
+ "sysinfo",
  "toml_edit",
  "ureq",
  "zip",

--- a/local/crates/fennara-cli/Cargo.toml
+++ b/local/crates/fennara-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 json5 = "0.4"
 serde_json = "1.0"
 sha2 = "0.10"
+sysinfo = "0.30"
 toml_edit = "0.22"
 ureq = { version = "2.12", features = ["json"] }
 zip = { version = "2.2", default-features = false, features = ["deflate"] }

--- a/local/crates/fennara-cli/src/doctor.rs
+++ b/local/crates/fennara-cli/src/doctor.rs
@@ -191,14 +191,27 @@ fn report_runtime_process(system: &System, spec: &RuntimeSpec, expected: Option<
             current_count += 1;
             first_current_path.get_or_insert(exe_display);
         } else if let Some(expected) = expected {
-            println!(
-                "warning: running {} may be stale: pid {} at {}",
-                spec.label,
-                process.pid(),
-                exe_display
-            );
-            println!("warning: expected {}", display_path(expected));
-            println!("warning: {}", spec.restart_hint);
+            if expected_for_compare.is_some() {
+                println!(
+                    "warning: running {} may be stale: pid {} at {}",
+                    spec.label,
+                    process.pid(),
+                    exe_display
+                );
+                println!("warning: expected {}", display_path(expected));
+                println!("warning: {}", spec.restart_hint);
+            } else {
+                println!(
+                    "warning: running {} detected, but expected path from current.json is missing or unreadable: {}",
+                    spec.label,
+                    display_path(expected)
+                );
+                println!(
+                    "warning: cannot compare pid {} at {} until the expected runtime path is available",
+                    process.pid(),
+                    exe_display
+                );
+            }
         } else {
             println!(
                 "warning: running {} detected but {} is missing from current.json: pid {} at {}",

--- a/local/crates/fennara-cli/src/doctor.rs
+++ b/local/crates/fennara-cli/src/doctor.rs
@@ -5,7 +5,15 @@ use crate::app_layout::{
 };
 use crate::webview_prereq;
 use serde_json::Value;
-use std::path::Path;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use sysinfo::System;
+
+const DAEMON_ADDR: &str = "127.0.0.1:41287";
+const DAEMON_HEALTH_TIMEOUT: Duration = Duration::from_millis(500);
 
 pub fn run(args: Vec<&str>) -> Result<(), String> {
     let repair = args.contains(&"--repair");
@@ -41,10 +49,14 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
         &layout.bin_dir.join(binary_name("fennara-daemon")),
     );
 
-    match read_current_manifest(&layout.current_manifest_path) {
-        Ok(Some(manifest)) => report_manifest(&layout.app_dir, &manifest),
+    let current_manifest = read_current_manifest(&layout.current_manifest_path);
+    match &current_manifest {
+        Ok(Some(manifest)) => report_manifest(&layout.app_dir, manifest),
         Ok(None) => println!("current version: not installed yet"),
         Err(error) => println!("current manifest: invalid ({error})"),
+    }
+    if let Ok(Some(manifest)) = &current_manifest {
+        report_running_state(&layout.app_dir, manifest);
     }
 
     println!(
@@ -81,6 +93,210 @@ fn report_manifest(app_dir: &Path, manifest: &Value) {
             let resolved = resolve_manifest_path(app_dir, path);
             report_file(field, &resolved);
         }
+    }
+}
+
+fn report_running_state(app_dir: &Path, manifest: &Value) {
+    let expected_version = manifest
+        .get("version")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+
+    report_running_daemon_version(expected_version);
+    report_running_runtime_processes(app_dir, manifest);
+}
+
+fn report_running_daemon_version(expected_version: &str) {
+    match daemon_health() {
+        Ok(health) => {
+            let running_version = health
+                .get("version")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            if running_version == expected_version {
+                println!("running daemon: version {running_version} (ok)");
+            } else {
+                println!(
+                    "warning: running daemon is version {running_version}, but current.json points at {expected_version}"
+                );
+                println!("warning: restart Godot or the Fennara daemon to use the current runtime");
+            }
+        }
+        Err(error) if error.kind == DaemonHealthErrorKind::NotRunning => {
+            println!("running daemon: not detected");
+        }
+        Err(error) => {
+            println!("running daemon: could not check ({})", error.message);
+        }
+    }
+}
+
+fn report_running_runtime_processes(app_dir: &Path, manifest: &Value) {
+    let specs = [
+        RuntimeSpec {
+            label: "MCP runtime",
+            process_name: binary_name("fennara-mcp-runtime"),
+            manifest_field: "mcp_runtime",
+            restart_hint: "restart the MCP client so it launches the current Fennara runtime",
+        },
+        RuntimeSpec {
+            label: "daemon runtime",
+            process_name: binary_name("fennara-daemon-runtime"),
+            manifest_field: "daemon_runtime",
+            restart_hint: "restart Godot or the Fennara daemon so it uses the current runtime",
+        },
+    ];
+
+    let mut system = System::new_all();
+    system.refresh_processes();
+
+    for spec in specs {
+        let expected = manifest
+            .get(spec.manifest_field)
+            .and_then(Value::as_str)
+            .map(|path| resolve_manifest_path(app_dir, path));
+        report_runtime_process(&system, &spec, expected.as_deref());
+    }
+}
+
+fn report_runtime_process(system: &System, spec: &RuntimeSpec, expected: Option<&Path>) {
+    let expected_for_compare = expected.and_then(canonicalize_for_compare);
+    let mut found = false;
+    let mut current_count = 0usize;
+    let mut first_current_path = None;
+
+    for process in system.processes().values() {
+        let exe = process.exe();
+        let exe_for_compare = exe.and_then(canonicalize_for_compare);
+        let exe_display = exe
+            .map(display_path)
+            .unwrap_or_else(|| "unknown".to_string());
+        let path_matches_expected = expected_for_compare
+            .as_ref()
+            .zip(exe_for_compare.as_ref())
+            .is_some_and(|(expected, exe)| expected == exe);
+        let exe_name_matches = exe
+            .and_then(Path::file_name)
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name == spec.process_name);
+        let process_name_matches = process.name() == spec.process_name;
+
+        if !process_name_matches && !exe_name_matches && !path_matches_expected {
+            continue;
+        }
+
+        found = true;
+
+        if path_matches_expected {
+            current_count += 1;
+            first_current_path.get_or_insert(exe_display);
+        } else if let Some(expected) = expected {
+            println!(
+                "warning: running {} may be stale: pid {} at {}",
+                spec.label,
+                process.pid(),
+                exe_display
+            );
+            println!("warning: expected {}", display_path(expected));
+            println!("warning: {}", spec.restart_hint);
+        } else {
+            println!(
+                "warning: running {} detected but {} is missing from current.json: pid {} at {}",
+                spec.label,
+                spec.manifest_field,
+                process.pid(),
+                exe_display
+            );
+        }
+    }
+
+    if current_count == 1 {
+        println!(
+            "running {}: 1 current process at {} (ok)",
+            spec.label,
+            first_current_path.unwrap_or_else(|| "unknown".to_string())
+        );
+    } else if current_count > 1 {
+        println!(
+            "running {}: {current_count} current processes (ok)",
+            spec.label
+        );
+    }
+
+    if !found {
+        println!("running {}: not detected", spec.label);
+    }
+}
+
+fn canonicalize_for_compare(path: &Path) -> Option<PathBuf> {
+    fs::canonicalize(path).ok()
+}
+
+struct RuntimeSpec {
+    label: &'static str,
+    process_name: String,
+    manifest_field: &'static str,
+    restart_hint: &'static str,
+}
+
+#[derive(Debug)]
+struct DaemonHealthError {
+    kind: DaemonHealthErrorKind,
+    message: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum DaemonHealthErrorKind {
+    NotRunning,
+    Other,
+}
+
+fn daemon_health() -> Result<Value, DaemonHealthError> {
+    let mut stream = TcpStream::connect(DAEMON_ADDR).map_err(|error| DaemonHealthError {
+        kind: if matches!(
+            error.kind(),
+            std::io::ErrorKind::ConnectionRefused | std::io::ErrorKind::TimedOut
+        ) {
+            DaemonHealthErrorKind::NotRunning
+        } else {
+            DaemonHealthErrorKind::Other
+        },
+        message: error.to_string(),
+    })?;
+    stream
+        .set_read_timeout(Some(DAEMON_HEALTH_TIMEOUT))
+        .map_err(other_daemon_health_error)?;
+    stream
+        .set_write_timeout(Some(DAEMON_HEALTH_TIMEOUT))
+        .map_err(other_daemon_health_error)?;
+
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+        .map_err(other_daemon_health_error)?;
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(other_daemon_health_error)?;
+    let (headers, body) = response
+        .split_once("\r\n\r\n")
+        .ok_or_else(|| other_daemon_health_message("invalid daemon HTTP response"))?;
+    if !headers.starts_with("HTTP/1.1 200") && !headers.starts_with("HTTP/1.0 200") {
+        return Err(other_daemon_health_message(
+            "daemon returned non-200 status",
+        ));
+    }
+    serde_json::from_str(body).map_err(|error| other_daemon_health_message(error.to_string()))
+}
+
+fn other_daemon_health_error(error: std::io::Error) -> DaemonHealthError {
+    other_daemon_health_message(error.to_string())
+}
+
+fn other_daemon_health_message(message: impl Into<String>) -> DaemonHealthError {
+    DaemonHealthError {
+        kind: DaemonHealthErrorKind::Other,
+        message: message.into(),
     }
 }
 

--- a/local/crates/fennara-cli/src/self_update.rs
+++ b/local/crates/fennara-cli/src/self_update.rs
@@ -4,9 +4,10 @@ use crate::release_client::{self, DownloadAsset};
 use crate::release_manifest::{ReleaseManifest, compare_versions};
 use std::cmp::Ordering;
 use std::env;
-use std::fs;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -94,6 +95,27 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
     println!("to: {}", selection.version);
     println!("target: {}", display_path(&target));
 
+    let (log_path, mut log_file) = create_log_file(&layout)?;
+    writeln!(log_file, "Fennara CLI self-update").ok();
+    writeln!(log_file, "from: {VERSION}").ok();
+    writeln!(log_file, "to: {}", selection.version).ok();
+    writeln!(log_file, "target: {}", display_path(&target)).ok();
+    if !continuation_args.is_empty() {
+        writeln!(
+            log_file,
+            "continuation: fennara {}",
+            continuation_args.join(" ")
+        )
+        .ok();
+    }
+    writeln!(log_file).ok();
+    log_file.flush().ok();
+
+    println!(
+        "self-update: updater output log: {}",
+        display_path(&log_path)
+    );
+
     let mut command = Command::new(&staged_cli);
     command
         .arg(COMPLETE_COMMAND)
@@ -105,7 +127,12 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
         println!("continuation: fennara {}", continuation_args.join(" "));
         command.arg("--").args(continuation_args);
     }
+    let stderr_log = log_file
+        .try_clone()
+        .map_err(|err| format!("failed to prepare self-update log: {err}"))?;
     command
+        .stdout(Stdio::from(log_file))
+        .stderr(Stdio::from(stderr_log))
         .spawn()
         .map_err(|err| format!("failed to start staged Fennara CLI updater: {err}"))?;
 
@@ -184,17 +211,31 @@ fn canonicalize_for_compare(path: &Path) -> Result<PathBuf, String> {
 }
 
 fn create_stage_dir(layout: &AppLayout) -> Result<PathBuf, String> {
+    let path = layout.cache_dir.join("self-update").join(unique_suffix());
+    fs::create_dir_all(&path)
+        .map_err(|err| format!("failed to create {}: {err}", display_path(&path)))?;
+    Ok(path)
+}
+
+fn create_log_file(layout: &AppLayout) -> Result<(PathBuf, File), String> {
+    let log_dir = layout.logs_dir.join("self-update");
+    fs::create_dir_all(&log_dir)
+        .map_err(|err| format!("failed to create {}: {err}", display_path(&log_dir)))?;
+    let path = log_dir.join(format!("self-update-{}.log", unique_suffix()));
+    let file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&path)
+        .map_err(|err| format!("failed to create {}: {err}", display_path(&path)))?;
+    Ok((path, file))
+}
+
+fn unique_suffix() -> String {
     let millis = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis())
         .unwrap_or(0);
-    let path = layout
-        .cache_dir
-        .join("self-update")
-        .join(format!("{}-{millis}", std::process::id()));
-    fs::create_dir_all(&path)
-        .map_err(|err| format!("failed to create {}: {err}", display_path(&path)))?;
-    Ok(path)
+    format!("{}-{millis}", std::process::id())
 }
 
 fn replace_with_retry(source: &Path, target: &Path) -> Result<(), String> {

--- a/local/crates/fennara-cli/src/self_update.rs
+++ b/local/crates/fennara-cli/src/self_update.rs
@@ -15,6 +15,7 @@ pub const COMPLETE_COMMAND: &str = "__complete-self-update";
 
 const REPLACE_ATTEMPTS: usize = 150;
 const REPLACE_RETRY_DELAY: Duration = Duration::from_millis(200);
+const SELF_UPDATE_RETAINED_ENTRIES: usize = 20;
 
 pub enum StartResult {
     AlreadyCurrent,
@@ -211,7 +212,12 @@ fn canonicalize_for_compare(path: &Path) -> Result<PathBuf, String> {
 }
 
 fn create_stage_dir(layout: &AppLayout) -> Result<PathBuf, String> {
-    let path = layout.cache_dir.join("self-update").join(unique_suffix());
+    let root = layout.cache_dir.join("self-update");
+    fs::create_dir_all(&root)
+        .map_err(|err| format!("failed to create {}: {err}", display_path(&root)))?;
+    prune_self_update_entries(&root, SELF_UPDATE_RETAINED_ENTRIES);
+
+    let path = root.join(unique_suffix());
     fs::create_dir_all(&path)
         .map_err(|err| format!("failed to create {}: {err}", display_path(&path)))?;
     Ok(path)
@@ -221,6 +227,8 @@ fn create_log_file(layout: &AppLayout) -> Result<(PathBuf, File), String> {
     let log_dir = layout.logs_dir.join("self-update");
     fs::create_dir_all(&log_dir)
         .map_err(|err| format!("failed to create {}: {err}", display_path(&log_dir)))?;
+    prune_self_update_entries(&log_dir, SELF_UPDATE_RETAINED_ENTRIES);
+
     let path = log_dir.join(format!("self-update-{}.log", unique_suffix()));
     let file = OpenOptions::new()
         .create_new(true)
@@ -236,6 +244,48 @@ fn unique_suffix() -> String {
         .map(|duration| duration.as_millis())
         .unwrap_or(0);
     format!("{}-{millis}", std::process::id())
+}
+
+fn prune_self_update_entries(root: &Path, keep_latest: usize) {
+    let Ok(root) = root.canonicalize() else {
+        return;
+    };
+    let Ok(entries) = fs::read_dir(&root) else {
+        return;
+    };
+
+    let mut entries: Vec<_> = entries
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path).ok()?;
+            let modified = metadata.modified().unwrap_or(UNIX_EPOCH);
+            Some((path, metadata.file_type(), modified))
+        })
+        .collect();
+    entries.sort_by(|left, right| right.2.cmp(&left.2));
+
+    for (path, file_type, _) in entries.into_iter().skip(keep_latest) {
+        if !path.starts_with(&root) {
+            println!(
+                "warning: skipped self-update cleanup outside {}: {}",
+                display_path(&root),
+                display_path(&path)
+            );
+            continue;
+        }
+        let result = if file_type.is_dir() {
+            fs::remove_dir_all(&path)
+        } else {
+            fs::remove_file(&path)
+        };
+        if let Err(err) = result {
+            println!(
+                "warning: failed to remove old self-update entry {}: {err}",
+                display_path(&path)
+            );
+        }
+    }
 }
 
 fn replace_with_retry(source: &Path, target: &Path) -> Result<(), String> {

--- a/scripts/package-addon-all.mjs
+++ b/scripts/package-addon-all.mjs
@@ -1,4 +1,12 @@
-import { copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -80,9 +88,45 @@ function copyDir(source, target) {
       copyDir(sourcePath, targetPath);
     } else {
       mkdirSync(path.dirname(targetPath), { recursive: true });
-      copyFileSync(sourcePath, targetPath);
+      copyFile(sourcePath, targetPath);
     }
   }
+}
+
+function copyFile(source, target) {
+  if (isTextAsset(source)) {
+    writeFileSync(target, normalizeLineEndings(readFileSync(source, "utf8")));
+  } else {
+    copyFileSync(source, target);
+  }
+}
+
+function isTextAsset(filePath) {
+  const name = path.basename(filePath);
+  if (name === "VERSION" || name === "LICENSE") {
+    return true;
+  }
+  return new Set([
+    ".cfg",
+    ".css",
+    ".gd",
+    ".gdextension",
+    ".gdshader",
+    ".html",
+    ".import",
+    ".js",
+    ".json",
+    ".md",
+    ".svg",
+    ".toml",
+    ".tres",
+    ".tscn",
+    ".txt",
+  ]).has(path.extname(filePath));
+}
+
+function normalizeLineEndings(text) {
+  return text.replace(/\r\n?/g, "\n");
 }
 
 function run(command, commandArgs) {

--- a/scripts/package-addon-all.mjs
+++ b/scripts/package-addon-all.mjs
@@ -5,11 +5,11 @@ import {
   readdirSync,
   rmSync,
   statSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { copyFile } from "./package-text-assets.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const args = parseArgs(process.argv.slice(2));
@@ -91,42 +91,6 @@ function copyDir(source, target) {
       copyFile(sourcePath, targetPath);
     }
   }
-}
-
-function copyFile(source, target) {
-  if (isTextAsset(source)) {
-    writeFileSync(target, normalizeLineEndings(readFileSync(source, "utf8")));
-  } else {
-    copyFileSync(source, target);
-  }
-}
-
-function isTextAsset(filePath) {
-  const name = path.basename(filePath);
-  if (name === "VERSION" || name === "LICENSE") {
-    return true;
-  }
-  return new Set([
-    ".cfg",
-    ".css",
-    ".gd",
-    ".gdextension",
-    ".gdshader",
-    ".html",
-    ".import",
-    ".js",
-    ".json",
-    ".md",
-    ".svg",
-    ".toml",
-    ".tres",
-    ".tscn",
-    ".txt",
-  ]).has(path.extname(filePath));
-}
-
-function normalizeLineEndings(text) {
-  return text.replace(/\r\n?/g, "\n");
 }
 
 function run(command, commandArgs) {

--- a/scripts/package-preview.mjs
+++ b/scripts/package-preview.mjs
@@ -251,7 +251,39 @@ function copyDir(source, target, filter) {
 
 function copyFile(source, target) {
   mkdirSync(path.dirname(target), { recursive: true });
-  copyFileSync(source, target);
+  if (isTextAsset(source)) {
+    writeFileSync(target, normalizeLineEndings(readFileSync(source, "utf8")));
+  } else {
+    copyFileSync(source, target);
+  }
+}
+
+function isTextAsset(filePath) {
+  const name = path.basename(filePath);
+  if (name === "VERSION" || name === "LICENSE") {
+    return true;
+  }
+  return new Set([
+    ".cfg",
+    ".css",
+    ".gd",
+    ".gdextension",
+    ".gdshader",
+    ".html",
+    ".import",
+    ".js",
+    ".json",
+    ".md",
+    ".svg",
+    ".toml",
+    ".tres",
+    ".tscn",
+    ".txt",
+  ]).has(path.extname(filePath));
+}
+
+function normalizeLineEndings(text) {
+  return text.replace(/\r\n?/g, "\n");
 }
 
 function run(command, commandArgs) {

--- a/scripts/package-preview.mjs
+++ b/scripts/package-preview.mjs
@@ -1,5 +1,4 @@
 import {
-  copyFileSync,
   mkdirSync,
   readdirSync,
   readFileSync,
@@ -10,6 +9,7 @@ import {
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { copyFile } from "./package-text-assets.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const args = parseArgs(process.argv.slice(2));
@@ -247,43 +247,6 @@ function copyDir(source, target, filter) {
       copyFile(sourcePath, targetPath);
     }
   }
-}
-
-function copyFile(source, target) {
-  mkdirSync(path.dirname(target), { recursive: true });
-  if (isTextAsset(source)) {
-    writeFileSync(target, normalizeLineEndings(readFileSync(source, "utf8")));
-  } else {
-    copyFileSync(source, target);
-  }
-}
-
-function isTextAsset(filePath) {
-  const name = path.basename(filePath);
-  if (name === "VERSION" || name === "LICENSE") {
-    return true;
-  }
-  return new Set([
-    ".cfg",
-    ".css",
-    ".gd",
-    ".gdextension",
-    ".gdshader",
-    ".html",
-    ".import",
-    ".js",
-    ".json",
-    ".md",
-    ".svg",
-    ".toml",
-    ".tres",
-    ".tscn",
-    ".txt",
-  ]).has(path.extname(filePath));
-}
-
-function normalizeLineEndings(text) {
-  return text.replace(/\r\n?/g, "\n");
 }
 
 function run(command, commandArgs) {

--- a/scripts/package-text-assets.mjs
+++ b/scripts/package-text-assets.mjs
@@ -1,0 +1,41 @@
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const TEXT_EXTENSIONS = new Set([
+  ".cfg",
+  ".css",
+  ".gd",
+  ".gdextension",
+  ".gdshader",
+  ".html",
+  ".import",
+  ".js",
+  ".json",
+  ".md",
+  ".svg",
+  ".toml",
+  ".tres",
+  ".tscn",
+  ".txt",
+]);
+
+export function copyFile(source, target) {
+  mkdirSync(path.dirname(target), { recursive: true });
+  if (isTextAsset(source)) {
+    writeFileSync(target, normalizeLineEndings(readFileSync(source, "utf8")));
+  } else {
+    copyFileSync(source, target);
+  }
+}
+
+export function isTextAsset(filePath) {
+  const name = path.basename(filePath);
+  if (name === "VERSION" || name === "LICENSE") {
+    return true;
+  }
+  return TEXT_EXTENSIONS.has(path.extname(filePath));
+}
+
+export function normalizeLineEndings(text) {
+  return text.replace(/\r\n?/g, "\n");
+}

--- a/scripts/sync-runtime.mjs
+++ b/scripts/sync-runtime.mjs
@@ -1,4 +1,12 @@
-import { copyFileSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,7 +31,19 @@ function copyDir(from, to) {
     if (statSync(sourcePath).isDirectory()) {
       copyDir(sourcePath, targetPath);
     } else {
-      copyFileSync(sourcePath, targetPath);
+      copyFile(sourcePath, targetPath);
     }
   }
+}
+
+function copyFile(sourcePath, targetPath) {
+  if (path.extname(sourcePath) === ".gd") {
+    writeFileSync(targetPath, normalizeLineEndings(readFileSync(sourcePath, "utf8")));
+  } else {
+    copyFileSync(sourcePath, targetPath);
+  }
+}
+
+function normalizeLineEndings(text) {
+  return text.replace(/\r\n?/g, "\n");
 }


### PR DESCRIPTION
## Summary

Addresses the CLI/doctor/release polish from issue #75, excluding `.uid` sidecars by design.

- log self-update continuation output and print the log path before the parent CLI exits
- teach `fennara doctor` to report stale running daemon/MCP runtime processes against `current.json`
- normalize shipped text assets to LF through packaging scripts and `.gitattributes`
- document `--project` split setups in plain language and make the README demo CTA clearer

## Motivation

The issue grouped a few non-blocking papercuts that make update runs harder to inspect and make project repos noisier after addon updates. This keeps update output recoverable for CI/agent runs, gives `doctor` a concrete stale-runtime warning, and makes release text assets deterministic across platforms.

## Validation

- `cargo test -p fennara-cli`
- `node --check scripts/package-preview.mjs; node --check scripts/package-addon-all.mjs; node --check scripts/sync-runtime.mjs`
- `git diff --check --cached`
- fresh bounded Fennara reviewer pass after fixing the first review finding

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced “doctor” diagnostics to verify daemon/MCP reachability and runtime process versions/status.
  * Update runs now create a per-run log file and display its path for easier resume/inspection after CLI replacement.
* **Bug Fixes**
  * Improved packaging and runtime sync handling for text assets by normalizing line endings to Unix format.
* **Documentation**
  * Expanded README and setup guides with demo browsing, `--project` workflow for separate tooling repos, and clearer restart/troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->