### PR TITLE
fix(tools): clarify write file arguments

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -202,8 +202,8 @@ Use get_class_info for CharacterBody2D and AnimationPlayer before writing the sc
 Use this for normal project text files when a Fennara-aware edit is appropriate.
 It supports two modes:
 
-- `write`: create or completely rewrite a file.
-- `update`: replace an exact `old_string` with `new_string`; include enough
+- `write`: create or completely rewrite a file with `new_content`.
+- `update`: replace exact `old_content` with `new_content`; include enough
   surrounding text to make the match unique.
 
 For `.gd` and `.gdshader` files, Fennara automatically runs diagnostics after

--- a/fennara-cpp/src/tools/run_scene_edit_script/script_contract.cpp
+++ b/fennara-cpp/src/tools/run_scene_edit_script/script_contract.cpp
@@ -47,7 +47,7 @@ godot::String write_or_resolve_script_path(const godot::String &normalized_scene
         godot::Dictionary write_args;
         write_args["mode"] = "write";
         write_args["file_path"] = effective_script_path;
-        write_args["content"] = code;
+        write_args["new_content"] = code;
 
         godot::Dictionary write_result = FennaraWriteOrUpdateFileTool::execute(write_args);
         if (!(bool)write_result.get("success", false)) {

--- a/fennara-cpp/src/tools/write_or_update_file/update.cpp
+++ b/fennara-cpp/src/tools/write_or_update_file/update.cpp
@@ -14,13 +14,13 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_update(
     godot::Dictionary result;
 
     godot::String file_path = args.get("file_path", "");
-    godot::String old_string = args.get("old_string", "");
-    godot::String new_string = args.get("new_string", "");
+    godot::String old_content = args.get("old_content", "");
+    godot::String replacement_content = args.get("new_content", "");
     bool replace_all = args.get("replace_all", false);
 
-    if (old_string.is_empty()) {
+    if (old_content.is_empty()) {
         result["success"] = false;
-        result["error"] = "old_string required for update mode";
+        result["error"] = "old_content required for update mode";
         return result;
     }
 
@@ -58,27 +58,27 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_update(
     }
 
     godot::String current_content = read_result.get("content", "");
-    int occurrence_count = current_content.count(old_string);
+    int occurrence_count = current_content.count(old_content);
     if (occurrence_count == 0) {
-        godot::String old_preview = old_string.length() > 80
-            ? old_string.substr(0, 80) + "..."
-            : old_string;
-        FLOG_ERR(godot::String("Write: old_string not found in ") +
-                 normalized_path + " old_string=\"" + old_preview + "\"");
+        godot::String old_preview = old_content.length() > 80
+            ? old_content.substr(0, 80) + "..."
+            : old_content;
+        FLOG_ERR(godot::String("Write: old_content not found in ") +
+                 normalized_path + " old_content=\"" + old_preview + "\"");
         result["success"] = false;
         result["error"] =
-            "YOU MUST READ THIS FILE FIRST BEFORE EDITING! OLD_STRING NOT "
+            "YOU MUST READ THIS FILE FIRST BEFORE EDITING! OLD_CONTENT NOT "
             "FOUND IN FILE: " +
             file_path;
         return result;
     }
     if (occurrence_count > 1 && !replace_all) {
-        FLOG_ERR(godot::String("Write: old_string found ") +
+        FLOG_ERR(godot::String("Write: old_content found ") +
                  godot::String::num_int64(occurrence_count) + " times in " +
                  normalized_path);
         result["success"] = false;
         result["error"] =
-            "YOU MUST READ THIS FILE FIRST BEFORE EDITING! OLD_STRING APPEARS "
+            "YOU MUST READ THIS FILE FIRST BEFORE EDITING! OLD_CONTENT APPEARS "
             + godot::String::num_int64(occurrence_count) +
             " TIMES IN FILE. PROVIDE MORE SURROUNDING CODE TO MAKE IT UNIQUE, "
             "OR SET REPLACE_ALL=TRUE";
@@ -87,17 +87,18 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_update(
 
     _snapshot_before_write(normalized_path, true);
 
-    godot::String new_content;
+    godot::String updated_content;
     if (replace_all) {
-        new_content = current_content.replace(old_string, new_string);
+        updated_content = current_content.replace(
+            old_content, replacement_content);
     } else {
-        int pos = current_content.find(old_string);
-        new_content = current_content.substr(0, pos) + new_string +
-                      current_content.substr(pos + old_string.length());
+        int pos = current_content.find(old_content);
+        updated_content = current_content.substr(0, pos) + replacement_content +
+                          current_content.substr(pos + old_content.length());
     }
 
     godot::Dictionary write_result =
-        _write_content(normalized_path, new_content, file_path, true);
+        _write_content(normalized_path, updated_content, file_path, true);
     if (!(bool)write_result.get("success", false)) {
         return write_result;
     }
@@ -107,20 +108,20 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_update(
         csharp_build::note_csharp_source_changed();
     }
     if (normalized_path.ends_with(".gdshader")) {
-        _refresh_cached_shader_resource(normalized_path, new_content);
+        _refresh_cached_shader_resource(normalized_path, updated_content);
         _reserialize_shader_owners(normalized_path, result);
     }
 
     FLOG_TOOL(godot::String("Write: done, replacements=") +
               godot::String::num_int64(replace_all ? occurrence_count : 1) +
               " lines=" +
-              godot::String::num_int64(new_content.split("\n").size()));
+              godot::String::num_int64(updated_content.split("\n").size()));
     result["success"] = true;
     result["mode"] = "update";
     result["file_path"] = normalized_path;
-    result["line_count"] = new_content.split("\n").size();
+    result["line_count"] = updated_content.split("\n").size();
     result["replacements_made"] = replace_all ? occurrence_count : 1;
-    _append_shader_diagnostics(result, normalized_path, new_content);
+    _append_shader_diagnostics(result, normalized_path, updated_content);
     return result;
 }
 

--- a/fennara-cpp/src/tools/write_or_update_file/write.cpp
+++ b/fennara-cpp/src/tools/write_or_update_file/write.cpp
@@ -14,13 +14,13 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_write(
     godot::Dictionary result;
 
     godot::String file_path = args.get("file_path", "");
-    godot::String content = args.get("content", "");
+    godot::String new_content = args.get("new_content", "");
     godot::String attach_to_scene = args.get("attach_to_scene", "");
     godot::String attach_to_node = args.get("attach_to_node", "");
 
-    if (content.is_empty()) {
+    if (new_content.is_empty()) {
         result["success"] = false;
-        result["error"] = "content required for write mode";
+        result["error"] = "new_content required for write mode";
         return result;
     }
 
@@ -51,7 +51,7 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_write(
     _snapshot_before_write(normalized_path, file_exists);
 
     godot::Dictionary write_result =
-        _write_content(normalized_path, content, file_path, file_exists);
+        _write_content(normalized_path, new_content, file_path, file_exists);
     if (!(bool)write_result.get("success", false)) {
         return write_result;
     }
@@ -61,19 +61,19 @@ godot::Dictionary FennaraWriteOrUpdateFileTool::_execute_write(
         csharp_build::note_csharp_source_changed();
     }
     if (normalized_path.ends_with(".gdshader")) {
-        _refresh_cached_shader_resource(normalized_path, content);
+        _refresh_cached_shader_resource(normalized_path, new_content);
         _reserialize_shader_owners(normalized_path, result);
     }
 
     FLOG_TOOL(godot::String("Write: done, lines=") +
-              godot::String::num_int64(content.split("\n").size()) +
+              godot::String::num_int64(new_content.split("\n").size()) +
               " created=" + (!file_exists ? "true" : "false"));
     result["success"] = true;
     result["mode"] = "write";
     result["file_path"] = normalized_path;
-    result["line_count"] = content.split("\n").size();
+    result["line_count"] = new_content.split("\n").size();
     result["created"] = !file_exists;
-    _append_shader_diagnostics(result, normalized_path, content);
+    _append_shader_diagnostics(result, normalized_path, new_content);
 
     if (!attach_to_scene.is_empty() && !attach_to_node.is_empty()) {
         if (!normalized_path.ends_with(".gd")) {

--- a/local/schemas/tools/write_or_update_file.json
+++ b/local/schemas/tools/write_or_update_file.json
@@ -28,21 +28,17 @@
         "type": "string",
         "description": "Path to the file relative to project root (e.g., 'scripts/enemy.gd') or absolute path (e.g., 'res://scripts/enemy.gd')"
       },
-      "content": {
+      "new_content": {
         "type": "string",
-        "description": "WRITE MODE ONLY: Full content of the file to write. Required when mode='write'."
+        "description": "Full replacement content. In write mode, this is the complete file content. In update mode, this replaces old_content and may be empty to delete the matched text. Required in both modes."
       },
-      "old_string": {
+      "old_content": {
         "type": "string",
         "description": "UPDATE MODE ONLY: Exact code to find and replace. Must match exactly including whitespace and indentation. Required when mode='update'. If this appears multiple times in the file, include more surrounding code to make it unique."
       },
-      "new_string": {
-        "type": "string",
-        "description": "UPDATE MODE ONLY: Code to insert in place of old_string. Can be empty string to delete code. Required when mode='update'."
-      },
       "replace_all": {
         "type": "boolean",
-        "description": "UPDATE MODE ONLY: Whether to replace all occurrences of old_string (default: false). If false and multiple matches exist, tool will return an error asking for more context."
+        "description": "UPDATE MODE ONLY: Whether to replace all occurrences of old_content (default: false). If false and multiple matches exist, tool will return an error asking for more context."
       },
       "attach_to_scene": {
         "type": "string",
@@ -55,7 +51,8 @@
     },
     "required": [
       "mode",
-      "file_path"
+      "file_path",
+      "new_content"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Renames the public `write_or_update_file` content arguments so write and update calls use one consistent vocabulary:

- `new_content` contains the complete file content in write mode and the replacement text in update mode.
- `old_content` contains the exact text matched in update mode.

The native implementation, embedded tool schema, internal `run_scene_edit_script` caller, errors, logs, and tool documentation now use the same names. This removes the ambiguous mix of `content`, `old_string`, and `new_string` that caused models to construct invalid calls.

Closes #90.

## Validation

- `scons target=editor`
- `cargo test --workspace`
- `node -e "JSON.parse(require('fs').readFileSync('local/schemas/tools/write_or_update_file.json','utf8'))"`
- `git diff --check origin/main...HEAD`

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the file editing tool to use clearer `new_content` and `old_content` parameters.
  * Write mode now accepts complete replacement content.
  * Update mode supports exact matching, single replacements, or replacing all matches.

* **Bug Fixes**
  * Added clearer errors when target content is missing or appears multiple times.
  * Improved post-edit reporting, shader refreshes, and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->