### PR TITLE
feat: expose providers in chat settings

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -26,7 +26,7 @@ External MCP apps are different. Claude Code, Claude Desktop, Codex, Cursor, Gem
 
 Cloud providers need your own API key or subscription key. Local providers need the local server running with a model available.
 
-Fennara can store keys from the provider picker in the dock. The key/env names above are the same names Fennara understands if you prefer environment variables. Stored keys live in the daemon's local app data, outside the Godot project.
+Fennara can store keys from the provider picker in the dock. Chat Settings includes an **Open providers** button for discovering the same picker. The key/env names above are the same names Fennara understands if you prefer environment variables. Stored keys live in the daemon's local app data, outside the Godot project.
 
 ## OpenRouter Model Ids
 
@@ -65,11 +65,11 @@ Changing this setting takes effect the next time Godot starts. It only changes w
 
 Inside the Fennara dock:
 
-1. Use `/provider` to open the provider picker.
-2. Add an API key for a cloud provider, or configure a local provider base URL.
-3. Use `/model` to choose a model from the connected provider.
+1. Open **Chat Settings** and click **Open providers**, or use `/provider` directly.
+2. Choose a provider and add the connection details it requires, such as an API key for a cloud provider or a base URL for a local provider.
+3. Use the model picker to choose a model from the connected provider.
 
-You can also open the same provider and model pickers from the dock controls.
+Chat Settings, the dock controls, and `/provider` all open the same registry-backed provider picker. Use `/model` or the dock model control to open the model picker.
 
 See [Built-In Chat Slash Commands](slash-commands.md) for command palette behavior.
 

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -56,6 +56,7 @@
   const chatSurfaceRestartStatus = document.querySelector("[data-chat-surface-restart]");
   const approvalModeControls = document.querySelectorAll("[data-approval-mode]");
   const settingsSavedToast = document.querySelector("[data-settings-saved-toast]");
+  const openSettingsProvidersButton = document.querySelector("[data-open-settings-providers]");
   const modelInput = document.querySelector("[data-model]");
   const modelStatuses = document.querySelectorAll("[data-model-status]");
   const chatSizeStatus = document.querySelector("[data-chat-size]");
@@ -344,6 +345,7 @@
       approvalModeControls,
       settingsSavedToast,
       saveSettingsButton,
+      openProvidersButton: openSettingsProvidersButton,
     },
     callbacks: {
       ensureDaemonConnected,
@@ -356,6 +358,7 @@
       cleanApprovalMode,
       getCurrentChatSurface: () => currentChatSurface,
       getCurrentApprovalMode: () => currentApprovalMode,
+      openProviderPicker,
       sendIfOpen: daemonClient.sendIfOpen,
       connect,
       appendSystem,

--- a/godot_demo/addons/fennara/dist/index.html
+++ b/godot_demo/addons/fennara/dist/index.html
@@ -386,6 +386,15 @@
             <button class="icon-button" type="submit" aria-label="Close settings">x</button>
           </header>
           <fieldset class="settings-group">
+            <legend>Providers</legend>
+            <p class="settings-note">
+              Choose a provider and configure the connection details it requires.
+            </p>
+            <button class="secondary-button settings-provider-button" type="button" data-open-settings-providers>
+              Open providers
+            </button>
+          </fieldset>
+          <fieldset class="settings-group">
             <legend>Tool approvals</legend>
             <label class="settings-radio">
               <input type="radio" name="approval_mode" value="ask" data-approval-mode checked />

--- a/godot_demo/addons/fennara/dist/settings-panel.js
+++ b/godot_demo/addons/fennara/dist/settings-panel.js
@@ -9,6 +9,7 @@
     const approvalModeControls = Array.from(elements.approvalModeControls || []);
     const settingsSavedToast = elements.settingsSavedToast || null;
     const saveSettingsButton = elements.saveSettingsButton || null;
+    const openProvidersButton = elements.openProvidersButton || null;
     const savedNoticeMs = constants.savedNoticeMs || 1800;
     const saveTimeoutMs = constants.saveTimeoutMs || 8000;
     const chatSurfaceBrowser = constants.chatSurfaceBrowser || "browser";
@@ -26,6 +27,7 @@
     const cleanApprovalMode = callbacks.cleanApprovalMode || ((mode) => mode === approvalModeFullAccess ? approvalModeFullAccess : approvalModeAsk);
     const getCurrentChatSurface = callbacks.getCurrentChatSurface || (() => chatSurfaceEmbedded);
     const getCurrentApprovalMode = callbacks.getCurrentApprovalMode || (() => approvalModeAsk);
+    const openProviderPicker = callbacks.openProviderPicker || function () {};
     const buildSavePayload = callbacks.buildSavePayload || (() => null);
     const sendIfOpen = callbacks.sendIfOpen || (() => false);
     const connect = callbacks.connect || function () {};
@@ -65,6 +67,13 @@
       control.addEventListener("change", () => {
         setDirty(true);
       });
+    });
+
+    openProvidersButton?.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      settingsDialog?.close();
+      openProviderPicker();
     });
 
     function openSettings() {

--- a/godot_demo/addons/fennara/dist/styles/settings.css
+++ b/godot_demo/addons/fennara/dist/styles/settings.css
@@ -35,6 +35,10 @@
   color: var(--muted);
 }
 
