### PR TITLE
fix(daemon): authenticate local control channel

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,7 @@ Fennara/
     fennara
     fennara-mcp
     fennara-daemon
+  daemon-control-token
   current.json
   versions/
     <version>/
@@ -132,6 +133,17 @@ Fennara/
 ```
 
 On Windows, executables use `.exe`.
+
+The daemon creates `daemon-control-token` with secure random bytes on first
+start. Privileged local HTTP routes and the Godot bridge websocket require this
+token through the `X-Fennara-Control-Token` header. The MCP runtime and Godot
+addon read the token from the same per-user Fennara app-data directory. Before
+sending the token, each client sends a random nonce to the public control
+challenge endpoint and requires a valid HMAC-SHA256 proof. This prevents a
+different process that owns the fixed port from collecting the reusable token.
+Static chat assets and the minimal health endpoint remain public on loopback;
+project chat websocket and media requests continue to use the owning editor's
+separate project chat token.
 
 The `webview/cef/...` directory is for read-only browser engine payloads shared
 by every Godot project/editor using that Fennara install. Per-process writable

--- a/fennara-cpp/include/fennara/app_paths.hpp
+++ b/fennara-cpp/include/fennara/app_paths.hpp
@@ -14,6 +14,7 @@ godot::String webview_profile_dir();
 godot::String webview_log_dir();
 godot::String csharp_ls_binary_path();
 godot::String daemon_binary_path();
+godot::String daemon_control_token_path();
 godot::String chat_settings_path();
 godot::PackedStringArray chat_settings_read_paths();
 godot::String docs_cache_dir();

--- a/fennara-cpp/include/fennara/control_auth.hpp
+++ b/fennara-cpp/include/fennara/control_auth.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace fennara::control_auth {
+
+godot::String verified_daemon_header();
+void request_legacy_daemon_shutdown();
+bool verify_daemon_and_append_header(godot::PackedStringArray &headers);
+
+} // namespace fennara::control_auth

--- a/fennara-cpp/include/fennara/control_auth.hpp
+++ b/fennara-cpp/include/fennara/control_auth.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
+#include <atomic>
+
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/string.hpp>
 
 namespace fennara::control_auth {
 
-godot::String verified_daemon_header();
-void request_legacy_daemon_shutdown();
+godot::String verified_daemon_header(const std::atomic_bool *cancelled = nullptr);
+void request_legacy_daemon_shutdown(const std::atomic_bool *cancelled = nullptr);
 bool verify_daemon_and_append_header(godot::PackedStringArray &headers);
 
 } // namespace fennara::control_auth

--- a/fennara-cpp/include/fennara/local_bridge.hpp
+++ b/fennara-cpp/include/fennara/local_bridge.hpp
@@ -10,7 +10,9 @@
 #include <godot_cpp/variant/string.hpp>
 
 #include <cstdint>
+#include <atomic>
 #include <future>
+#include <memory>
 
 namespace fennara {
 
@@ -61,6 +63,7 @@ private:
     godot::String _active_mcp_target_path;
     godot::Ref<FennaraSnapshotManager> _snapshot_mgr;
     std::future<godot::String> _daemon_auth_future;
+    std::shared_ptr<std::atomic_bool> _daemon_auth_cancel;
 
     void _connect_socket();
     void _close_socket();

--- a/fennara-cpp/include/fennara/local_bridge.hpp
+++ b/fennara-cpp/include/fennara/local_bridge.hpp
@@ -10,6 +10,7 @@
 #include <godot_cpp/variant/string.hpp>
 
 #include <cstdint>
+#include <future>
 
 namespace fennara {
 
@@ -59,6 +60,7 @@ private:
     godot::String _active_mcp_target_name;
     godot::String _active_mcp_target_path;
     godot::Ref<FennaraSnapshotManager> _snapshot_mgr;
+    std::future<godot::String> _daemon_auth_future;
 
     void _connect_socket();
     void _close_socket();

--- a/fennara-cpp/src/app_paths.cpp
+++ b/fennara-cpp/src/app_paths.cpp
@@ -151,6 +151,11 @@ godot::String daemon_binary_path() {
     return paths.is_empty() ? godot::String() : paths[0].path_join("bin").path_join(name);
 }
 
+godot::String daemon_control_token_path() {
+    const godot::String dir = app_dir();
+    return dir.is_empty() ? godot::String() : dir.path_join("daemon-control-token");
+}
+
 godot::String chat_settings_path() {
     const godot::String dir = app_dir();
     return dir.is_empty() ? godot::String() : dir.path_join("chat_settings.json");

--- a/fennara-cpp/src/control_auth.cpp
+++ b/fennara-cpp/src/control_auth.cpp
@@ -1,0 +1,155 @@
+#include "fennara/control_auth.hpp"
+
+#include "fennara/app_paths.hpp"
+
+#include <godot_cpp/classes/crypto.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/http_client.hpp>
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/marshalls.hpp>
+#include <godot_cpp/classes/time.hpp>
+
+#include <chrono>
+#include <thread>
+
+namespace fennara::control_auth {
+namespace {
+
+constexpr const char *kDaemonHost = "127.0.0.1";
+constexpr int kDaemonPort = 41287;
+constexpr int kChallengeBytes = 32;
+constexpr int kChallengeTimeoutMs = 2000;
+constexpr int kMaxChallengeResponseBytes = 4096;
+
+godot::String base64_url_encode(const godot::PackedByteArray &bytes) {
+    return godot::Marshalls::get_singleton()
+        ->raw_to_base64(bytes)
+        .replace("+", "-")
+        .replace("/", "_")
+        .replace("=", "");
+}
+
+godot::PackedByteArray base64_url_decode(godot::String value) {
+    value = value.replace("-", "+").replace("_", "/");
+    while (value.length() % 4 != 0) {
+        value += "=";
+    }
+    return godot::Marshalls::get_singleton()->base64_to_raw(value);
+}
+
+godot::Dictionary request_json(godot::HTTPClient::Method method,
+                               const godot::String &path) {
+    godot::Ref<godot::HTTPClient> http;
+    http.instantiate();
+    if (http.is_null() || http->connect_to_host(kDaemonHost, kDaemonPort) != godot::OK) {
+        return godot::Dictionary();
+    }
+
+    const uint64_t deadline = godot::Time::get_singleton()->get_ticks_msec() + kChallengeTimeoutMs;
+    bool request_sent = false;
+    godot::String response_body;
+    while (godot::Time::get_singleton()->get_ticks_msec() < deadline) {
+        http->poll();
+        const godot::HTTPClient::Status status = http->get_status();
+        if (status == godot::HTTPClient::STATUS_CANT_CONNECT ||
+            status == godot::HTTPClient::STATUS_CONNECTION_ERROR) {
+            return godot::Dictionary();
+        }
+        if (status == godot::HTTPClient::STATUS_CONNECTED && !request_sent) {
+            godot::PackedStringArray headers;
+            headers.append("Accept: application/json");
+            if (http->request(method, path, headers) != godot::OK) {
+                return godot::Dictionary();
+            }
+            request_sent = true;
+        }
+        if (status == godot::HTTPClient::STATUS_BODY) {
+            const godot::PackedByteArray chunk = http->read_response_body_chunk();
+            if (!chunk.is_empty()) {
+                if (response_body.to_utf8_buffer().size() + chunk.size() >
+                    kMaxChallengeResponseBytes) {
+                    return godot::Dictionary();
+                }
+                response_body += chunk.get_string_from_utf8();
+            }
+            if (http->get_status() != godot::HTTPClient::STATUS_BODY && http->has_response()) {
+                break;
+            }
+        } else if (request_sent && status == godot::HTTPClient::STATUS_CONNECTED &&
+                   http->has_response()) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    if (http->get_response_code() != 200) {
+        return godot::Dictionary();
+    }
+
+    const godot::Variant parsed = godot::JSON::parse_string(response_body);
+    if (parsed.get_type() != godot::Variant::DICTIONARY) {
+        return godot::Dictionary();
+    }
+    return parsed;
+}
+
+bool verify_daemon(const godot::PackedByteArray &key) {
+    godot::Ref<godot::Crypto> crypto;
+    crypto.instantiate();
+    if (crypto.is_null()) {
+        return false;
+    }
+    const godot::PackedByteArray nonce = crypto->generate_random_bytes(kChallengeBytes);
+    if (nonce.size() != kChallengeBytes) {
+        return false;
+    }
+
+    const godot::String path = "/control/challenge?nonce=" + base64_url_encode(nonce);
+    const godot::Dictionary response = request_json(godot::HTTPClient::METHOD_GET, path);
+    const godot::PackedByteArray proof =
+        base64_url_decode(godot::String(response.get("proof", "")));
+    const godot::PackedByteArray expected = crypto->hmac_digest(
+        godot::HashingContext::HASH_SHA256, key, nonce);
+    return expected.size() == kChallengeBytes &&
+           crypto->constant_time_compare(expected, proof);
+}
+
+} // namespace
+
+godot::String verified_daemon_header() {
+    const godot::String path = app_paths::daemon_control_token_path();
+    godot::Ref<godot::FileAccess> file =
+        godot::FileAccess::open(path, godot::FileAccess::READ);
+    if (file.is_null()) {
+        return "";
+    }
+    const godot::String token = file->get_as_text().strip_edges();
+    if (token.is_empty() || token.contains("\r") || token.contains("\n")) {
+        return "";
+    }
+    const godot::PackedByteArray key = base64_url_decode(token);
+    if (key.size() != kChallengeBytes || !verify_daemon(key)) {
+        return "";
+    }
+    return "X-Fennara-Control-Token: " + token;
+}
+
+void request_legacy_daemon_shutdown() {
+    const godot::Dictionary health =
+        request_json(godot::HTTPClient::METHOD_GET, "/health");
+    if (godot::String(health.get("daemon", "")) != "fennara-daemon") {
+        return;
+    }
+    request_json(godot::HTTPClient::METHOD_POST, "/shutdown");
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+}
+
+bool verify_daemon_and_append_header(godot::PackedStringArray &headers) {
+    const godot::String header = verified_daemon_header();
+    if (header.is_empty()) {
+        return false;
+    }
+    headers.append(header);
+    return true;
+}
+
+} // namespace fennara::control_auth

--- a/fennara-cpp/src/control_auth.cpp
+++ b/fennara-cpp/src/control_auth.cpp
@@ -38,7 +38,11 @@ godot::PackedByteArray base64_url_decode(godot::String value) {
 }
 
 godot::Dictionary request_json(godot::HTTPClient::Method method,
-                               const godot::String &path) {
+                               const godot::String &path,
+                               const std::atomic_bool *cancelled) {
+    if (cancelled != nullptr && cancelled->load()) {
+        return godot::Dictionary();
+    }
     godot::Ref<godot::HTTPClient> http;
     http.instantiate();
     if (http.is_null() || http->connect_to_host(kDaemonHost, kDaemonPort) != godot::OK) {
@@ -49,6 +53,9 @@ godot::Dictionary request_json(godot::HTTPClient::Method method,
     bool request_sent = false;
     godot::String response_body;
     while (godot::Time::get_singleton()->get_ticks_msec() < deadline) {
+        if (cancelled != nullptr && cancelled->load()) {
+            return godot::Dictionary();
+        }
         http->poll();
         const godot::HTTPClient::Status status = http->get_status();
         if (status == godot::HTTPClient::STATUS_CANT_CONNECT ||
@@ -92,7 +99,8 @@ godot::Dictionary request_json(godot::HTTPClient::Method method,
     return parsed;
 }
 
-bool verify_daemon(const godot::PackedByteArray &key) {
+bool verify_daemon(const godot::PackedByteArray &key,
+                   const std::atomic_bool *cancelled) {
     godot::Ref<godot::Crypto> crypto;
     crypto.instantiate();
     if (crypto.is_null()) {
@@ -104,7 +112,8 @@ bool verify_daemon(const godot::PackedByteArray &key) {
     }
 
     const godot::String path = "/control/challenge?nonce=" + base64_url_encode(nonce);
-    const godot::Dictionary response = request_json(godot::HTTPClient::METHOD_GET, path);
+    const godot::Dictionary response =
+        request_json(godot::HTTPClient::METHOD_GET, path, cancelled);
     const godot::PackedByteArray proof =
         base64_url_decode(godot::String(response.get("proof", "")));
     const godot::PackedByteArray expected = crypto->hmac_digest(
@@ -115,7 +124,10 @@ bool verify_daemon(const godot::PackedByteArray &key) {
 
 } // namespace
 
-godot::String verified_daemon_header() {
+godot::String verified_daemon_header(const std::atomic_bool *cancelled) {
+    if (cancelled != nullptr && cancelled->load()) {
+        return "";
+    }
     const godot::String path = app_paths::daemon_control_token_path();
     godot::Ref<godot::FileAccess> file =
         godot::FileAccess::open(path, godot::FileAccess::READ);
@@ -127,20 +139,25 @@ godot::String verified_daemon_header() {
         return "";
     }
     const godot::PackedByteArray key = base64_url_decode(token);
-    if (key.size() != kChallengeBytes || !verify_daemon(key)) {
+    if (key.size() != kChallengeBytes || !verify_daemon(key, cancelled)) {
         return "";
     }
     return "X-Fennara-Control-Token: " + token;
 }
 
-void request_legacy_daemon_shutdown() {
+void request_legacy_daemon_shutdown(const std::atomic_bool *cancelled) {
     const godot::Dictionary health =
-        request_json(godot::HTTPClient::METHOD_GET, "/health");
+        request_json(godot::HTTPClient::METHOD_GET, "/health", cancelled);
     if (godot::String(health.get("daemon", "")) != "fennara-daemon") {
         return;
     }
-    request_json(godot::HTTPClient::METHOD_POST, "/shutdown");
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    request_json(godot::HTTPClient::METHOD_POST, "/shutdown", cancelled);
+    for (int elapsed_ms = 0; elapsed_ms < 200; elapsed_ms += 5) {
+        if (cancelled != nullptr && cancelled->load()) {
+            return;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
 }
 
 bool verify_daemon_and_append_header(godot::PackedStringArray &headers) {

--- a/fennara-cpp/src/local_bridge/local_bridge.cpp
+++ b/fennara-cpp/src/local_bridge/local_bridge.cpp
@@ -141,6 +141,13 @@ godot::String FennaraLocalBridge::get_chat_token() const {
 
 void FennaraLocalBridge::_exit_tree() {
     _close_socket();
+    if (_daemon_auth_cancel) {
+        _daemon_auth_cancel->store(true);
+    }
+    if (_daemon_auth_future.valid()) {
+        _daemon_auth_future.get();
+    }
+    _daemon_auth_cancel.reset();
 }
 
 void FennaraLocalBridge::_connect_socket() {
@@ -152,10 +159,13 @@ void FennaraLocalBridge::_connect_socket() {
     }
 
     if (!_daemon_auth_future.valid()) {
-        _daemon_auth_future = std::async(std::launch::async, []() {
-            const godot::String header = control_auth::verified_daemon_header();
-            if (header.is_empty()) {
-                control_auth::request_legacy_daemon_shutdown();
+        _daemon_auth_cancel = std::make_shared<std::atomic_bool>(false);
+        const std::shared_ptr<std::atomic_bool> cancel = _daemon_auth_cancel;
+        _daemon_auth_future = std::async(std::launch::async, [cancel]() {
+            const godot::String header =
+                control_auth::verified_daemon_header(cancel.get());
+            if (header.is_empty() && !cancel->load()) {
+                control_auth::request_legacy_daemon_shutdown(cancel.get());
             }
             return header;
         });
@@ -169,6 +179,7 @@ void FennaraLocalBridge::_connect_socket() {
     }
 
     const godot::String control_header = _daemon_auth_future.get();
+    _daemon_auth_cancel.reset();
     if (control_header.is_empty()) {
         _daemon_spawn_attempted = false;
         _start_daemon_if_available();

--- a/fennara-cpp/src/local_bridge/local_bridge.cpp
+++ b/fennara-cpp/src/local_bridge/local_bridge.cpp
@@ -1,12 +1,16 @@
 #include "fennara/local_bridge.hpp"
 
 #include "fennara/app_paths.hpp"
+#include "fennara/control_auth.hpp"
 #include "fennara/logger.hpp"
 #include "fennara/snapshot_manager.hpp"
 
 #include <godot_cpp/classes/json.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/core/class_db.hpp>
+
+#include <chrono>
+#include <future>
 
 namespace fennara {
 
@@ -147,6 +151,31 @@ void FennaraLocalBridge::_connect_socket() {
         }
     }
 
+    if (!_daemon_auth_future.valid()) {
+        _daemon_auth_future = std::async(std::launch::async, []() {
+            const godot::String header = control_auth::verified_daemon_header();
+            if (header.is_empty()) {
+                control_auth::request_legacy_daemon_shutdown();
+            }
+            return header;
+        });
+        _reconnect_timer = 0.05;
+        return;
+    }
+    if (_daemon_auth_future.wait_for(std::chrono::seconds(0)) !=
+        std::future_status::ready) {
+        _reconnect_timer = 0.05;
+        return;
+    }
+
+    const godot::String control_header = _daemon_auth_future.get();
+    if (control_header.is_empty()) {
+        _daemon_spawn_attempted = false;
+        _start_daemon_if_available();
+        _reconnect_timer = _daemon_spawn_attempted ? 0.5 : RECONNECT_DELAY_SECONDS;
+        return;
+    }
+
     _ws.instantiate();
     if (!_ws.is_valid()) {
         FLOG_ERR("Local bridge failed to initialize WebSocketPeer");
@@ -156,6 +185,10 @@ void FennaraLocalBridge::_connect_socket() {
     _intentional_close = false;
     _sent_hello = false;
     _last_state = godot::WebSocketPeer::STATE_CLOSED;
+
+    godot::PackedStringArray headers;
+    headers.append(control_header);
+    _ws->set_handshake_headers(headers);
 
     godot::Error err = _ws->connect_to_url(LOCAL_DAEMON_WS_URL);
     if (err != godot::OK) {

--- a/fennara-cpp/src/tools/runtime_script.cpp
+++ b/fennara-cpp/src/tools/runtime_script.cpp
@@ -1,5 +1,6 @@
 #include "fennara/tools/runtime_script.hpp"
 
+#include "fennara/control_auth.hpp"
 #include "fennara/logger.hpp"
 #include "fennara/runtime/runtime_script_diagnostics.hpp"
 
@@ -120,6 +121,9 @@ godot::Dictionary post_daemon(const godot::String &path,
     godot::PackedStringArray headers;
     headers.append("Content-Type: application/json");
     headers.append("Accept: application/json");
+    if (!control_auth::verify_daemon_and_append_header(headers)) {
+        return make_error("Local daemon control token is unavailable.");
+    }
     godot::PackedByteArray body = godot::JSON::stringify(payload).to_utf8_buffer();
     uint64_t deadline = now_ms() + static_cast<uint64_t>(timeout_ms);
     bool sent = false;

--- a/fennara-cpp/src/tools/runtime_session/runtime_session.cpp
+++ b/fennara-cpp/src/tools/runtime_session/runtime_session.cpp
@@ -1,5 +1,6 @@
 #include "fennara/tools/runtime_session.hpp"
 
+#include "fennara/control_auth.hpp"
 #include "fennara/lsp/csharp_build.hpp"
 #include "fennara/runtime/runtime_scene_preflight.hpp"
 #include "fennara/tools/validate_scene.hpp"
@@ -98,6 +99,11 @@ godot::Dictionary post_daemon(const godot::String &path,
     godot::PackedStringArray headers;
     headers.append("Content-Type: application/json");
     headers.append("Accept: application/json");
+    if (!control_auth::verify_daemon_and_append_header(headers)) {
+        result["success"] = false;
+        result["error"] = "Local daemon control token is unavailable.";
+        return result;
+    }
     godot::PackedByteArray body = godot::JSON::stringify(payload).to_utf8_buffer();
     uint64_t deadline = daemon_now_ms() + static_cast<uint64_t>(timeout_ms);
     bool sent = false;

--- a/fennara-cpp/src/tools/validate_scene/validate_scene.cpp
+++ b/fennara-cpp/src/tools/validate_scene/validate_scene.cpp
@@ -1,5 +1,6 @@
 #include "fennara/tools/validate_scene.hpp"
 
+#include "fennara/control_auth.hpp"
 #include "fennara/helpers.hpp"
 #include "fennara/logger.hpp"
 #include "fennara/tools/scene_io.hpp"
@@ -107,6 +108,11 @@ godot::Dictionary post_local_daemon_json(const godot::String &path,
     godot::PackedStringArray headers;
     headers.append("Content-Type: application/json");
     headers.append("Accept: application/json");
+    if (!control_auth::verify_daemon_and_append_header(headers)) {
+        result["success"] = false;
+        result["error"] = "Local daemon control token is unavailable.";
+        return result;
+    }
     godot::PackedByteArray body = godot::JSON::stringify(payload).to_utf8_buffer();
     uint64_t deadline = now_ms() + static_cast<uint64_t>(timeout_ms);
     bool request_sent = false;

--- a/local/Cargo.lock
+++ b/local/Cargo.lock
@@ -229,6 +229,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -287,11 +288,13 @@ dependencies = [
  "base64",
  "futures-util",
  "getrandom 0.3.4",
+ "hmac",
  "libc",
  "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "sysinfo",
  "tokio",
 ]
@@ -301,8 +304,11 @@ name = "fennara-mcp"
 version = "0.3.7"
 dependencies = [
  "base64",
+ "getrandom 0.3.4",
+ "hmac",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -449,6 +455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]

--- a/local/Cargo.lock
+++ b/local/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "sysinfo",
  "tokio",
 ]

--- a/local/crates/fennara-daemon/Cargo.toml
+++ b/local/crates/fennara-daemon/Cargo.toml
@@ -17,5 +17,6 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+subtle = "2.6"
 sysinfo = "0.30"
 tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }

--- a/local/crates/fennara-daemon/Cargo.toml
+++ b/local/crates/fennara-daemon/Cargo.toml
@@ -10,10 +10,12 @@ axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
 futures-util = "0.3"
 getrandom = "0.3"
+hmac = "0.12"
 libc = "0.2"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 sysinfo = "0.30"
 tokio = { version = "1.48", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
@@ -488,7 +488,7 @@ pub(crate) fn app_dir() -> PathBuf {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Some(path) = env::var_os("XDG_DATA_HOME") {
+        if let Some(path) = env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
             return PathBuf::from(path).join("fennara");
         }
         if let Some(path) = home_dir() {

--- a/local/crates/fennara-daemon/src/runtime_daemon/control_auth.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/control_auth.rs
@@ -16,6 +16,7 @@ use std::{
     path::Path,
     sync::Arc,
 };
+use subtle::ConstantTimeEq;
 
 use super::util::fennara_app_dir;
 
@@ -95,7 +96,9 @@ fn is_authorized(headers: &HeaderMap, expected: &str) -> bool {
     headers
         .get(CONTROL_HEADER)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value == expected)
+        .is_some_and(|value| {
+            value.len() == expected.len() && bool::from(value.as_bytes().ct_eq(expected.as_bytes()))
+        })
 }
 
 fn load_or_create_at(path: &Path) -> Result<String, String> {
@@ -109,7 +112,7 @@ fn load_or_create_at(path: &Path) -> Result<String, String> {
     }
 
     let token = generate_token()?;
-    let temp_path = path.with_extension(format!("{}.tmp", std::process::id()));
+    let temp_path = path.with_extension(format!("{}.{}.tmp", std::process::id(), &token[..8]));
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
@@ -142,6 +145,13 @@ fn load_or_create_at(path: &Path) -> Result<String, String> {
             read_valid_token(path)?
                 .ok_or_else(|| format!("{} does not contain a valid control token", path.display()))
         }
+        Err(error) if error.kind() == ErrorKind::Unsupported => {
+            let _ = fs::remove_file(&temp_path);
+            Err(format!(
+                "cannot publish {} atomically because its filesystem does not support hard links; move the Fennara app-data directory to a filesystem with hard-link support",
+                path.display()
+            ))
+        }
         Err(error) => {
             let _ = fs::remove_file(&temp_path);
             Err(format!("failed to publish {}: {error}", path.display()))
@@ -173,6 +183,7 @@ fn generate_token() -> Result<String, String> {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::{Arc, Barrier};
 
     fn test_path(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!(
@@ -207,5 +218,34 @@ mod tests {
 
         headers.insert(CONTROL_HEADER, "expected".parse().unwrap());
         assert!(is_authorized(&headers, "expected"));
+    }
+
+    #[test]
+    fn concurrent_creators_reuse_one_control_token() {
+        const THREADS: usize = 8;
+        let path = test_path("concurrent");
+        let _ = fs::remove_file(&path);
+        let barrier = Arc::new(Barrier::new(THREADS));
+        let handles = (0..THREADS)
+            .map(|_| {
+                let path = path.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    load_or_create_at(&path).expect("concurrent token creation should succeed")
+                })
+            })
+            .collect::<Vec<_>>();
+        let tokens = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("token creator should not panic"))
+            .collect::<Vec<_>>();
+
+        assert!(tokens.iter().all(|token| token == &tokens[0]));
+        assert_eq!(
+            URL_SAFE_NO_PAD.decode(&tokens[0]).unwrap().len(),
+            CONTROL_TOKEN_BYTES
+        );
+        let _ = fs::remove_file(path);
     }
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/control_auth.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/control_auth.rs
@@ -1,0 +1,211 @@
+use axum::{
+    Json,
+    extract::{Extension, Query, Request, State},
+    http::{HeaderMap, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use serde_json::json;
+use sha2::Sha256;
+use std::{
+    fs::{self, OpenOptions},
+    io::{ErrorKind, Write},
+    path::Path,
+    sync::Arc,
+};
+
+use super::util::fennara_app_dir;
+
+pub(crate) const CONTROL_HEADER: &str = "x-fennara-control-token";
+const CONTROL_TOKEN_FILE: &str = "daemon-control-token";
+const CONTROL_TOKEN_BYTES: usize = 32;
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Deserialize)]
+pub(crate) struct ChallengeQuery {
+    nonce: String,
+}
+
+pub(crate) fn load_or_create() -> Result<Arc<str>, String> {
+    let path = fennara_app_dir()?.join(CONTROL_TOKEN_FILE);
+    load_or_create_at(&path).map(Arc::from)
+}
+
+pub(crate) async fn require_control_auth(
+    State(expected): State<Arc<str>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if is_authorized(request.headers(), &expected) {
+        return next.run(request).await;
+    }
+
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "ok": false,
+            "error": "Local daemon control authentication failed."
+        })),
+    )
+        .into_response()
+}
+
+pub(crate) async fn challenge(
+    Extension(token): Extension<Arc<str>>,
+    Query(query): Query<ChallengeQuery>,
+) -> Response {
+    if query.nonce.len() != 43 {
+        return challenge_error();
+    }
+    let Ok(nonce) = URL_SAFE_NO_PAD.decode(&query.nonce) else {
+        return challenge_error();
+    };
+    if nonce.len() != CONTROL_TOKEN_BYTES {
+        return challenge_error();
+    }
+
+    let token_bytes = URL_SAFE_NO_PAD
+        .decode(token.as_ref())
+        .expect("stored control token should remain valid");
+    let mut mac = HmacSha256::new_from_slice(&token_bytes)
+        .expect("HMAC accepts control tokens of any length");
+    mac.update(&nonce);
+    Json(json!({
+        "ok": true,
+        "proof": URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+    }))
+    .into_response()
+}
+
+fn challenge_error() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(json!({
+            "ok": false,
+            "error": "A 32-byte URL-safe base64 nonce is required."
+        })),
+    )
+        .into_response()
+}
+
+fn is_authorized(headers: &HeaderMap, expected: &str) -> bool {
+    headers
+        .get(CONTROL_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value == expected)
+}
+
+fn load_or_create_at(path: &Path) -> Result<String, String> {
+    if let Some(token) = read_valid_token(path)? {
+        return Ok(token);
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+
+    let token = generate_token()?;
+    let temp_path = path.with_extension(format!("{}.tmp", std::process::id()));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let _ = fs::remove_file(&temp_path);
+    let mut file = options
+        .open(&temp_path)
+        .map_err(|error| format!("failed to create {}: {error}", temp_path.display()))?;
+    if let Err(error) = file
+        .write_all(token.as_bytes())
+        .and_then(|_| file.write_all(b"\n"))
+        .and_then(|_| file.sync_all())
+    {
+        let _ = fs::remove_file(&temp_path);
+        return Err(format!("failed to write {}: {error}", temp_path.display()));
+    }
+    drop(file);
+
+    match fs::hard_link(&temp_path, path) {
+        Ok(()) => {
+            let _ = fs::remove_file(&temp_path);
+            Ok(token)
+        }
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&temp_path);
+            read_valid_token(path)?
+                .ok_or_else(|| format!("{} does not contain a valid control token", path.display()))
+        }
+        Err(error) => {
+            let _ = fs::remove_file(&temp_path);
+            Err(format!("failed to publish {}: {error}", path.display()))
+        }
+    }
+}
+
+fn read_valid_token(path: &Path) -> Result<Option<String>, String> {
+    let raw = match fs::read_to_string(path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(format!("failed to read {}: {error}", path.display())),
+    };
+    let token = raw.trim();
+    let decoded = URL_SAFE_NO_PAD.decode(token).ok();
+    Ok(decoded
+        .filter(|bytes| bytes.len() == CONTROL_TOKEN_BYTES)
+        .map(|_| token.to_string()))
+}
+
+fn generate_token() -> Result<String, String> {
+    let mut bytes = [0_u8; CONTROL_TOKEN_BYTES];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| format!("failed to generate daemon control token: {error}"))?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "fennara-control-auth-{}-{name}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn creates_and_reuses_a_valid_control_token() {
+        let path = test_path("create");
+        let _ = fs::remove_file(&path);
+
+        let first = load_or_create_at(&path).expect("control token should be created");
+        let second = load_or_create_at(&path).expect("control token should be reused");
+
+        assert_eq!(first, second);
+        assert_eq!(
+            URL_SAFE_NO_PAD.decode(first).unwrap().len(),
+            CONTROL_TOKEN_BYTES
+        );
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn requires_the_exact_control_header() {
+        let mut headers = HeaderMap::new();
+        assert!(!is_authorized(&headers, "expected"));
+
+        headers.insert(CONTROL_HEADER, "wrong".parse().unwrap());
+        assert!(!is_authorized(&headers, "expected"));
+
+        headers.insert(CONTROL_HEADER, "expected".parse().unwrap());
+        assert!(is_authorized(&headers, "expected"));
+    }
+}

--- a/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
@@ -1,5 +1,5 @@
 use axum::{
-    Json, Router,
+    Extension, Json, Router, middleware,
     routing::{get, post},
 };
 use serde_json::{Value, json};
@@ -7,6 +7,7 @@ use std::{net::SocketAddr, time::Duration};
 use tokio::sync::oneshot;
 
 pub(crate) mod chat;
+pub(crate) mod control_auth;
 pub(crate) mod docs_cache;
 pub(crate) mod godot_bridge;
 pub(crate) mod permissions;
@@ -26,20 +27,13 @@ pub(crate) const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub async fn run() {
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let state = AppState::new(shutdown_tx);
+    let control_token = control_auth::load_or_create()
+        .expect("failed to initialize local daemon control authentication");
 
-    let app = Router::new()
-        .route("/health", get(health))
+    let privileged = Router::new()
         .route("/status", get(godot_bridge::status))
         .route("/shutdown", post(shutdown))
-        .route("/chat", get(chat::chat_index_redirect))
-        .route("/chat/", get(chat::chat_index))
         .route("/chat/traces", get(chat::chat_traces))
-        .route(
-            "/chat/tool-media/{tool_call_id}/{index}",
-            get(chat::chat_tool_media),
-        )
-        .route("/chat/{*path}", get(chat::chat_asset))
-        .route("/chat/ws", get(chat::chat_ws))
         .route("/tools/call", post(godot_bridge::call_tool))
         .route(
             "/runtime/run-godot-scene",
@@ -66,6 +60,24 @@ pub async fn run() {
             post(runtime_sessions::runtime_session_script),
         )
         .route("/godot/ws", get(godot_bridge::godot_ws))
+        .route_layer(middleware::from_fn_with_state(
+            control_token.clone(),
+            control_auth::require_control_auth,
+        ));
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/control/challenge", get(control_auth::challenge))
+        .route("/chat", get(chat::chat_index_redirect))
+        .route("/chat/", get(chat::chat_index))
+        .route(
+            "/chat/tool-media/{tool_call_id}/{index}",
+            get(chat::chat_tool_media),
+        )
+        .route("/chat/{*path}", get(chat::chat_asset))
+        .route("/chat/ws", get(chat::chat_ws))
+        .merge(privileged)
+        .layer(Extension(control_token))
         .with_state(state);
 
     let addr: SocketAddr = format!("{DAEMON_HOST}:{DAEMON_PORT}")

--- a/local/crates/fennara-daemon/src/runtime_daemon/util.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/util.rs
@@ -67,9 +67,12 @@ pub(crate) fn fennara_app_dir() -> Result<PathBuf, String> {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
+        if let Some(path) = env::var_os("XDG_DATA_HOME") {
+            return Ok(PathBuf::from(path).join("fennara"));
+        }
         home_dir()
             .map(|path| path.join(".local").join("share").join("fennara"))
-            .ok_or_else(|| "HOME is not set".to_string())
+            .ok_or_else(|| "HOME and XDG_DATA_HOME are not set".to_string())
     }
 }
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/util.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/util.rs
@@ -67,7 +67,7 @@ pub(crate) fn fennara_app_dir() -> Result<PathBuf, String> {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Some(path) = env::var_os("XDG_DATA_HOME") {
+        if let Some(path) = env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
             return Ok(PathBuf::from(path).join("fennara"));
         }
         home_dir()

--- a/local/crates/fennara-mcp/Cargo.toml
+++ b/local/crates/fennara-mcp/Cargo.toml
@@ -7,5 +7,8 @@ repository.workspace = true
 
 [dependencies]
 base64 = "0.22"
+getrandom = "0.3"
+hmac = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"

--- a/local/crates/fennara-mcp/src/runtime/daemon_client.rs
+++ b/local/crates/fennara-mcp/src/runtime/daemon_client.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpStream;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const DAEMON_ADDR: &str = "127.0.0.1:41287";
@@ -99,6 +99,10 @@ fn read_http_json_response_limited(stream: TcpStream, max_bytes: usize) -> Resul
 
 fn daemon_control_token() -> Result<String, String> {
     let path = fennara_app_dir()?.join(CONTROL_TOKEN_FILE);
+    daemon_control_token_at(&path)
+}
+
+fn daemon_control_token_at(path: &Path) -> Result<String, String> {
     let raw = fs::read_to_string(&path)
         .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
     let token = raw.trim();
@@ -115,12 +119,16 @@ fn daemon_control_token() -> Result<String, String> {
 }
 
 fn verify_daemon(control_token: &str) -> Result<(), String> {
+    verify_daemon_at(control_token, DAEMON_ADDR)
+}
+
+fn verify_daemon_at(control_token: &str, address: &str) -> Result<(), String> {
     let mut nonce = [0_u8; 32];
     getrandom::fill(&mut nonce)
         .map_err(|error| format!("failed to create daemon challenge: {error}"))?;
     let encoded_nonce = URL_SAFE_NO_PAD.encode(nonce);
 
-    let mut stream = TcpStream::connect(DAEMON_ADDR)
+    let mut stream = TcpStream::connect(address)
         .map_err(|error| format!("Open a Godot project with Fennara enabled. ({error})"))?;
     stream
         .set_read_timeout(Some(Duration::from_secs(2)))
@@ -178,12 +186,87 @@ fn fennara_app_dir() -> Result<PathBuf, String> {
 
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        if let Some(path) = env::var_os("XDG_DATA_HOME") {
+        if let Some(path) = env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty()) {
             return Ok(PathBuf::from(path).join("fennara"));
         }
         env::var_os("HOME")
             .map(PathBuf::from)
             .map(|path| path.join(".local").join("share").join("fennara"))
             .ok_or_else(|| "HOME and XDG_DATA_HOME are not set".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn test_token_path() -> PathBuf {
+        std::env::temp_dir().join(format!("fennara-mcp-control-token-{}", std::process::id()))
+    }
+
+    fn mock_challenge_server(proof: &str) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap().to_string();
+        let proof = proof.to_string();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let _ = stream.read(&mut request).unwrap();
+            let body = json!({ "ok": true, "proof": proof }).to_string();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        (address, handle)
+    }
+
+    #[test]
+    fn daemon_control_token_validates_file_contents() {
+        let path = test_token_path();
+        let _ = fs::remove_file(&path);
+
+        let missing = daemon_control_token_at(&path).unwrap_err();
+        assert!(missing.contains("failed to read"));
+
+        fs::write(&path, "not-a-token\n").unwrap();
+        let malformed = daemon_control_token_at(&path).unwrap_err();
+        assert!(malformed.contains("does not contain a valid daemon control token"));
+
+        fs::write(&path, URL_SAFE_NO_PAD.encode([1_u8; 3])).unwrap();
+        let incorrect_length = daemon_control_token_at(&path).unwrap_err();
+        assert!(incorrect_length.contains("does not contain a valid daemon control token"));
+
+        let token = URL_SAFE_NO_PAD.encode([7_u8; 32]);
+        fs::write(&path, format!("{token}\n")).unwrap();
+        assert_eq!(daemon_control_token_at(&path).unwrap(), token);
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn verify_daemon_rejects_invalid_proof_encoding() {
+        let token = URL_SAFE_NO_PAD.encode([9_u8; 32]);
+        let (address, server) = mock_challenge_server("not*base64");
+
+        let error = verify_daemon_at(&token, &address).unwrap_err();
+
+        assert!(error.contains("returned an invalid proof"));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn verify_daemon_rejects_incorrect_hmac_proof() {
+        let token = URL_SAFE_NO_PAD.encode([9_u8; 32]);
+        let wrong_proof = URL_SAFE_NO_PAD.encode([0_u8; 32]);
+        let (address, server) = mock_challenge_server(&wrong_proof);
+
+        let error = verify_daemon_at(&token, &address).unwrap_err();
+
+        assert!(error.contains("failed identity verification"));
+        server.join().unwrap();
     }
 }

--- a/local/crates/fennara-mcp/src/runtime/daemon_client.rs
+++ b/local/crates/fennara-mcp/src/runtime/daemon_client.rs
@@ -1,9 +1,20 @@
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use hmac::{Hmac, Mac};
 use serde_json::{Value, json};
+use sha2::Sha256;
+use std::env;
+use std::fs;
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::path::PathBuf;
 use std::time::Duration;
 
 const DAEMON_ADDR: &str = "127.0.0.1:41287";
+const CONTROL_HEADER: &str = "X-Fennara-Control-Token";
+const CONTROL_TOKEN_FILE: &str = "daemon-control-token";
+const MAX_DAEMON_RESPONSE_BYTES: usize = 32 * 1024 * 1024;
+const MAX_CHALLENGE_RESPONSE_BYTES: usize = 4096;
+type HmacSha256 = Hmac<Sha256>;
 
 pub(crate) fn daemon_status() -> Result<Value, String> {
     daemon_get("/status")
@@ -19,6 +30,8 @@ pub(crate) fn daemon_tool_call(tool: &str, args: Value) -> Result<Value, String>
 }
 
 fn daemon_get(path: &str) -> Result<Value, String> {
+    let control_token = daemon_control_token()?;
+    verify_daemon(&control_token)?;
     let mut stream = TcpStream::connect(DAEMON_ADDR)
         .map_err(|error| format!("Open a Godot project with Fennara enabled. ({error})"))?;
     stream
@@ -28,7 +41,9 @@ fn daemon_get(path: &str) -> Result<Value, String> {
         .set_write_timeout(Some(Duration::from_secs(2)))
         .map_err(|error| error.to_string())?;
 
-    let request = format!("GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+    let request = format!(
+        "GET {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n{CONTROL_HEADER}: {control_token}\r\nConnection: close\r\n\r\n"
+    );
     stream
         .write_all(request.as_bytes())
         .map_err(|error| error.to_string())?;
@@ -37,6 +52,8 @@ fn daemon_get(path: &str) -> Result<Value, String> {
 }
 
 fn daemon_post(path: &str, body: &str) -> Result<Value, String> {
+    let control_token = daemon_control_token()?;
+    verify_daemon(&control_token)?;
     let mut stream = TcpStream::connect(DAEMON_ADDR)
         .map_err(|error| format!("Open a Godot project with Fennara enabled. ({error})"))?;
     stream
@@ -47,7 +64,7 @@ fn daemon_post(path: &str, body: &str) -> Result<Value, String> {
         .map_err(|error| error.to_string())?;
 
     let request = format!(
-        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "POST {path} HTTP/1.1\r\nHost: 127.0.0.1\r\n{CONTROL_HEADER}: {control_token}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
     stream
@@ -57,11 +74,19 @@ fn daemon_post(path: &str, body: &str) -> Result<Value, String> {
     read_http_json_response(stream)
 }
 
-fn read_http_json_response(mut stream: TcpStream) -> Result<Value, String> {
+fn read_http_json_response(stream: TcpStream) -> Result<Value, String> {
+    read_http_json_response_limited(stream, MAX_DAEMON_RESPONSE_BYTES)
+}
+
+fn read_http_json_response_limited(stream: TcpStream, max_bytes: usize) -> Result<Value, String> {
     let mut response = String::new();
     stream
+        .take(max_bytes as u64 + 1)
         .read_to_string(&mut response)
         .map_err(|error| error.to_string())?;
+    if response.len() > max_bytes {
+        return Err("daemon HTTP response exceeded the local size limit".to_string());
+    }
 
     let (headers, body) = response
         .split_once("\r\n\r\n")
@@ -70,4 +95,95 @@ fn read_http_json_response(mut stream: TcpStream) -> Result<Value, String> {
         return Err("daemon returned non-200 status".to_string());
     }
     serde_json::from_str(body).map_err(|error| error.to_string())
+}
+
+fn daemon_control_token() -> Result<String, String> {
+    let path = fennara_app_dir()?.join(CONTROL_TOKEN_FILE);
+    let raw = fs::read_to_string(&path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let token = raw.trim();
+    let valid = URL_SAFE_NO_PAD
+        .decode(token)
+        .is_ok_and(|bytes| bytes.len() == 32);
+    if !valid {
+        return Err(format!(
+            "{} does not contain a valid daemon control token",
+            path.display()
+        ));
+    }
+    Ok(token.to_string())
+}
+
+fn verify_daemon(control_token: &str) -> Result<(), String> {
+    let mut nonce = [0_u8; 32];
+    getrandom::fill(&mut nonce)
+        .map_err(|error| format!("failed to create daemon challenge: {error}"))?;
+    let encoded_nonce = URL_SAFE_NO_PAD.encode(nonce);
+
+    let mut stream = TcpStream::connect(DAEMON_ADDR)
+        .map_err(|error| format!("Open a Godot project with Fennara enabled. ({error})"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| error.to_string())?;
+    stream
+        .set_write_timeout(Some(Duration::from_secs(2)))
+        .map_err(|error| error.to_string())?;
+    let request = format!(
+        "GET /control/challenge?nonce={encoded_nonce} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| error.to_string())?;
+    let response = read_http_json_response_limited(stream, MAX_CHALLENGE_RESPONSE_BYTES)?;
+    let proof = response
+        .get("proof")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            "The process on the Fennara daemon port could not prove its identity.".to_string()
+        })?;
+    let proof = URL_SAFE_NO_PAD.decode(proof).map_err(|_| {
+        "The process on the Fennara daemon port returned an invalid proof.".to_string()
+    })?;
+    let token_bytes = URL_SAFE_NO_PAD
+        .decode(control_token)
+        .map_err(|_| "The local daemon control token is invalid.".to_string())?;
+    let mut mac = HmacSha256::new_from_slice(&token_bytes)
+        .map_err(|_| "The local daemon control token is invalid.".to_string())?;
+    mac.update(&nonce);
+    mac.verify_slice(&proof).map_err(|_| {
+        "The process on the Fennara daemon port failed identity verification.".to_string()
+    })
+}
+
+fn fennara_app_dir() -> Result<PathBuf, String> {
+    #[cfg(target_os = "windows")]
+    {
+        env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .map(|path| path.join("Fennara"))
+            .ok_or_else(|| "LOCALAPPDATA is not set".to_string())
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        env::var_os("HOME")
+            .map(PathBuf::from)
+            .map(|path| {
+                path.join("Library")
+                    .join("Application Support")
+                    .join("Fennara")
+            })
+            .ok_or_else(|| "HOME is not set".to_string())
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(path) = env::var_os("XDG_DATA_HOME") {
+            return Ok(PathBuf::from(path).join("fennara"));
+        }
+        env::var_os("HOME")
+            .map(PathBuf::from)
+            .map(|path| path.join(".local").join("share").join("fennara"))
+            .ok_or_else(|| "HOME and XDG_DATA_HOME are not set".to_string())
+    }
 }


### PR DESCRIPTION
## What changed

- Added a securely generated per-user daemon control token with atomic first publication.
- Protected privileged daemon HTTP routes and the Godot bridge websocket with the control token.
- Added an HMAC-SHA256 nonce challenge so clients verify the daemon before sending the reusable token to port 41287.
- Updated the MCP runtime, Godot bridge, runtime-session helpers, runtime-script helper, and scene validation helper to use the authenticated channel.
- Added a bounded background handoff for an older unauthenticated daemon that is still running during an upgrade.
- Aligned Linux token paths with `XDG_DATA_HOME` and documented the control boundary.

## Why

The daemon previously treated loopback and fixed-port ownership as sufficient trust for privileged local operations. That left the control channel without explicit client authentication and made a naive bearer-token fix vulnerable to credential capture by another process owning the port.

The challenge verifies server possession of the token before clients disclose it, while the route middleware rejects privileged requests without the exact token. Project chat tokens remain separate.

Closes #81

## Validation

- `cargo test -p fennara-daemon control_auth`
- `cargo test -p fennara-mcp`
- `cargo check -p fennara-daemon -p fennara-mcp`
- `scons platform=windows target=editor -j4`

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added header-based authentication for local daemon control over HTTP and during local connection setup, backed by a persistent daemon control token.
  * Protected privileged daemon endpoints while keeping only minimal health/public assets locally accessible.
  * Implemented nonce + HMAC verification to prevent other processes from reusing credentials.

* **Bug Fixes**
  * Improved daemon request robustness by enforcing maximum response sizes.
  * Added safer handling when authentication isn’t available and enabled cancelable authentication flow.

* **Documentation**
  * Updated install/auth documentation with control-token storage and endpoint access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->