+.settings-provider-button {
+  justify-self: start;
+}
+
 .settings-note {
   margin: 0;
   color: var(--faint);

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -56,6 +56,7 @@
   const chatSurfaceRestartStatus = document.querySelector("[data-chat-surface-restart]");
   const approvalModeControls = document.querySelectorAll("[data-approval-mode]");
   const settingsSavedToast = document.querySelector("[data-settings-saved-toast]");
+  const openSettingsProvidersButton = document.querySelector("[data-open-settings-providers]");
   const modelInput = document.querySelector("[data-model]");
   const modelStatuses = document.querySelectorAll("[data-model-status]");
   const chatSizeStatus = document.querySelector("[data-chat-size]");
@@ -344,6 +345,7 @@
       approvalModeControls,
       settingsSavedToast,
       saveSettingsButton,
+      openProvidersButton: openSettingsProvidersButton,
     },
     callbacks: {
       ensureDaemonConnected,
@@ -356,6 +358,7 @@
       cleanApprovalMode,
       getCurrentChatSurface: () => currentChatSurface,
       getCurrentApprovalMode: () => currentApprovalMode,
+      openProviderPicker,
       sendIfOpen: daemonClient.sendIfOpen,
       connect,
       appendSystem,

--- a/ui/chat/index.html
+++ b/ui/chat/index.html
@@ -386,6 +386,15 @@
             <button class="icon-button" type="submit" aria-label="Close settings">x</button>
           </header>
           <fieldset class="settings-group">
+            <legend>Providers</legend>
+            <p class="settings-note">
+              Choose a provider and configure the connection details it requires.
+            </p>
+            <button class="secondary-button settings-provider-button" type="button" data-open-settings-providers>
+              Open providers
+            </button>
+          </fieldset>
+          <fieldset class="settings-group">
             <legend>Tool approvals</legend>
             <label class="settings-radio">
               <input type="radio" name="approval_mode" value="ask" data-approval-mode checked />

--- a/ui/chat/settings-panel.js
+++ b/ui/chat/settings-panel.js
@@ -9,6 +9,7 @@
     const approvalModeControls = Array.from(elements.approvalModeControls || []);
     const settingsSavedToast = elements.settingsSavedToast || null;
     const saveSettingsButton = elements.saveSettingsButton || null;
+    const openProvidersButton = elements.openProvidersButton || null;
     const savedNoticeMs = constants.savedNoticeMs || 1800;
     const saveTimeoutMs = constants.saveTimeoutMs || 8000;
     const chatSurfaceBrowser = constants.chatSurfaceBrowser || "browser";
@@ -26,6 +27,7 @@
     const cleanApprovalMode = callbacks.cleanApprovalMode || ((mode) => mode === approvalModeFullAccess ? approvalModeFullAccess : approvalModeAsk);
     const getCurrentChatSurface = callbacks.getCurrentChatSurface || (() => chatSurfaceEmbedded);
     const getCurrentApprovalMode = callbacks.getCurrentApprovalMode || (() => approvalModeAsk);
+    const openProviderPicker = callbacks.openProviderPicker || function () {};
     const buildSavePayload = callbacks.buildSavePayload || (() => null);
     const sendIfOpen = callbacks.sendIfOpen || (() => false);
     const connect = callbacks.connect || function () {};
@@ -65,6 +67,13 @@
       control.addEventListener("change", () => {
         setDirty(true);
       });
+    });
+
+    openProvidersButton?.addEventListener("click", (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      settingsDialog?.close();
+      openProviderPicker();
     });
 
     function openSettings() {

--- a/ui/chat/styles/settings.css
+++ b/ui/chat/styles/settings.css
@@ -35,6 +35,10 @@
   color: var(--muted);
 }
 
+.settings-provider-button {
+  justify-self: start;
+}
+
 .settings-note {
   margin: 0;
   color: var(--faint);


### PR DESCRIPTION
## Summary

- add an **Open providers** action to Chat Settings
- route the action to the existing registry-backed provider picker used by `/provider`
- keep the opening click from reaching the global outside-click handler
- document the shared Settings, dock, and slash-command provider flow

## Why

Provider setup was available through the dock and `/provider`, but it was not discoverable from Chat Settings. Reusing the existing picker keeps provider configuration generic and avoids a second provider-specific settings implementation.

## Validation

- `node --check ui/chat/app.js`
- `node --check ui/chat/settings-panel.js`
- `node --check godot_demo/addons/fennara/dist/app.js`
- `node --check godot_demo/addons/fennara/dist/settings-panel.js`
- `node scripts/check-version.mjs`
- verified the source chat UI matches the tracked addon copy

Closes #78

Assisted by Codex