### PR TITLE
feat(update): add safe in-editor update and recovery flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ fennara install --project path/to/your-godot-project
 fennara update --project path/to/your-godot-project
 ```
 
+If an interrupted native update prevents the addon from loading, close Godot
+and restore the recorded transaction with the same installed CLI:
+
+```bash
+fennara recover --project path/to/your-godot-project
+```
+
 Your MCP app can point at the global Fennara launcher from anywhere. It does not
 need config files inside the Godot project. Fennara uses the Godot project you
 open in the editor.

--- a/README.md
+++ b/README.md
@@ -121,13 +121,6 @@ fennara install --project path/to/your-godot-project
 fennara update --project path/to/your-godot-project
 ```
 
-If an interrupted native update prevents the addon from loading, close Godot
-and restore the recorded transaction with the same installed CLI:
-
-```bash
-fennara recover --project path/to/your-godot-project
-```
-
 Your MCP app can point at the global Fennara launcher from anywhere. It does not
 need config files inside the Godot project. Fennara uses the Godot project you
 open in the editor.
@@ -221,6 +214,13 @@ output.
 If validation cannot finish, the reopened dock offers **Restore Previous
 Version**, **Open Logs**, and **Copy Report**. Rollback also waits for explicit
 confirmation before closing Godot.
+
+If an interrupted native update prevents the addon from loading, close Godot
+and restore the recorded transaction with the same installed CLI:
+
+```bash
+fennara recover --project path/to/your-godot-project
+```
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,14 @@ fennara doctor
 
 #### 2. Add Fennara To A Godot Project
 
-Run this from the Godot project folder:
+When the chat toolbar shows an available release, select **Prepare Update**.
+Fennara downloads and verifies the update while Godot stays open. After staging
+finishes, choose **Close Godot and Install** or **Not Now**. The external updater
+waits for that exact editor process to exit, replaces the addon using
+same-filesystem directory renames, reopens the same project, and keeps the
+previous addon until the new GDExtension and daemon validate successfully.
+
+The terminal flow remains available:
 
 ```bash
 cd path/to/your-godot-project
@@ -203,6 +210,10 @@ fennara update
 When an update has to replace the running CLI before continuing, Fennara prints
 the updater log path so CI and agent runs can inspect the resumed project-update
 output.
+
+If validation cannot finish, the reopened dock offers **Restore Previous
+Version**, **Open Logs**, and **Copy Report**. Rollback also waits for explicit
+confirmation before closing Godot.
 
 ## Tools
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,13 +39,17 @@ webview after preparation begins.
 
 Verified addon files are staged under
 `.godot/fennara-update/<operation-id>/`. After explicit confirmation, a detached
-CLI waits for the exact Godot PID and start time to disappear. It moves the
-active addon to `previous-addon`, moves the staged addon to `addons/fennara`,
-switches the versioned runtime manifest, and reopens the same editor project.
+CLI waits for the exact Godot PID and start time to disappear. It rechecks a
+digest covering the complete staged addon, snapshots both shared launchers and
+the runtime manifest, moves the active addon to `previous-addon`, moves the
+staged addon to `addons/fennara`, and reopens the same editor project.
 The reopened GDExtension writes an activation handshake. The CLI deletes the
-backup only after that handshake and matching daemon health succeed. Otherwise
-the receipt remains `recovery_required` and the native dock can launch the
-same detached flow to restore the previous addon and runtime manifest.
+backup only after the success receipt, handshake, and matching daemon health
+are durable. Otherwise the receipt remains `recovery_required` and rollback
+restores the previous addon, launchers, and runtime manifest. If interruption
+temporarily leaves the addon unable to load, the installed CLI remains outside
+the project addon and provides `fennara recover --project <path>` as the
+single-addon emergency recovery entry point.
 
 ## In-Editor Chat Webview
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,23 @@ MCP client
 | GDExtension | `fennara-cpp/` | Godot-facing tools, dock UI, diagnostics, validation, runtime capture, and editor integration. |
 | Tool schemas | `local/schemas/tools/` | MCP tool descriptions exposed to clients. |
 
+## Native Update Handoff
+
+The chat UI requests update preparation through the daemon and the bound Godot
+bridge. The native `UpdateCoordinator` launches the installed CLI, follows the
+durable operation state, and presents progress without depending on the
+webview after preparation begins.
+
+Verified addon files are staged under
+`.godot/fennara-update/<operation-id>/`. After explicit confirmation, a detached
+CLI waits for the exact Godot PID and start time to disappear. It moves the
+active addon to `previous-addon`, moves the staged addon to `addons/fennara`,
+switches the versioned runtime manifest, and reopens the same editor project.
+The reopened GDExtension writes an activation handshake. The CLI deletes the
+backup only after that handshake and matching daemon health succeed. Otherwise
+the receipt remains `recovery_required` and the native dock can launch the
+same detached flow to restore the previous addon and runtime manifest.
+
 ## In-Editor Chat Webview
 
 The optional chat dock is hosted by the GDExtension UI layer. The shared host

--- a/docs/release.md
+++ b/docs/release.md
@@ -304,7 +304,7 @@ When release packaging builds the CLI, those templates are compiled into the bin
 
 - `install.ps1` and `install.sh` fetch the latest CLI asset by default.
 - `fennara update` fetches the release manifest from `latest` by default, self-updates the installed CLI when needed, then resolves local/addon/shared runtime assets from it.
-- In-editor updates stage verified assets before shutdown, keep the previous addon and runtime manifest until activation validation succeeds, and require the reopened GDExtension handshake before deleting the rollback copy.
+- In-editor updates stage verified assets before shutdown, recheck the complete staged-addon digest before replacement, keep the previous addon, launchers, and runtime manifest until activation validation succeeds, and require the reopened GDExtension handshake before deleting rollback data.
 - `fennara install` fetches the release manifest from `latest` by default, then resolves local/addon/shared runtime assets from it.
 - The Godot plugin update check compares against GitHub's latest release.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -304,6 +304,7 @@ When release packaging builds the CLI, those templates are compiled into the bin
 
 - `install.ps1` and `install.sh` fetch the latest CLI asset by default.
 - `fennara update` fetches the release manifest from `latest` by default, self-updates the installed CLI when needed, then resolves local/addon/shared runtime assets from it.
+- In-editor updates stage verified assets before shutdown, keep the previous addon and runtime manifest until activation validation succeeds, and require the reopened GDExtension handshake before deleting the rollback copy.
 - `fennara install` fetches the release manifest from `latest` by default, then resolves local/addon/shared runtime assets from it.
 - The Godot plugin update check compares against GitHub's latest release.
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -119,7 +119,8 @@ This is the quick map for contributors and coding agents working in this reposit
 | --- | --- |
 | Add or change a Godot tool | `fennara-cpp/src/tools/` and `local/schemas/tools/` |
 | Change MCP schema text | `local/schemas/tools/` |
-| Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/`; native update staging is owned by `release_update.rs` and `update_stage.rs` |
+| Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/`; native staging and detached apply/rollback are owned by `release_update.rs`, `update_stage.rs`, and `update_apply.rs` |
+| Change native update progress, shutdown confirmation, activation handshake, or recovery | `fennara-cpp/src/update/`, `fennara-cpp/src/ui/update_panel.cpp`, `fennara-cpp/src/ui/dock.cpp`, `local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs`, and `ui/chat/` |
 | Change native first-run setup or CLI bootstrap | `fennara-cpp/src/setup/`, `fennara-cpp/src/ui/setup_panel.cpp`, and `fennara-cpp/src/ui/dock.cpp` |
 | Change install/update operation logs, phases, error codes, or diagnostic reports | `local/crates/fennara-cli/src/operation.rs`, `local/crates/fennara-cli/src/operation/`, and `local/crates/fennara-cli/src/diagnostics.rs` |
 | Change webview prerequisite checks | `local/crates/fennara-cli/src/webview_prereq.rs`, `local/crates/fennara-cli/src/webview_runtime.rs`, and `fennara-cpp/src/ui/webview_host*` |

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -119,7 +119,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | --- | --- |
 | Add or change a Godot tool | `fennara-cpp/src/tools/` and `local/schemas/tools/` |
 | Change MCP schema text | `local/schemas/tools/` |
-| Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/` |
+| Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/`; native update staging is owned by `release_update.rs` and `update_stage.rs` |
 | Change native first-run setup or CLI bootstrap | `fennara-cpp/src/setup/`, `fennara-cpp/src/ui/setup_panel.cpp`, and `fennara-cpp/src/ui/dock.cpp` |
 | Change install/update operation logs, phases, error codes, or diagnostic reports | `local/crates/fennara-cli/src/operation.rs`, `local/crates/fennara-cli/src/operation/`, and `local/crates/fennara-cli/src/diagnostics.rs` |
 | Change webview prerequisite checks | `local/crates/fennara-cli/src/webview_prereq.rs`, `local/crates/fennara-cli/src/webview_runtime.rs`, and `fennara-cpp/src/ui/webview_host*` |

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -119,7 +119,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | --- | --- |
 | Add or change a Godot tool | `fennara-cpp/src/tools/` and `local/schemas/tools/` |
 | Change MCP schema text | `local/schemas/tools/` |
-| Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/`; native staging and detached apply/rollback are owned by `release_update.rs`, `update_stage.rs`, and `update_apply.rs` |
+| Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/`; native staging and detached apply/rollback are owned by `release_update.rs`, `update_stage.rs`, `update_stage/`, and `update_apply/` |
 | Change native update progress, shutdown confirmation, activation handshake, or recovery | `fennara-cpp/src/update/`, `fennara-cpp/src/ui/update_panel.cpp`, `fennara-cpp/src/ui/dock.cpp`, `local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs`, and `ui/chat/` |
 | Change native first-run setup or CLI bootstrap | `fennara-cpp/src/setup/`, `fennara-cpp/src/ui/setup_panel.cpp`, and `fennara-cpp/src/ui/dock.cpp` |
 | Change install/update operation logs, phases, error codes, or diagnostic reports | `local/crates/fennara-cli/src/operation.rs`, `local/crates/fennara-cli/src/operation/`, and `local/crates/fennara-cli/src/diagnostics.rs` |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -272,7 +272,7 @@ fennara update --prepare --project path/to/your-godot-project
 Preparation downloads and verifies manifest-backed release assets, validates
 the packaged addon, and copies it to an operation-specific directory under
 `.godot/fennara-update/`. It records `ready_to_close` only after the staging
-receipt is durable. Preparation does not replace `addons/fennara`, switch
+receipt and a digest covering every staged addon file are durable. Preparation does not replace `addons/fennara`, switch
 `current.json`, or restart the running daemon.
 
 The chat update action runs this preparation command and displays native
@@ -280,13 +280,27 @@ progress in the Godot dock. Once the operation reaches `ready_to_close`, the
 dock asks the user to choose **Close Godot and Install** or **Not Now**. On
 confirmation, a detached CLI waits for the exact Godot process to exit, moves
 the current addon into the operation directory as `previous-addon`, renames the
-verified staged addon into `addons/fennara`, activates the matching runtime,
-and reopens the same executable and project.
+verified staged addon into `addons/fennara`, activates the matching runtime and
+shared launchers, and reopens the same executable and project. Immediately
+before replacement, the CLI recomputes the full staged-addon digest and rejects
+any changed or missing file.
 
-The previous addon and runtime manifest remain available until the reopened
+The previous addon, shared launchers, and runtime manifest remain available until the reopened
 GDExtension writes its activation handshake and the CLI confirms the matching
 daemon. Failed validation records `recovery_required`; the dock then offers
 **Restore Previous Version**, **Open Logs**, and **Copy Report**.
+
+If a machine loses power during the brief addon replacement and the addon
+cannot load far enough to show the recovery panel, close Godot and run:
+
+```bash
+fennara recover --project path/to/your-godot-project
+```
+
+The installed CLI finds the newest interrupted operation, restores its addon,
+shared launchers, and runtime manifest, then reopens the recorded Godot
+executable when it is still available. Pass `--operation <operation-id>` to
+select a specific interrupted operation.
 
 ## Troubleshooting
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -262,7 +262,7 @@ When an update has to replace the running CLI before continuing, Fennara prints
 the updater log path. Use that log to inspect the resumed project-update output
 in CI or agent-driven runs.
 
-The native update flow prepares verified files before asking Godot to close. Its
+The native update flow separates preparation from user-confirmed shutdown. Its
 CLI staging primitive is:
 
 ```bash
@@ -272,8 +272,9 @@ fennara update --prepare --project path/to/your-godot-project
 Preparation downloads and verifies manifest-backed release assets, validates
 the packaged addon, and copies it to an operation-specific directory under
 `.godot/fennara-update/`. It records `ready_to_close` only after the staging
-receipt and a digest covering every staged addon file are durable. Preparation does not replace `addons/fennara`, switch
-`current.json`, or restart the running daemon.
+receipt and a digest covering every staged addon file are durable. Preparation
+does not ask Godot to close, replace `addons/fennara`, switch `current.json`, or
+restart the running daemon.
 
 The chat update action runs this preparation command and displays native
 progress in the Godot dock. Once the operation reaches `ready_to_close`, the

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -262,6 +262,19 @@ When an update has to replace the running CLI before continuing, Fennara prints
 the updater log path. Use that log to inspect the resumed project-update output
 in CI or agent-driven runs.
 
+The native update flow prepares verified files before asking Godot to close. Its
+CLI staging primitive is:
+
+```bash
+fennara update --prepare --project path/to/your-godot-project
+```
+
+Preparation downloads and verifies manifest-backed release assets, validates
+the packaged addon, and copies it to an operation-specific directory under
+`.godot/fennara-update/`. It records `ready_to_close` only after the staging
+receipt is durable. Preparation does not replace `addons/fennara`, switch
+`current.json`, or restart the running daemon.
+
 ## Troubleshooting
 
 ### An Install Or Update Failed

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -275,6 +275,19 @@ the packaged addon, and copies it to an operation-specific directory under
 receipt is durable. Preparation does not replace `addons/fennara`, switch
 `current.json`, or restart the running daemon.
 
+The chat update action runs this preparation command and displays native
+progress in the Godot dock. Once the operation reaches `ready_to_close`, the
+dock asks the user to choose **Close Godot and Install** or **Not Now**. On
+confirmation, a detached CLI waits for the exact Godot process to exit, moves
+the current addon into the operation directory as `previous-addon`, renames the
+verified staged addon into `addons/fennara`, activates the matching runtime,
+and reopens the same executable and project.
+
+The previous addon and runtime manifest remain available until the reopened
+GDExtension writes its activation handshake and the CLI confirms the matching
+daemon. Failed validation records `recovery_required`; the dock then offers
+**Restore Previous Version**, **Open Logs**, and **Copy Report**.
+
 ## Troubleshooting
 
 ### An Install Or Update Failed

--- a/fennara-cpp/include/fennara/local_bridge.hpp
+++ b/fennara-cpp/include/fennara/local_bridge.hpp
@@ -44,7 +44,6 @@ public:
                                    const godot::String &text);
 
 private:
-    static constexpr const char *LOCAL_DAEMON_WS_URL = "ws://127.0.0.1:41287/godot/ws";
     static constexpr double RECONNECT_DELAY_SECONDS = 2.0;
     static constexpr int LOCAL_BRIDGE_WS_BUFFER_SIZE_BYTES = 16 * 1024 * 1024;
 

--- a/fennara-cpp/include/fennara/local_bridge.hpp
+++ b/fennara-cpp/include/fennara/local_bridge.hpp
@@ -44,6 +44,7 @@ public:
                                    const godot::String &text);
 
 private:
+    static constexpr const char *LOCAL_DAEMON_WS_URL = "ws://127.0.0.1:41287/godot/ws";
     static constexpr double RECONNECT_DELAY_SECONDS = 2.0;
     static constexpr int LOCAL_BRIDGE_WS_BUFFER_SIZE_BYTES = 16 * 1024 * 1024;
 

--- a/fennara-cpp/include/fennara/ui/dock.hpp
+++ b/fennara-cpp/include/fennara/ui/dock.hpp
@@ -14,6 +14,8 @@ class FennaraLocalBridge;
 class FirstRunSetup;
 class FirstRunSetupPanel;
 class WebviewHost;
+class UpdateCoordinator;
+class UpdatePanel;
 
 class FennaraDock : public godot::Control {
     GDCLASS(FennaraDock, godot::Control)
@@ -30,6 +32,8 @@ private:
     godot::Control *browser_fallback_panel = nullptr;
     FirstRunSetup *first_run_setup = nullptr;
     FirstRunSetupPanel *setup_panel = nullptr;
+    UpdateCoordinator *update_coordinator = nullptr;
+    UpdatePanel *update_panel = nullptr;
     godot::Label *browser_fallback_message = nullptr;
     godot::Label *browser_restart_label = nullptr;
     godot::Button *open_browser_button = nullptr;
@@ -53,6 +57,7 @@ private:
     void _refresh_status();
     void _on_mcp_target_state_changed(bool active);
     void _on_setup_succeeded();
+    void _on_update_requested();
     void _on_open_browser_pressed();
     void _on_use_embedded_toggled(bool pressed);
     godot::String _chat_url() const;
@@ -61,6 +66,7 @@ private:
     bool _save_chat_surface(const godot::String &surface) const;
     void _show_browser_fallback(const godot::String &message);
     bool _show_setup_if_needed();
+    bool _show_update_if_needed();
     bool _webview_region_is_stable();
     void _output_log(const godot::String &message) const;
 

--- a/fennara-cpp/include/fennara/ui/update_panel.hpp
+++ b/fennara-cpp/include/fennara/ui/update_panel.hpp
@@ -5,6 +5,10 @@
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/label.hpp>
 
+namespace godot {
+class ProgressBar;
+}
+
 namespace fennara {
 
 class UpdateCoordinator;
@@ -25,6 +29,9 @@ private:
     godot::Label *title_label = nullptr;
     godot::Label *status_label = nullptr;
     godot::Label *error_label = nullptr;
+    godot::Label *operation_label = nullptr;
+    godot::Label *action_label = nullptr;
+    godot::ProgressBar *progress = nullptr;
     godot::Button *close_button = nullptr;
     godot::Button *not_now_button = nullptr;
     godot::Button *retry_button = nullptr;
@@ -40,6 +47,7 @@ private:
     void _on_close_confirmed();
     void _on_restore_pressed();
     void _on_restore_confirmed();
+    void _on_copy_report_pressed();
 };
 
 } // namespace fennara

--- a/fennara-cpp/include/fennara/ui/update_panel.hpp
+++ b/fennara-cpp/include/fennara/ui/update_panel.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/confirmation_dialog.hpp>
+#include <godot_cpp/classes/control.hpp>
+#include <godot_cpp/classes/label.hpp>
+
+namespace fennara {
+
+class UpdateCoordinator;
+
+class UpdatePanel : public godot::Control {
+    GDCLASS(UpdatePanel, godot::Control)
+
+public:
+    void _ready() override;
+    void set_coordinator(UpdateCoordinator *value);
+    void refresh();
+
+protected:
+    static void _bind_methods();
+
+private:
+    UpdateCoordinator *coordinator = nullptr;
+    godot::Label *title_label = nullptr;
+    godot::Label *status_label = nullptr;
+    godot::Label *error_label = nullptr;
+    godot::Button *close_button = nullptr;
+    godot::Button *not_now_button = nullptr;
+    godot::Button *retry_button = nullptr;
+    godot::Button *restore_button = nullptr;
+    godot::Button *cancel_button = nullptr;
+    godot::Button *copy_button = nullptr;
+    godot::Button *logs_button = nullptr;
+    godot::ConfirmationDialog *close_confirmation = nullptr;
+    godot::ConfirmationDialog *restore_confirmation = nullptr;
+
+    void _build_ui();
+    void _on_close_pressed();
+    void _on_close_confirmed();
+    void _on_restore_pressed();
+    void _on_restore_confirmed();
+};
+
+} // namespace fennara

--- a/fennara-cpp/include/fennara/update/update_coordinator.hpp
+++ b/fennara-cpp/include/fennara/update/update_coordinator.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+namespace fennara {
+
+class UpdateCoordinator : public godot::Node {
+    GDCLASS(UpdateCoordinator, godot::Node)
+
+public:
+    enum class Step {
+        Idle,
+        Preparing,
+        ReadyToClose,
+        WaitingForGodot,
+        Failed,
+        RecoveryRequired,
+    };
+
+    UpdateCoordinator() = default;
+
+    void _ready() override;
+    void _process(double delta) override;
+
+    void start_prepare();
+    void confirm_close_and_install();
+    void restore_previous_version();
+    void dismiss();
+    void retry();
+    void cancel_waiting();
+    void copy_report();
+    void open_logs();
+
+    bool should_show() const;
+    bool is_preparing() const;
+    bool is_ready_to_close() const;
+    bool is_waiting_for_godot() const;
+    bool has_failed() const;
+    bool needs_recovery() const;
+    godot::String get_status() const;
+    godot::String get_detail() const;
+    godot::String get_error_code() const;
+    godot::String get_operation_id() const;
+    godot::String get_target_version() const;
+
+protected:
+    static void _bind_methods();
+
+private:
+    Step step = Step::Idle;
+    godot::String status_text;
+    godot::String detail_text;
+    godot::String error_code;
+    godot::String operation_id;
+    godot::String target_version;
+    godot::String staging_root;
+    int64_t child_pid = -1;
+    double poll_timer = 0.0;
+    bool dismissed = false;
+
+    godot::String _project_path() const;
+    godot::String _update_root() const;
+    godot::String _receipt_path() const;
+    godot::Dictionary _read_operation() const;
+    godot::Dictionary _read_receipt(const godot::String &root) const;
+    void _poll_operation();
+    void _scan_pending_updates();
+    void _write_activation_handshake(const godot::String &root,
+                                     const godot::Dictionary &receipt) const;
+    bool _launch_completion(const godot::String &command);
+    void _request_editor_close();
+    void _set_step(Step next, const godot::String &status, const godot::String &detail);
+    void _fail(const godot::String &code, const godot::String &message);
+};
+
+} // namespace fennara

--- a/fennara-cpp/src/addon_access.cpp
+++ b/fennara-cpp/src/addon_access.cpp
@@ -23,7 +23,11 @@ godot::Array load_allowed_roots() {
         return godot::Array();
     }
 
-    godot::Variant parsed = godot::JSON::parse_string(file->get_as_text());
+    const godot::String contents = file->get_as_text().strip_edges();
+    if (contents.is_empty()) {
+        return godot::Array();
+    }
+    godot::Variant parsed = godot::JSON::parse_string(contents);
     if (parsed.get_type() != godot::Variant::DICTIONARY) {
         return godot::Array();
     }

--- a/fennara-cpp/src/app_paths.cpp
+++ b/fennara-cpp/src/app_paths.cpp
@@ -200,7 +200,11 @@ godot::Dictionary read_json_first_existing(const godot::PackedStringArray &paths
             continue;
         }
 
-        godot::Variant parsed = godot::JSON::parse_string(file->get_as_text());
+        const godot::String contents = file->get_as_text().strip_edges();
+        if (contents.is_empty()) {
+            continue;
+        }
+        godot::Variant parsed = godot::JSON::parse_string(contents);
         if (parsed.get_type() != godot::Variant::DICTIONARY) {
             continue;
         }

--- a/fennara-cpp/src/control_auth.cpp
+++ b/fennara-cpp/src/control_auth.cpp
@@ -45,7 +45,8 @@ godot::Dictionary request_json(godot::HTTPClient::Method method,
     }
     godot::Ref<godot::HTTPClient> http;
     http.instantiate();
-    if (http.is_null() || http->connect_to_host(kDaemonHost, kDaemonPort) != godot::OK) {
+    if (http.is_null() ||
+        http->connect_to_host(kDaemonHost, kDaemonPort) != godot::OK) {
         return godot::Dictionary();
     }
 
@@ -79,12 +80,20 @@ godot::Dictionary request_json(godot::HTTPClient::Method method,
                 }
                 response_body += chunk.get_string_from_utf8();
             }
-            if (http->get_status() != godot::HTTPClient::STATUS_BODY && http->has_response()) {
+            const int64_t response_length = http->get_response_body_length();
+            if (response_length >= 0 &&
+                response_body.to_utf8_buffer().size() >= response_length) {
                 break;
             }
         } else if (request_sent && status == godot::HTTPClient::STATUS_CONNECTED &&
                    http->has_response()) {
-            break;
+            const int64_t response_length = http->get_response_body_length();
+            if (response_length == 0 ||
+                (response_length > 0 &&
+                 response_body.to_utf8_buffer().size() >= response_length) ||
+                (response_length < 0 && !response_body.is_empty())) {
+                break;
+            }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
@@ -92,7 +101,11 @@ godot::Dictionary request_json(godot::HTTPClient::Method method,
         return godot::Dictionary();
     }
 
-    const godot::Variant parsed = godot::JSON::parse_string(response_body);
+    const godot::String response_json = response_body.strip_edges();
+    if (response_json.is_empty()) {
+        return godot::Dictionary();
+    }
+    const godot::Variant parsed = godot::JSON::parse_string(response_json);
     if (parsed.get_type() != godot::Variant::DICTIONARY) {
         return godot::Dictionary();
     }

--- a/fennara-cpp/src/local_bridge/local_bridge.cpp
+++ b/fennara-cpp/src/local_bridge/local_bridge.cpp
@@ -103,7 +103,11 @@ void FennaraLocalBridge::_process(double delta) {
                 continue;
             }
 
-            godot::Variant parsed = godot::JSON::parse_string(packet.get_string_from_utf8());
+            const godot::String message = packet.get_string_from_utf8().strip_edges();
+            if (message.is_empty()) {
+                continue;
+            }
+            godot::Variant parsed = godot::JSON::parse_string(message);
             if (parsed.get_type() != godot::Variant::DICTIONARY) {
                 continue;
             }
@@ -202,7 +206,8 @@ void FennaraLocalBridge::_connect_socket() {
     headers.append(control_header);
     _ws->set_handshake_headers(headers);
 
-    godot::Error err = _ws->connect_to_url(LOCAL_DAEMON_WS_URL);
+    const godot::String daemon_url = "ws://127.0.0.1:41287/godot/ws";
+    godot::Error err = _ws->connect_to_url(daemon_url);
     if (err != godot::OK) {
         FLOG_NET("Local bridge daemon unavailable");
         _ws.unref();

--- a/fennara-cpp/src/local_bridge/local_bridge.cpp
+++ b/fennara-cpp/src/local_bridge/local_bridge.cpp
@@ -206,8 +206,7 @@ void FennaraLocalBridge::_connect_socket() {
     headers.append(control_header);
     _ws->set_handshake_headers(headers);
 
-    const godot::String daemon_url = "ws://127.0.0.1:41287/godot/ws";
-    godot::Error err = _ws->connect_to_url(daemon_url);
+    godot::Error err = _ws->connect_to_url(LOCAL_DAEMON_WS_URL);
     if (err != godot::OK) {
         FLOG_NET("Local bridge daemon unavailable");
         _ws.unref();

--- a/fennara-cpp/src/local_bridge/local_bridge.cpp
+++ b/fennara-cpp/src/local_bridge/local_bridge.cpp
@@ -18,6 +18,7 @@ void FennaraLocalBridge::_bind_methods() {
     ADD_SIGNAL(godot::MethodInfo(
         "mcp_target_state_changed",
         godot::PropertyInfo(godot::Variant::BOOL, "active")));
+    ADD_SIGNAL(godot::MethodInfo("fennara_update_requested"));
     godot::ClassDB::bind_method(
         godot::D_METHOD("_on_async_tool_call_completed", "results", "request_id", "tool_name", "input", "started_at_ms", "executor"),
         &FennaraLocalBridge::_on_async_tool_call_completed);

--- a/fennara-cpp/src/local_bridge/tool_calls.cpp
+++ b/fennara-cpp/src/local_bridge/tool_calls.cpp
@@ -334,6 +334,8 @@ void FennaraLocalBridge::_handle_message(const godot::Dictionary &message) {
         _handle_snapshot_revert(message);
     } else if (type == "open_project_file") {
         _handle_open_project_file(message);
+    } else if (type == "prepare_fennara_update") {
+        emit_signal("fennara_update_requested");
     } else if (type == "active_project_changed") {
         bool active = message.get("is_active", false);
         _active_mcp_target_name = godot::String(message.get("active_project_name", "")).strip_edges();

--- a/fennara-cpp/src/register_types.cpp
+++ b/fennara-cpp/src/register_types.cpp
@@ -20,10 +20,12 @@
 #include "fennara/snapshot_manager.hpp"
 #include "fennara/setup/first_run_setup.hpp"
 #include "fennara/warning_capture.hpp"
+#include "fennara/update/update_coordinator.hpp"
 
 #include "fennara/ui/dock.hpp"
 #include "fennara/ui/fennara_plugin.hpp"
 #include "fennara/ui/setup_panel.hpp"
+#include "fennara/ui/update_panel.hpp"
 #include "fennara/ui/script_context_menu.hpp"
 
 #include <gdextension_interface.h>
@@ -55,9 +57,11 @@ void initialize_fennara(godot::ModuleInitializationLevel p_level) {
         godot::ClassDB::register_class<fennara::FennaraSnapshotManager>();
         godot::ClassDB::register_class<fennara::FennaraWarningCapture>();
         godot::ClassDB::register_class<fennara::FirstRunSetup>();
+        godot::ClassDB::register_class<fennara::UpdateCoordinator>();
 
         godot::ClassDB::register_class<fennara::FennaraDock>();
         godot::ClassDB::register_class<fennara::FirstRunSetupPanel>();
+        godot::ClassDB::register_class<fennara::UpdatePanel>();
     }
 
     if (p_level == godot::MODULE_INITIALIZATION_LEVEL_EDITOR) {

--- a/fennara-cpp/src/setup/first_run_lock.cpp
+++ b/fennara-cpp/src/setup/first_run_lock.cpp
@@ -60,11 +60,13 @@ bool FirstRunSetup::_try_acquire_lock() {
     }
 
     const godot::String owner_path = lock_owner_path(bootstrap_lock_path);
-    const godot::Variant parsed =
-        godot::JSON::parse_string(godot::FileAccess::get_file_as_string(owner_path));
     int32_t owner_pid = -1;
-    if (parsed.get_type() == godot::Variant::DICTIONARY) {
-        owner_pid = static_cast<int32_t>((int64_t)godot::Dictionary(parsed).get("pid", -1));
+    if (godot::FileAccess::file_exists(owner_path)) {
+        const godot::Variant parsed =
+            godot::JSON::parse_string(godot::FileAccess::get_file_as_string(owner_path));
+        if (parsed.get_type() == godot::Variant::DICTIONARY) {
+            owner_pid = static_cast<int32_t>((int64_t)godot::Dictionary(parsed).get("pid", -1));
+        }
     }
     godot::OS *os = godot::OS::get_singleton();
     if (os != nullptr && owner_pid > 0 && os->is_process_running(owner_pid)) {

--- a/fennara-cpp/src/setup/first_run_operation.cpp
+++ b/fennara-cpp/src/setup/first_run_operation.cpp
@@ -144,8 +144,12 @@ godot::Dictionary FirstRunSetup::_find_install_operation() const {
     if (dir.is_empty() || operation_id.is_empty()) {
         return godot::Dictionary();
     }
-    const godot::Variant parsed = godot::JSON::parse_string(godot::FileAccess::get_file_as_string(
-        dir.path_join(operation_id + godot::String(".json"))));
+    const godot::String path = dir.path_join(operation_id + godot::String(".json"));
+    if (!godot::FileAccess::file_exists(path)) {
+        return godot::Dictionary();
+    }
+    const godot::Variant parsed =
+        godot::JSON::parse_string(godot::FileAccess::get_file_as_string(path));
     if (parsed.get_type() != godot::Variant::DICTIONARY) {
         return godot::Dictionary();
     }

--- a/fennara-cpp/src/ui/dock.cpp
+++ b/fennara-cpp/src/ui/dock.cpp
@@ -5,7 +5,9 @@
 #include "fennara/logger.hpp"
 #include "fennara/setup/first_run_setup.hpp"
 #include "fennara/ui/setup_panel.hpp"
+#include "fennara/ui/update_panel.hpp"
 #include "fennara/ui/webview_host.hpp"
+#include "fennara/update/update_coordinator.hpp"
 
 #include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/input_event_key.hpp>
@@ -51,6 +53,9 @@ void FennaraDock::_bind_methods() {
     godot::ClassDB::bind_method(
         godot::D_METHOD("_on_setup_succeeded"),
         &FennaraDock::_on_setup_succeeded);
+    godot::ClassDB::bind_method(
+        godot::D_METHOD("_on_update_requested"),
+        &FennaraDock::_on_update_requested);
     godot::ClassDB::bind_method(
         godot::D_METHOD("_on_open_browser_pressed"),
         &FennaraDock::_on_open_browser_pressed);
@@ -237,6 +242,12 @@ void FennaraDock::_build_ui() {
             margin->move_child(browser_fallback_panel, margin->get_child_count() - 1);
         }
     }
+    if (local_bridge &&
+        !local_bridge->is_connected("fennara_update_requested",
+                                    callable_mp(this, &FennaraDock::_on_update_requested))) {
+        local_bridge->connect("fennara_update_requested",
+                              callable_mp(this, &FennaraDock::_on_update_requested));
+    }
 
     first_run_setup = memnew(FirstRunSetup);
     first_run_setup->set_name("FirstRunSetup");
@@ -251,6 +262,19 @@ void FennaraDock::_build_ui() {
     setup_panel->set_visible(false);
     margin->add_child(setup_panel);
     margin->move_child(setup_panel, margin->get_child_count() - 1);
+
+    update_coordinator = memnew(UpdateCoordinator);
+    update_coordinator->set_name("UpdateCoordinator");
+    add_child(update_coordinator);
+    update_coordinator->connect("state_changed",
+                                callable_mp(this, &FennaraDock::_refresh_status));
+
+    update_panel = memnew(UpdatePanel);
+    update_panel->set_name("UpdatePanel");
+    update_panel->set_coordinator(update_coordinator);
+    update_panel->set_visible(false);
+    margin->add_child(update_panel);
+    margin->move_child(update_panel, margin->get_child_count() - 1);
 }
 
 void FennaraDock::_try_start_webview() {
@@ -329,10 +353,31 @@ void FennaraDock::_refresh_status() {
     if (fallback_label == nullptr) {
         return;
     }
-    if (_show_setup_if_needed()) {
+    if (_show_update_if_needed() || _show_setup_if_needed()) {
         return;
     }
     _try_start_webview();
+}
+
+bool FennaraDock::_show_update_if_needed() {
+    if (update_coordinator == nullptr || update_panel == nullptr) {
+        return false;
+    }
+    const bool visible = update_coordinator->should_show();
+    update_panel->set_visible(visible);
+    if (visible) {
+        _release_webview_keyboard_focus();
+        if (internal_webview_surface != nullptr) {
+            internal_webview_surface->set_visible(false);
+        }
+        if (fallback_label != nullptr) {
+            fallback_label->set_visible(false);
+        }
+        if (browser_fallback_panel != nullptr) {
+            browser_fallback_panel->set_visible(false);
+        }
+    }
+    return visible;
 }
 
 bool FennaraDock::_show_setup_if_needed() {
@@ -403,6 +448,12 @@ void FennaraDock::_on_mcp_target_state_changed(bool active) {
 
 void FennaraDock::_on_setup_succeeded() {
     _refresh_status();
+}
+
+void FennaraDock::_on_update_requested() {
+    if (update_coordinator != nullptr) {
+        update_coordinator->start_prepare();
+    }
 }
 
 void FennaraDock::_on_open_browser_pressed() {

--- a/fennara-cpp/src/ui/dock.cpp
+++ b/fennara-cpp/src/ui/dock.cpp
@@ -155,10 +155,16 @@ void FennaraDock::_sync_webview_bounds() {
         return;
     }
 
-    webview_host->resize_to(webview_region ? webview_region : this);
-    if (webview_host->uses_internal_surface()) {
-        webview_host->set_visible(true);
+    const bool native_panel_visible =
+        (update_panel != nullptr && update_panel->is_visible()) ||
+        (setup_panel != nullptr && setup_panel->is_visible());
+    if (native_panel_visible) {
+        webview_host->set_visible(false);
+        return;
     }
+
+    webview_host->resize_to(webview_region ? webview_region : this);
+    webview_host->set_visible(true);
 }
 
 void FennaraDock::_build_ui() {
@@ -367,6 +373,9 @@ bool FennaraDock::_show_update_if_needed() {
     update_panel->set_visible(visible);
     if (visible) {
         _release_webview_keyboard_focus();
+        if (webview_host != nullptr && webview_host->is_started()) {
+            webview_host->set_visible(false);
+        }
         if (internal_webview_surface != nullptr) {
             internal_webview_surface->set_visible(false);
         }
@@ -395,6 +404,9 @@ bool FennaraDock::_show_setup_if_needed() {
     setup_panel->set_visible(visible);
     if (visible) {
         _release_webview_keyboard_focus();
+        if (webview_host != nullptr && webview_host->is_started()) {
+            webview_host->set_visible(false);
+        }
         if (internal_webview_surface != nullptr) {
             internal_webview_surface->set_visible(false);
         }

--- a/fennara-cpp/src/ui/update_panel.cpp
+++ b/fennara-cpp/src/ui/update_panel.cpp
@@ -4,6 +4,8 @@
 
 #include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/margin_container.hpp>
+#include <godot_cpp/classes/panel_container.hpp>
+#include <godot_cpp/classes/progress_bar.hpp>
 #include <godot_cpp/classes/v_box_container.hpp>
 #include <godot_cpp/core/class_db.hpp>
 
@@ -19,6 +21,8 @@ void UpdatePanel::_bind_methods() {
                                 &UpdatePanel::_on_restore_pressed);
     godot::ClassDB::bind_method(godot::D_METHOD("_on_restore_confirmed"),
                                 &UpdatePanel::_on_restore_confirmed);
+    godot::ClassDB::bind_method(godot::D_METHOD("_on_copy_report_pressed"),
+                                &UpdatePanel::_on_copy_report_pressed);
 }
 
 void UpdatePanel::_ready() {
@@ -45,13 +49,18 @@ void UpdatePanel::_build_ui() {
     set_h_size_flags(godot::Control::SIZE_EXPAND_FILL);
     set_v_size_flags(godot::Control::SIZE_EXPAND_FILL);
 
+    godot::PanelContainer *panel = memnew(godot::PanelContainer);
+    panel->set_anchors_preset(godot::Control::PRESET_FULL_RECT);
+    panel->set_h_size_flags(godot::Control::SIZE_EXPAND_FILL);
+    panel->set_v_size_flags(godot::Control::SIZE_EXPAND_FILL);
+    add_child(panel);
+
     godot::MarginContainer *margin = memnew(godot::MarginContainer);
-    margin->set_anchors_preset(godot::Control::PRESET_FULL_RECT);
     margin->add_theme_constant_override("margin_left", 28);
     margin->add_theme_constant_override("margin_right", 28);
     margin->add_theme_constant_override("margin_top", 40);
     margin->add_theme_constant_override("margin_bottom", 28);
-    add_child(margin);
+    panel->add_child(margin);
 
     godot::VBoxContainer *content = memnew(godot::VBoxContainer);
     content->set_alignment(godot::BoxContainer::ALIGNMENT_CENTER);
@@ -69,6 +78,18 @@ void UpdatePanel::_build_ui() {
     status_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
     content->add_child(status_label);
 
+    progress = memnew(godot::ProgressBar);
+    progress->set_indeterminate(true);
+    progress->set_show_percentage(false);
+    progress->set_custom_minimum_size(godot::Vector2(280, 8));
+    progress->set_h_size_flags(godot::Control::SIZE_EXPAND_FILL);
+    content->add_child(progress);
+
+    operation_label = memnew(godot::Label);
+    operation_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
+    operation_label->add_theme_color_override("font_color", godot::Color("#8fa3b8"));
+    content->add_child(operation_label);
+
     error_label = memnew(godot::Label);
     error_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
     error_label->add_theme_color_override("font_color", godot::Color("#ff8585"));
@@ -80,7 +101,7 @@ void UpdatePanel::_build_ui() {
     content->add_child(primary);
 
     close_button = memnew(godot::Button);
-    close_button->set_text("Close Godot and Install");
+    close_button->set_text("Install Update...");
     close_button->connect("pressed", callable_mp(this, &UpdatePanel::_on_close_pressed));
     primary->add_child(close_button);
 
@@ -111,13 +132,18 @@ void UpdatePanel::_build_ui() {
 
     copy_button = memnew(godot::Button);
     copy_button->set_text("Copy Report");
-    copy_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::copy_report));
+    copy_button->connect("pressed", callable_mp(this, &UpdatePanel::_on_copy_report_pressed));
     diagnostics->add_child(copy_button);
 
     logs_button = memnew(godot::Button);
     logs_button->set_text("Open Logs");
     logs_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::open_logs));
     diagnostics->add_child(logs_button);
+
+    action_label = memnew(godot::Label);
+    action_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
+    action_label->add_theme_color_override("font_color", godot::Color("#8fc79f"));
+    content->add_child(action_label);
 
     close_confirmation = memnew(godot::ConfirmationDialog);
     close_confirmation->set_title("Close Godot and install Fennara?");
@@ -141,7 +167,20 @@ void UpdatePanel::refresh() {
     if (coordinator == nullptr || title_label == nullptr) {
         return;
     }
+    if (coordinator->is_preparing()) {
+        title_label->set_text("Preparing Fennara update");
+    } else if (coordinator->is_ready_to_close()) {
+        title_label->set_text("Ready to install Fennara");
+    } else if (coordinator->is_waiting_for_godot()) {
+        title_label->set_text("Installing Fennara update");
+    } else {
+        title_label->set_text("Update Fennara");
+    }
     status_label->set_text(coordinator->get_status() + "\n\n" + coordinator->get_detail());
+    progress->set_visible(coordinator->is_preparing() || coordinator->is_waiting_for_godot());
+    const godot::String operation = coordinator->get_operation_id();
+    operation_label->set_visible(!operation.is_empty());
+    operation_label->set_text(operation.is_empty() ? godot::String() : "Operation: " + operation);
     error_label->set_text(coordinator->get_error_code().is_empty()
                               ? godot::String()
                               : "Error: " + coordinator->get_error_code());
@@ -153,11 +192,18 @@ void UpdatePanel::refresh() {
     const bool diagnostics = coordinator->has_failed() || coordinator->needs_recovery();
     copy_button->set_visible(diagnostics);
     logs_button->set_visible(diagnostics);
+    if (!diagnostics) {
+        action_label->set_text("");
+    }
 }
 
 void UpdatePanel::_on_close_pressed() { close_confirmation->popup_centered(); }
 void UpdatePanel::_on_close_confirmed() { coordinator->confirm_close_and_install(); }
 void UpdatePanel::_on_restore_pressed() { restore_confirmation->popup_centered(); }
 void UpdatePanel::_on_restore_confirmed() { coordinator->restore_previous_version(); }
+void UpdatePanel::_on_copy_report_pressed() {
+    coordinator->copy_report();
+    action_label->set_text("Sanitized update report copied.");
+}
 
 } // namespace fennara

--- a/fennara-cpp/src/ui/update_panel.cpp
+++ b/fennara-cpp/src/ui/update_panel.cpp
@@ -1,0 +1,163 @@
+#include "fennara/ui/update_panel.hpp"
+
+#include "fennara/update/update_coordinator.hpp"
+
+#include <godot_cpp/classes/h_box_container.hpp>
+#include <godot_cpp/classes/margin_container.hpp>
+#include <godot_cpp/classes/v_box_container.hpp>
+#include <godot_cpp/core/class_db.hpp>
+
+namespace fennara {
+
+void UpdatePanel::_bind_methods() {
+    godot::ClassDB::bind_method(godot::D_METHOD("refresh"), &UpdatePanel::refresh);
+    godot::ClassDB::bind_method(godot::D_METHOD("_on_close_pressed"),
+                                &UpdatePanel::_on_close_pressed);
+    godot::ClassDB::bind_method(godot::D_METHOD("_on_close_confirmed"),
+                                &UpdatePanel::_on_close_confirmed);
+    godot::ClassDB::bind_method(godot::D_METHOD("_on_restore_pressed"),
+                                &UpdatePanel::_on_restore_pressed);
+    godot::ClassDB::bind_method(godot::D_METHOD("_on_restore_confirmed"),
+                                &UpdatePanel::_on_restore_confirmed);
+}
+
+void UpdatePanel::_ready() {
+    _build_ui();
+    refresh();
+}
+
+void UpdatePanel::set_coordinator(UpdateCoordinator *value) {
+    if (coordinator != nullptr) {
+        const godot::Callable callback = callable_mp(this, &UpdatePanel::refresh);
+        if (coordinator->is_connected("state_changed", callback)) {
+            coordinator->disconnect("state_changed", callback);
+        }
+    }
+    coordinator = value;
+    if (coordinator != nullptr) {
+        coordinator->connect("state_changed", callable_mp(this, &UpdatePanel::refresh));
+    }
+    refresh();
+}
+
+void UpdatePanel::_build_ui() {
+    set_anchors_preset(godot::Control::PRESET_FULL_RECT);
+    set_h_size_flags(godot::Control::SIZE_EXPAND_FILL);
+    set_v_size_flags(godot::Control::SIZE_EXPAND_FILL);
+
+    godot::MarginContainer *margin = memnew(godot::MarginContainer);
+    margin->set_anchors_preset(godot::Control::PRESET_FULL_RECT);
+    margin->add_theme_constant_override("margin_left", 28);
+    margin->add_theme_constant_override("margin_right", 28);
+    margin->add_theme_constant_override("margin_top", 40);
+    margin->add_theme_constant_override("margin_bottom", 28);
+    add_child(margin);
+
+    godot::VBoxContainer *content = memnew(godot::VBoxContainer);
+    content->set_alignment(godot::BoxContainer::ALIGNMENT_CENTER);
+    content->add_theme_constant_override("separation", 14);
+    margin->add_child(content);
+
+    title_label = memnew(godot::Label);
+    title_label->set_text("Update Fennara");
+    title_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
+    title_label->add_theme_font_size_override("font_size", 22);
+    content->add_child(title_label);
+
+    status_label = memnew(godot::Label);
+    status_label->set_autowrap_mode(godot::TextServer::AUTOWRAP_WORD_SMART);
+    status_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
+    content->add_child(status_label);
+
+    error_label = memnew(godot::Label);
+    error_label->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
+    error_label->add_theme_color_override("font_color", godot::Color("#ff8585"));
+    content->add_child(error_label);
+
+    godot::HBoxContainer *primary = memnew(godot::HBoxContainer);
+    primary->set_alignment(godot::BoxContainer::ALIGNMENT_CENTER);
+    primary->add_theme_constant_override("separation", 8);
+    content->add_child(primary);
+
+    close_button = memnew(godot::Button);
+    close_button->set_text("Close Godot and Install");
+    close_button->connect("pressed", callable_mp(this, &UpdatePanel::_on_close_pressed));
+    primary->add_child(close_button);
+
+    not_now_button = memnew(godot::Button);
+    not_now_button->set_text("Not Now");
+    not_now_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::dismiss));
+    primary->add_child(not_now_button);
+
+    retry_button = memnew(godot::Button);
+    retry_button->set_text("Retry");
+    retry_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::retry));
+    primary->add_child(retry_button);
+
+    restore_button = memnew(godot::Button);
+    restore_button->set_text("Restore Previous Version");
+    restore_button->connect("pressed", callable_mp(this, &UpdatePanel::_on_restore_pressed));
+    primary->add_child(restore_button);
+
+    cancel_button = memnew(godot::Button);
+    cancel_button->set_text("Cancel");
+    cancel_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::cancel_waiting));
+    primary->add_child(cancel_button);
+
+    godot::HBoxContainer *diagnostics = memnew(godot::HBoxContainer);
+    diagnostics->set_alignment(godot::BoxContainer::ALIGNMENT_CENTER);
+    diagnostics->add_theme_constant_override("separation", 8);
+    content->add_child(diagnostics);
+
+    copy_button = memnew(godot::Button);
+    copy_button->set_text("Copy Report");
+    copy_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::copy_report));
+    diagnostics->add_child(copy_button);
+
+    logs_button = memnew(godot::Button);
+    logs_button->set_text("Open Logs");
+    logs_button->connect("pressed", callable_mp(coordinator, &UpdateCoordinator::open_logs));
+    diagnostics->add_child(logs_button);
+
+    close_confirmation = memnew(godot::ConfirmationDialog);
+    close_confirmation->set_title("Close Godot and install Fennara?");
+    close_confirmation->set_text(
+        "Godot will handle unsaved-work confirmation normally. The verified update will only be installed after this editor process exits.");
+    close_confirmation->get_ok_button()->set_text("Close Godot and Install");
+    close_confirmation->connect("confirmed", callable_mp(this, &UpdatePanel::_on_close_confirmed));
+    add_child(close_confirmation);
+
+    restore_confirmation = memnew(godot::ConfirmationDialog);
+    restore_confirmation->set_title("Restore the previous Fennara version?");
+    restore_confirmation->set_text(
+        "Godot must close briefly so the external updater can restore the saved addon and runtime selection.");
+    restore_confirmation->get_ok_button()->set_text("Close Godot and Restore");
+    restore_confirmation->connect("confirmed",
+                                  callable_mp(this, &UpdatePanel::_on_restore_confirmed));
+    add_child(restore_confirmation);
+}
+
+void UpdatePanel::refresh() {
+    if (coordinator == nullptr || title_label == nullptr) {
+        return;
+    }
+    status_label->set_text(coordinator->get_status() + "\n\n" + coordinator->get_detail());
+    error_label->set_text(coordinator->get_error_code().is_empty()
+                              ? godot::String()
+                              : "Error: " + coordinator->get_error_code());
+    close_button->set_visible(coordinator->is_ready_to_close());
+    not_now_button->set_visible(coordinator->is_ready_to_close());
+    retry_button->set_visible(coordinator->has_failed());
+    restore_button->set_visible(coordinator->needs_recovery());
+    cancel_button->set_visible(coordinator->is_waiting_for_godot());
+    const bool diagnostics = coordinator->has_failed() || coordinator->needs_recovery();
+    copy_button->set_visible(diagnostics);
+    logs_button->set_visible(diagnostics);
+}
+
+void UpdatePanel::_on_close_pressed() { close_confirmation->popup_centered(); }
+void UpdatePanel::_on_close_confirmed() { coordinator->confirm_close_and_install(); }
+void UpdatePanel::_on_restore_pressed() { restore_confirmation->popup_centered(); }
+void UpdatePanel::_on_restore_confirmed() { coordinator->restore_previous_version(); }
+
+} // namespace fennara

--- a/fennara-cpp/src/update/update_coordinator.cpp
+++ b/fennara-cpp/src/update/update_coordinator.cpp
@@ -1,0 +1,246 @@
+#include "fennara/update/update_coordinator.hpp"
+
+#include "fennara/app_paths.hpp"
+#include "fennara/logger.hpp"
+#include "fennara/update_notice.hpp"
+
+#include <godot_cpp/classes/display_server.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/scene_tree.hpp>
+#include <godot_cpp/classes/time.hpp>
+#include <godot_cpp/classes/window.hpp>
+#include <godot_cpp/core/class_db.hpp>
+
+namespace fennara {
+namespace {
+
+constexpr double kPollSeconds = 0.25;
+
+} // namespace
+
+void UpdateCoordinator::_bind_methods() {
+    ADD_SIGNAL(godot::MethodInfo("state_changed"));
+    godot::ClassDB::bind_method(godot::D_METHOD("start_prepare"),
+                                &UpdateCoordinator::start_prepare);
+    godot::ClassDB::bind_method(godot::D_METHOD("confirm_close_and_install"),
+                                &UpdateCoordinator::confirm_close_and_install);
+    godot::ClassDB::bind_method(godot::D_METHOD("restore_previous_version"),
+                                &UpdateCoordinator::restore_previous_version);
+    godot::ClassDB::bind_method(godot::D_METHOD("dismiss"), &UpdateCoordinator::dismiss);
+    godot::ClassDB::bind_method(godot::D_METHOD("retry"), &UpdateCoordinator::retry);
+    godot::ClassDB::bind_method(godot::D_METHOD("cancel_waiting"),
+                                &UpdateCoordinator::cancel_waiting);
+    godot::ClassDB::bind_method(godot::D_METHOD("copy_report"),
+                                &UpdateCoordinator::copy_report);
+    godot::ClassDB::bind_method(godot::D_METHOD("open_logs"),
+                                &UpdateCoordinator::open_logs);
+    godot::ClassDB::bind_method(godot::D_METHOD("should_show"),
+                                &UpdateCoordinator::should_show);
+    godot::ClassDB::bind_method(godot::D_METHOD("is_preparing"),
+                                &UpdateCoordinator::is_preparing);
+    godot::ClassDB::bind_method(godot::D_METHOD("is_ready_to_close"),
+                                &UpdateCoordinator::is_ready_to_close);
+    godot::ClassDB::bind_method(godot::D_METHOD("is_waiting_for_godot"),
+                                &UpdateCoordinator::is_waiting_for_godot);
+    godot::ClassDB::bind_method(godot::D_METHOD("has_failed"),
+                                &UpdateCoordinator::has_failed);
+    godot::ClassDB::bind_method(godot::D_METHOD("needs_recovery"),
+                                &UpdateCoordinator::needs_recovery);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_status"),
+                                &UpdateCoordinator::get_status);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_detail"),
+                                &UpdateCoordinator::get_detail);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_error_code"),
+                                &UpdateCoordinator::get_error_code);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_operation_id"),
+                                &UpdateCoordinator::get_operation_id);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_target_version"),
+                                &UpdateCoordinator::get_target_version);
+}
+
+void UpdateCoordinator::_ready() {
+    set_process(true);
+    _scan_pending_updates();
+}
+
+void UpdateCoordinator::_process(double delta) {
+    poll_timer -= delta;
+    if (poll_timer <= 0.0) {
+        poll_timer = kPollSeconds;
+        if (step == Step::Idle) {
+            _scan_pending_updates();
+        } else if (step == Step::Preparing || step == Step::WaitingForGodot) {
+            _poll_operation();
+        }
+    }
+}
+
+void UpdateCoordinator::start_prepare() {
+    if (step == Step::Preparing || step == Step::WaitingForGodot) {
+        return;
+    }
+    if (step == Step::ReadyToClose || step == Step::RecoveryRequired) {
+        dismissed = false;
+        emit_signal("state_changed");
+        return;
+    }
+    godot::OS *os = godot::OS::get_singleton();
+    if (os == nullptr || !godot::FileAccess::file_exists(app_paths::cli_binary_path())) {
+        _fail("FEN-UPDATE-CLI-MISSING", "The installed Fennara CLI is unavailable.");
+        return;
+    }
+    dismissed = false;
+    error_code = "";
+    target_version = update_notice::latest_version();
+    const uint64_t now = static_cast<uint64_t>(
+        godot::Time::get_singleton()->get_unix_time_from_system() * 1000.0);
+    operation_id = "update-" + godot::String::num_uint64(now) + "-godot-" +
+                   godot::String::num_int64(os->get_process_id());
+    staging_root = _update_root().path_join(operation_id);
+
+    godot::PackedStringArray args;
+    args.append("update");
+    args.append("--prepare");
+    args.append("--project");
+    args.append(_project_path());
+    args.append("--operation-id");
+    args.append(operation_id);
+    args.append("--godot-pid");
+    args.append(godot::String::num_int64(os->get_process_id()));
+    args.append("--godot-executable");
+    args.append(os->get_executable_path());
+    child_pid = os->create_process(app_paths::cli_binary_path(), args, false);
+    if (child_pid <= 0) {
+        _fail("FEN-UPDATE-CLI-LAUNCH", "The Fennara update process could not be started.");
+        return;
+    }
+    _set_step(Step::Preparing, "Preparing the Fennara update...",
+              "Downloading and verifying every required file while Godot stays open");
+}
+
+void UpdateCoordinator::confirm_close_and_install() {
+    if (step != Step::ReadyToClose || !_launch_completion("__complete-project-update")) {
+        return;
+    }
+    _set_step(Step::WaitingForGodot, "Waiting for Godot to close...",
+              "The external updater will install the staged files after this editor exits");
+    _request_editor_close();
+}
+
+void UpdateCoordinator::restore_previous_version() {
+    if (step != Step::RecoveryRequired || !_launch_completion("__rollback-project-update")) {
+        return;
+    }
+    _set_step(Step::WaitingForGodot, "Waiting for Godot to close...",
+              "The external updater will restore the previous Fennara version");
+    _request_editor_close();
+}
+
+void UpdateCoordinator::dismiss() {
+    dismissed = true;
+    emit_signal("state_changed");
+}
+
+void UpdateCoordinator::retry() {
+    if (step == Step::Failed) {
+        start_prepare();
+    } else if (step == Step::ReadyToClose) {
+        dismissed = false;
+        emit_signal("state_changed");
+    }
+}
+
+void UpdateCoordinator::cancel_waiting() {
+    if (step != Step::WaitingForGodot || staging_root.is_empty()) {
+        return;
+    }
+    godot::Ref<godot::FileAccess> file = godot::FileAccess::open(
+        staging_root.path_join("cancel"), godot::FileAccess::WRITE);
+    if (file.is_valid()) {
+        file->store_string("cancel\n");
+    }
+}
+
+void UpdateCoordinator::copy_report() {
+    godot::DisplayServer *display = godot::DisplayServer::get_singleton();
+    if (display == nullptr) {
+        return;
+    }
+    godot::String report = "Fennara update report\nOperation: " + operation_id +
+                           "\nStatus: " + status_text + "\nDetail: " + detail_text +
+                           "\nCode: " + (error_code.is_empty() ? "none" : error_code) + "\n";
+    display->clipboard_set(report);
+}
+
+void UpdateCoordinator::open_logs() {
+    godot::OS *os = godot::OS::get_singleton();
+    if (os != nullptr && !operation_id.is_empty()) {
+        os->shell_show_in_file_manager(
+            app_paths::operation_logs_dir().path_join(operation_id + godot::String(".jsonl")), true);
+    }
+}
+
+bool UpdateCoordinator::should_show() const {
+    return !dismissed && step != Step::Idle;
+}
+bool UpdateCoordinator::is_preparing() const { return step == Step::Preparing; }
+bool UpdateCoordinator::is_ready_to_close() const { return step == Step::ReadyToClose; }
+bool UpdateCoordinator::is_waiting_for_godot() const { return step == Step::WaitingForGodot; }
+bool UpdateCoordinator::has_failed() const { return step == Step::Failed; }
+bool UpdateCoordinator::needs_recovery() const { return step == Step::RecoveryRequired; }
+godot::String UpdateCoordinator::get_status() const { return status_text; }
+godot::String UpdateCoordinator::get_detail() const { return detail_text; }
+godot::String UpdateCoordinator::get_error_code() const { return error_code; }
+godot::String UpdateCoordinator::get_operation_id() const { return operation_id; }
+godot::String UpdateCoordinator::get_target_version() const { return target_version; }
+
+bool UpdateCoordinator::_launch_completion(const godot::String &command) {
+    godot::OS *os = godot::OS::get_singleton();
+    if (os == nullptr) {
+        _fail("FEN-UPDATE-HANDOFF-FAILED", "Godot could not launch the external updater.");
+        return false;
+    }
+    godot::PackedStringArray args;
+    args.append(command);
+    args.append("--project");
+    args.append(_project_path());
+    args.append("--resume-operation");
+    args.append(operation_id);
+    args.append("--wait-for-pid");
+    args.append(godot::String::num_int64(os->get_process_id()));
+    args.append("--godot-executable");
+    args.append(os->get_executable_path());
+    child_pid = os->create_process(app_paths::cli_binary_path(), args, false);
+    if (child_pid <= 0) {
+        _fail("FEN-UPDATE-HANDOFF-FAILED", "The external Fennara updater could not start.");
+        return false;
+    }
+    return true;
+}
+
+void UpdateCoordinator::_request_editor_close() {
+    godot::SceneTree *tree = get_tree();
+    godot::Window *root = tree == nullptr ? nullptr : tree->get_root();
+    if (root == nullptr) {
+        _fail("FEN-UPDATE-EDITOR-CLOSE", "Godot could not request normal editor shutdown.");
+        return;
+    }
+    root->call_deferred("emit_signal", "close_requested");
+}
+
+void UpdateCoordinator::_set_step(Step next, const godot::String &status,
+                                  const godot::String &detail) {
+    step = next;
+    status_text = status;
+    detail_text = detail;
+    emit_signal("state_changed");
+}
+
+void UpdateCoordinator::_fail(const godot::String &code, const godot::String &message) {
+    error_code = code;
+    _set_step(Step::Failed, "Fennara update could not finish.", message);
+    FLOG_ERR("Native update failed " + code + ": " + message);
+}
+
+} // namespace fennara

--- a/fennara-cpp/src/update/update_coordinator.cpp
+++ b/fennara-cpp/src/update/update_coordinator.cpp
@@ -221,12 +221,12 @@ bool UpdateCoordinator::_launch_completion(const godot::String &command) {
 
 void UpdateCoordinator::_request_editor_close() {
     godot::SceneTree *tree = get_tree();
-    godot::Window *root = tree == nullptr ? nullptr : tree->get_root();
-    if (root == nullptr) {
+    if (tree == nullptr || tree->get_root() == nullptr) {
         _fail("FEN-UPDATE-EDITOR-CLOSE", "Godot could not request normal editor shutdown.");
         return;
     }
-    root->call_deferred("emit_signal", "close_requested");
+    tree->get_root()->call_deferred("propagate_notification",
+                                    godot::Node::NOTIFICATION_WM_CLOSE_REQUEST);
 }
 
 void UpdateCoordinator::_set_step(Step next, const godot::String &status,

--- a/fennara-cpp/src/update/update_discovery.cpp
+++ b/fennara-cpp/src/update/update_discovery.cpp
@@ -1,0 +1,142 @@
+#include "fennara/update/update_coordinator.hpp"
+
+#include "fennara/app_paths.hpp"
+
+#include <godot_cpp/classes/dir_access.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+
+namespace fennara {
+namespace {
+
+bool terminal_failure(const godot::String &phase) {
+    return phase == "failed" || phase == "rolled_back" || phase == "recovery_required";
+}
+
+godot::String addon_version() {
+    return godot::FileAccess::get_file_as_string("res://addons/fennara/VERSION").strip_edges();
+}
+
+} // namespace
+
+godot::String UpdateCoordinator::_project_path() const {
+    godot::ProjectSettings *settings = godot::ProjectSettings::get_singleton();
+    return settings == nullptr ? godot::String() : settings->globalize_path("res://");
+}
+
+godot::String UpdateCoordinator::_update_root() const {
+    return _project_path().path_join(".godot").path_join("fennara-update");
+}
+
+godot::String UpdateCoordinator::_receipt_path() const {
+    return staging_root.path_join("receipt.json");
+}
+
+godot::Dictionary UpdateCoordinator::_read_operation() const {
+    if (operation_id.is_empty()) {
+        return godot::Dictionary();
+    }
+    const godot::Variant parsed = godot::JSON::parse_string(
+        godot::FileAccess::get_file_as_string(
+            app_paths::operations_dir().path_join(operation_id + godot::String(".json"))));
+    return parsed.get_type() == godot::Variant::DICTIONARY ? godot::Dictionary(parsed)
+                                                            : godot::Dictionary();
+}
+
+godot::Dictionary UpdateCoordinator::_read_receipt(const godot::String &root) const {
+    const godot::Variant parsed = godot::JSON::parse_string(
+        godot::FileAccess::get_file_as_string(root.path_join("receipt.json")));
+    return parsed.get_type() == godot::Variant::DICTIONARY ? godot::Dictionary(parsed)
+                                                            : godot::Dictionary();
+}
+
+void UpdateCoordinator::_poll_operation() {
+    const godot::Dictionary state = _read_operation();
+    if (state.is_empty()) {
+        return;
+    }
+    const godot::String phase = state.get("phase", "");
+    if (phase == "ready_to_close") {
+        const godot::Dictionary receipt = _read_receipt(staging_root);
+        target_version = receipt.get("to_version", target_version);
+        _set_step(Step::ReadyToClose, "Fennara " + target_version + " is ready.",
+                  "Godot must close briefly to install the verified update");
+        return;
+    }
+    if (phase == "recovery_required") {
+        _set_step(Step::RecoveryRequired, "Fennara could not validate the update.",
+                  "Restore the previous version, or open the logs for details");
+        return;
+    }
+    if (phase == "succeeded") {
+        dismissed = true;
+        _set_step(Step::Idle, "Fennara is already up to date.", "No update was required");
+        return;
+    }
+    if (terminal_failure(phase)) {
+        godot::Dictionary last_error = state.get("last_error", godot::Dictionary());
+        _fail(last_error.get("code", "FEN-UPDATE-FAILED"),
+              last_error.get("message", "The Fennara update could not finish."));
+        return;
+    }
+    _set_step(step, "Preparing the Fennara update...", "Operation " + operation_id);
+}
+
+void UpdateCoordinator::_scan_pending_updates() {
+    const godot::String root = _update_root();
+    godot::Ref<godot::DirAccess> dir = godot::DirAccess::open(root);
+    if (dir.is_null()) {
+        return;
+    }
+    dir->list_dir_begin();
+    for (godot::String name = dir->get_next(); !name.is_empty(); name = dir->get_next()) {
+        if (!dir->current_is_dir() || name.ends_with(".preparing")) {
+            continue;
+        }
+        const godot::String candidate = root.path_join(name);
+        const godot::Dictionary receipt = _read_receipt(candidate);
+        const godot::String state = receipt.get("state", "");
+        const int64_t updater_pid = receipt.get("updater_pid", -1);
+        const bool updater_running =
+            updater_pid > 0 && godot::OS::get_singleton()->is_process_running(updater_pid);
+        if (state == "validating" && updater_running) {
+            _write_activation_handshake(candidate, receipt);
+        }
+        if (state == "recovery_required" ||
+            ((state == "applying" || state == "reopening" || state == "validating") &&
+             !updater_running)) {
+            operation_id = receipt.get("operation_id", name);
+            target_version = receipt.get("to_version", "");
+            staging_root = candidate;
+            _set_step(Step::RecoveryRequired, "Fennara could not validate the update.",
+                      "The previous working version is still available to restore");
+            break;
+        }
+        if (state == "ready_to_close") {
+            operation_id = receipt.get("operation_id", name);
+            target_version = receipt.get("to_version", "");
+            staging_root = candidate;
+            _set_step(Step::ReadyToClose, "Fennara " + target_version + " is ready.",
+                      "Godot must close briefly to install the verified update");
+            break;
+        }
+    }
+    dir->list_dir_end();
+}
+
+void UpdateCoordinator::_write_activation_handshake(
+    const godot::String &root, const godot::Dictionary &receipt) const {
+    const godot::String expected = receipt.get("to_version", "");
+    if (expected.is_empty() || addon_version() != expected) {
+        return;
+    }
+    godot::Dictionary handshake;
+    handshake["operation_id"] = receipt.get("operation_id", "");
+    handshake["addon_version"] = expected;
+    handshake["godot_pid"] = godot::OS::get_singleton()->get_process_id();
+    app_paths::write_json(root.path_join("activation-handshake.json"), handshake);
+}
+
+} // namespace fennara

--- a/fennara-cpp/src/update/update_discovery.cpp
+++ b/fennara-cpp/src/update/update_discovery.cpp
@@ -7,12 +7,22 @@
 #include <godot_cpp/classes/json.hpp>
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/classes/time.hpp>
 
 namespace fennara {
 namespace {
 
+constexpr uint64_t STALLED_UPDATE_SECONDS = 120;
+
 bool terminal_failure(const godot::String &phase) {
     return phase == "failed" || phase == "rolled_back" || phase == "recovery_required";
+}
+
+bool update_state_is_stalled(const godot::String &receipt_path) {
+    const uint64_t modified = godot::FileAccess::get_modified_time(receipt_path);
+    const uint64_t now = static_cast<uint64_t>(
+        godot::Time::get_singleton()->get_unix_time_from_system());
+    return modified > 0 && now > modified && now - modified >= STALLED_UPDATE_SECONDS;
 }
 
 godot::String addon_version() {
@@ -38,16 +48,24 @@ godot::Dictionary UpdateCoordinator::_read_operation() const {
     if (operation_id.is_empty()) {
         return godot::Dictionary();
     }
-    const godot::Variant parsed = godot::JSON::parse_string(
-        godot::FileAccess::get_file_as_string(
-            app_paths::operations_dir().path_join(operation_id + godot::String(".json"))));
+    const godot::String path =
+        app_paths::operations_dir().path_join(operation_id + godot::String(".json"));
+    if (!godot::FileAccess::file_exists(path)) {
+        return godot::Dictionary();
+    }
+    const godot::Variant parsed =
+        godot::JSON::parse_string(godot::FileAccess::get_file_as_string(path));
     return parsed.get_type() == godot::Variant::DICTIONARY ? godot::Dictionary(parsed)
                                                             : godot::Dictionary();
 }
 
 godot::Dictionary UpdateCoordinator::_read_receipt(const godot::String &root) const {
-    const godot::Variant parsed = godot::JSON::parse_string(
-        godot::FileAccess::get_file_as_string(root.path_join("receipt.json")));
+    const godot::String path = root.path_join("receipt.json");
+    if (!godot::FileAccess::file_exists(path)) {
+        return godot::Dictionary();
+    }
+    const godot::Variant parsed =
+        godot::JSON::parse_string(godot::FileAccess::get_file_as_string(path));
     return parsed.get_type() == godot::Variant::DICTIONARY ? godot::Dictionary(parsed)
                                                             : godot::Dictionary();
 }
@@ -59,6 +77,9 @@ void UpdateCoordinator::_poll_operation() {
     }
     const godot::String phase = state.get("phase", "");
     if (phase == "ready_to_close") {
+        if (step == Step::WaitingForGodot) {
+            return;
+        }
         const godot::Dictionary receipt = _read_receipt(staging_root);
         target_version = receipt.get("to_version", target_version);
         _set_step(Step::ReadyToClose, "Fennara " + target_version + " is ready.",
@@ -98,15 +119,14 @@ void UpdateCoordinator::_scan_pending_updates() {
         const godot::String candidate = root.path_join(name);
         const godot::Dictionary receipt = _read_receipt(candidate);
         const godot::String state = receipt.get("state", "");
-        const int64_t updater_pid = receipt.get("updater_pid", -1);
-        const bool updater_running =
-            updater_pid > 0 && godot::OS::get_singleton()->is_process_running(updater_pid);
-        if (state == "validating" && updater_running) {
+        if (state == "validating") {
             _write_activation_handshake(candidate, receipt);
         }
+        const bool interrupted =
+            (state == "applying" || state == "reopening" || state == "validating") &&
+            update_state_is_stalled(candidate.path_join("receipt.json"));
         if (state == "recovery_required" ||
-            ((state == "applying" || state == "reopening" || state == "validating") &&
-             !updater_running)) {
+            interrupted) {
             operation_id = receipt.get("operation_id", name);
             target_version = receipt.get("to_version", "");
             staging_root = candidate;

--- a/fennara-cpp/src/update/update_discovery.cpp
+++ b/fennara-cpp/src/update/update_discovery.cpp
@@ -119,12 +119,12 @@ void UpdateCoordinator::_scan_pending_updates() {
         const godot::String candidate = root.path_join(name);
         const godot::Dictionary receipt = _read_receipt(candidate);
         const godot::String state = receipt.get("state", "");
-        if (state == "validating") {
-            _write_activation_handshake(candidate, receipt);
-        }
         const bool interrupted =
             (state == "applying" || state == "reopening" || state == "validating") &&
             update_state_is_stalled(candidate.path_join("receipt.json"));
+        if (state == "validating" && !interrupted) {
+            _write_activation_handshake(candidate, receipt);
+        }
         if (state == "recovery_required" ||
             interrupted) {
             operation_id = receipt.get("operation_id", name);

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -135,7 +135,9 @@
     }
     versionWarning.disabled = true;
     versionWarning.setAttribute("aria-busy", "true");
-    updateStartOverlay.hidden = false;
+    if (updateStartOverlay) {
+      updateStartOverlay.hidden = false;
+    }
     const sent = send({
       type: "prepare_fennara_update",
       request_id: nextRequestId("prepare-fennara-update"),
@@ -143,7 +145,9 @@
     if (!sent) {
       versionWarning.disabled = false;
       versionWarning.removeAttribute("aria-busy");
-      updateStartOverlay.hidden = true;
+      if (updateStartOverlay) {
+        updateStartOverlay.hidden = true;
+      }
       appendSystem("Godot is not connected, so the update could not start.");
     }
   });
@@ -1427,6 +1431,9 @@
     if (message.type === "fennara_update_requested") {
       versionWarning.disabled = false;
       versionWarning.removeAttribute("aria-busy");
+      if (updateStartOverlay) {
+        updateStartOverlay.hidden = true;
+      }
       return;
     }
     if (message.type === "chat_context_snippet") {
@@ -1586,7 +1593,9 @@
       if (requestId.startsWith("prepare-fennara-update")) {
         versionWarning.disabled = false;
         versionWarning.removeAttribute("aria-busy");
-        updateStartOverlay.hidden = true;
+        if (updateStartOverlay) {
+          updateStartOverlay.hidden = true;
+        }
       }
       if (requestId.startsWith("open-project-file")) {
         appendSystem(errorText);

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -70,7 +70,7 @@
   const versionWarning = document.querySelector("[data-version-warning]");
   const versionPopover = document.querySelector("[data-version-popover]");
   const versionWarningText = document.querySelector("[data-version-warning-text]");
-  const versionCommand = document.querySelector("[data-version-command]");
+  const prepareFennaraUpdateButton = document.querySelector("[data-prepare-fennara-update]");
   const usageContainer = document.querySelector(".composer-usage");
   const usagePopover = document.querySelector("[data-usage-popover]");
   const usageTotalCost = document.querySelector("[data-usage-total-cost]");
@@ -125,10 +125,21 @@
     versionWarning,
     versionPopover,
     versionWarningText,
-    versionCommand,
     escapeHtml: markdown.utils.escapeHtml,
   });
   const applyProjectStatus = projectStatusController.applyProjectStatus;
+
+  prepareFennaraUpdateButton?.addEventListener("click", () => {
+    prepareFennaraUpdateButton.disabled = true;
+    const sent = send({
+      type: "prepare_fennara_update",
+      request_id: nextRequestId("prepare-fennara-update"),
+    });
+    if (!sent) {
+      prepareFennaraUpdateButton.disabled = false;
+      appendSystem("Godot is not connected, so the update could not start.");
+    }
+  });
 
   let activeChatId = null;
   let currentModel = "";
@@ -1406,6 +1417,12 @@
       applyProjectStatus(message);
       return;
     }
+    if (message.type === "fennara_update_requested") {
+      prepareFennaraUpdateButton.disabled = false;
+      appendSystem("Update preparation opened in the Fennara Godot dock.");
+      window.setTimeout(clearSystemStatus, 3000);
+      return;
+    }
     if (message.type === "chat_context_snippet") {
       addContextSnippet(message);
       return;
@@ -1560,6 +1577,9 @@
       const errorText = message.message || "Chat request failed.";
       transcriptRenderer.updateContextCompaction("failed");
       const requestId = String(message.request_id || "");
+      if (requestId.startsWith("prepare-fennara-update")) {
+        prepareFennaraUpdateButton.disabled = false;
+      }
       if (requestId.startsWith("open-project-file")) {
         appendSystem(errorText);
         window.setTimeout(clearSystemStatus, 2400);

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -70,7 +70,7 @@
   const versionWarning = document.querySelector("[data-version-warning]");
   const versionPopover = document.querySelector("[data-version-popover]");
   const versionWarningText = document.querySelector("[data-version-warning-text]");
-  const prepareFennaraUpdateButton = document.querySelector("[data-prepare-fennara-update]");
+  const updateStartOverlay = document.querySelector("[data-update-start-overlay]");
   const usageContainer = document.querySelector(".composer-usage");
   const usagePopover = document.querySelector("[data-usage-popover]");
   const usageTotalCost = document.querySelector("[data-usage-total-cost]");
@@ -129,14 +129,21 @@
   });
   const applyProjectStatus = projectStatusController.applyProjectStatus;
 
-  prepareFennaraUpdateButton?.addEventListener("click", () => {
-    prepareFennaraUpdateButton.disabled = true;
+  versionWarning?.addEventListener("click", () => {
+    if (versionWarning.disabled) {
+      return;
+    }
+    versionWarning.disabled = true;
+    versionWarning.setAttribute("aria-busy", "true");
+    updateStartOverlay.hidden = false;
     const sent = send({
       type: "prepare_fennara_update",
       request_id: nextRequestId("prepare-fennara-update"),
     });
     if (!sent) {
-      prepareFennaraUpdateButton.disabled = false;
+      versionWarning.disabled = false;
+      versionWarning.removeAttribute("aria-busy");
+      updateStartOverlay.hidden = true;
       appendSystem("Godot is not connected, so the update could not start.");
     }
   });
@@ -1418,9 +1425,8 @@
       return;
     }
     if (message.type === "fennara_update_requested") {
-      prepareFennaraUpdateButton.disabled = false;
-      appendSystem("Update preparation opened in the Fennara Godot dock.");
-      window.setTimeout(clearSystemStatus, 3000);
+      versionWarning.disabled = false;
+      versionWarning.removeAttribute("aria-busy");
       return;
     }
     if (message.type === "chat_context_snippet") {
@@ -1578,7 +1584,9 @@
       transcriptRenderer.updateContextCompaction("failed");
       const requestId = String(message.request_id || "");
       if (requestId.startsWith("prepare-fennara-update")) {
-        prepareFennaraUpdateButton.disabled = false;
+        versionWarning.disabled = false;
+        versionWarning.removeAttribute("aria-busy");
+        updateStartOverlay.hidden = true;
       }
       if (requestId.startsWith("open-project-file")) {
         appendSystem(errorText);

--- a/godot_demo/addons/fennara/dist/index.html
+++ b/godot_demo/addons/fennara/dist/index.html
@@ -27,16 +27,16 @@
             </div>
           </div>
           <div class="version-menu" data-version-menu hidden>
-            <button class="icon-button version-button" type="button" aria-label="Fennara update available" aria-expanded="false" data-version-warning>
+            <button class="version-button" type="button" aria-label="Update Fennara" aria-expanded="false" data-version-warning>
               <svg class="svg-icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 19V5"></path>
                 <path d="m6.5 10.5 5.5-5.5 5.5 5.5"></path>
               </svg>
+              <span>Update</span>
             </button>
             <div class="version-popover" role="tooltip" data-version-popover>
               <strong>Update available</strong>
-              <span data-version-warning-text>Prepare the update while Godot stays open.</span>
-              <button class="version-update-action" type="button" data-prepare-fennara-update>Prepare Update</button>
+              <span data-version-warning-text>Press Update to start.</span>
             </div>
           </div>
           <button class="icon-button" type="button" title="Settings" aria-label="Settings" data-open-settings>
@@ -55,6 +55,14 @@
           </button>
         </div>
       </header>
+
+      <section class="update-start-overlay" aria-live="polite" data-update-start-overlay hidden>
+        <div class="update-start-card">
+          <span class="update-start-spinner" aria-hidden="true"></span>
+          <strong>Starting Fennara update</strong>
+          <span>Opening verified update preparation in Godot...</span>
+        </div>
+      </section>
 
       <aside class="chat-drawer" aria-label="Chats drawer" data-chat-drawer>
         <div class="drawer-top">

--- a/godot_demo/addons/fennara/dist/index.html
+++ b/godot_demo/addons/fennara/dist/index.html
@@ -35,8 +35,8 @@
             </button>
             <div class="version-popover" role="tooltip" data-version-popover>
               <strong>Update available</strong>
-              <span data-version-warning-text>Close Godot, then run this command in the current project.</span>
-              <code data-version-command>fennara update</code>
+              <span data-version-warning-text>Prepare the update while Godot stays open.</span>
+              <button class="version-update-action" type="button" data-prepare-fennara-update>Prepare Update</button>
             </div>
           </div>
           <button class="icon-button" type="button" title="Settings" aria-label="Settings" data-open-settings>

--- a/godot_demo/addons/fennara/dist/project-status.js
+++ b/godot_demo/addons/fennara/dist/project-status.js
@@ -71,12 +71,13 @@
       }
       const current = version.current_version || "installed";
       const latest = version.latest_version || "latest";
+      versionWarning.title = `Update Fennara ${current} to ${latest}`;
       if (versionWarningText) {
         versionWarningText.innerHTML = [
           `Current: ${escapeHtml(current)}`,
           `Available: ${escapeHtml(latest)}`,
           "",
-          "The update will be verified before Godot asks to close.",
+          "Press Update to start.",
         ].join("<br>");
       }
       if (versionPopover) {

--- a/godot_demo/addons/fennara/dist/project-status.js
+++ b/godot_demo/addons/fennara/dist/project-status.js
@@ -17,7 +17,6 @@
     const versionWarning = options.versionWarning || null;
     const versionPopover = options.versionPopover || null;
     const versionWarningText = options.versionWarningText || null;
-    const versionCommand = options.versionCommand || null;
     const escapeHtml = options.escapeHtml || defaultEscapeHtml;
 
     function basename(path) {
@@ -77,11 +76,8 @@
           `Current: ${escapeHtml(current)}`,
           `Available: ${escapeHtml(latest)}`,
           "",
-          "Close Godot, then run this in the current project.",
+          "The update will be verified before Godot asks to close.",
         ].join("<br>");
-      }
-      if (versionCommand) {
-        versionCommand.textContent = "fennara update";
       }
       if (versionPopover) {
         versionPopover.hidden = false;

--- a/godot_demo/addons/fennara/dist/styles/controls.css
+++ b/godot_demo/addons/fennara/dist/styles/controls.css
@@ -21,6 +21,49 @@
   display: none !important;
 }
 
+.update-start-overlay[hidden] {
+  display: none;
+}
+
+.update-start-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background: #242424;
+}
+
+.update-start-card {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  max-width: 420px;
+  text-align: center;
+  color: #c8c8c8;
+}
+
+.update-start-card strong {
+  color: #f0f0f0;
+  font-size: 20px;
+}
+
+.update-start-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid #4b4b4b;
+  border-top-color: #6ea8e5;
+  border-radius: 50%;
+  animation: fennara-update-spin 0.8s linear infinite;
+}
+
+@keyframes fennara-update-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .target-pill {
   display: flex;
   align-items: center;
@@ -117,9 +160,23 @@
 }
 
 .version-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  min-height: 30px;
+  padding: 0 10px;
   border-color: #4f93d2;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: var(--radius);
   background: #478ec9;
   color: #f2f8ff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 700;
+  box-shadow: 0 0 0 1px rgba(112, 188, 255, 0.12);
 }
 
 .version-button:hover {
@@ -170,22 +227,7 @@
   white-space: nowrap;
 }
 
-.version-update-action {
-  border: 1px solid rgba(112, 188, 255, 0.45);
-  border-radius: 7px;
-  background: rgba(55, 132, 210, 0.22);
-  color: var(--text-primary);
-  padding: 7px 10px;
-  cursor: pointer;
-  font: inherit;
-}
-
-.version-update-action:hover,
-.version-update-action:focus-visible {
-  background: rgba(55, 132, 210, 0.36);
-}
-
-.version-update-action:disabled {
+.version-button:disabled {
   cursor: wait;
   opacity: 0.6;
 }

--- a/godot_demo/addons/fennara/dist/styles/controls.css
+++ b/godot_demo/addons/fennara/dist/styles/controls.css
@@ -170,6 +170,26 @@
   white-space: nowrap;
 }
 
+.version-update-action {
+  border: 1px solid rgba(112, 188, 255, 0.45);
+  border-radius: 7px;
+  background: rgba(55, 132, 210, 0.22);
+  color: var(--text-primary);
+  padding: 7px 10px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.version-update-action:hover,
+.version-update-action:focus-visible {
+  background: rgba(55, 132, 210, 0.36);
+}
+
+.version-update-action:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
 .icon-button,
 .secondary-button,
 .primary-button {

--- a/local/Cargo.lock
+++ b/local/Cargo.lock
@@ -272,6 +272,7 @@ name = "fennara-cli"
 version = "0.3.8"
 dependencies = [
  "json5",
+ "serde",
  "serde_json",
  "sha2",
  "sysinfo",

--- a/local/crates/fennara-cli/Cargo.toml
+++ b/local/crates/fennara-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 json5 = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 sysinfo = "0.30"

--- a/local/crates/fennara-cli/src/daemon_setup.rs
+++ b/local/crates/fennara-cli/src/daemon_setup.rs
@@ -125,6 +125,61 @@ pub fn check_compatibility(expected_version: &str) -> Result<Compatibility, Stri
     }
 }
 
+pub fn shutdown_if_running(layout: &AppLayout) -> Result<(), String> {
+    if matches!(
+        health(),
+        Err(HealthError {
+            kind: HealthErrorKind::NotRunning,
+            ..
+        })
+    ) {
+        return Ok(());
+    }
+    let token_path = layout.app_dir.join("daemon-control-token");
+    let token = std::fs::read_to_string(&token_path)
+        .map_err(|error| format!("failed to read {}: {error}", display_path(&token_path)))?
+        .trim()
+        .to_string();
+    if token.is_empty() || token.contains(['\r', '\n']) {
+        return Err("the local daemon control token is invalid".to_string());
+    }
+    let mut stream = TcpStream::connect(DAEMON_ADDR)
+        .map_err(|error| format!("failed to connect to the running daemon: {error}"))?;
+    stream
+        .set_read_timeout(Some(HEALTH_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    stream
+        .set_write_timeout(Some(HEALTH_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    let request = format!(
+        "POST /shutdown HTTP/1.1\r\nHost: 127.0.0.1\r\nX-Fennara-Control-Token: {token}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("failed to request daemon shutdown: {error}"))?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| format!("failed to read daemon shutdown response: {error}"))?;
+    if !response.starts_with("HTTP/1.1 200") && !response.starts_with("HTTP/1.0 200") {
+        return Err("daemon rejected the authenticated shutdown request".to_string());
+    }
+    let deadline = Instant::now() + START_TIMEOUT;
+    while Instant::now() < deadline {
+        if matches!(
+            health(),
+            Err(HealthError {
+                kind: HealthErrorKind::NotRunning,
+                ..
+            })
+        ) {
+            return Ok(());
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+    Err("the previous Fennara daemon did not stop before update activation".to_string())
+}
+
 pub fn health() -> Result<Value, HealthError> {
     let mut stream = TcpStream::connect(DAEMON_ADDR).map_err(|error| HealthError {
         kind: if matches!(

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -17,6 +17,7 @@ mod release_package;
 mod release_package_tests;
 mod release_update;
 mod self_update;
+mod update_stage;
 mod webview_prereq;
 mod webview_runtime;
 
@@ -114,7 +115,7 @@ Usage:
   fennara diagnostics [--operation <operation-id>] [--json]
   fennara install [--project <path>] [--version <version>]
   fennara mcp-setup <target flags>
-  fennara update [--version <version>] [--project <path>] [--no-self-update]
+  fennara update [--version <version>] [--project <path>] [--no-self-update] [--prepare]
   fennara self-update [--version <version>]
   fennara --version
   fennara --help

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -42,6 +42,7 @@ fn run_tracked(args: Vec<String>) -> Result<(), String> {
     let kind = match args.first().map(String::as_str) {
         Some("install") => Some(operation::OperationKind::Install),
         Some("update") => Some(operation::OperationKind::Update),
+        Some("recover") => Some(operation::OperationKind::Update),
         Some(update_apply::COMPLETE_COMMAND | update_apply::ROLLBACK_COMMAND) => {
             Some(operation::OperationKind::Update)
         }
@@ -101,6 +102,7 @@ fn run(args: Vec<String>) -> Result<(), String> {
         Some("install") => project_install::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("mcp-setup") => mcp_setup::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("update") => release_update::run(args.iter().skip(1).map(String::as_str).collect()),
+        Some("recover") => update_apply::recover(args.iter().skip(1).map(String::as_str).collect()),
         Some(update_apply::COMPLETE_COMMAND) => {
             update_apply::complete(args.iter().skip(1).map(String::as_str).collect())
         }
@@ -126,6 +128,7 @@ Usage:
   fennara install [--project <path>] [--version <version>]
   fennara mcp-setup <target flags>
   fennara update [--version <version>] [--project <path>] [--no-self-update] [--prepare]
+  fennara recover --project <path> [--operation <operation-id>]
   fennara self-update [--version <version>]
   fennara --version
   fennara --help
@@ -137,6 +140,7 @@ Commands:
   install    Set up Fennara in a Godot project
   mcp-setup  Configure an MCP app to launch Fennara
   update     Update the CLI, local package, addon, and project guidance
+  recover    Restore an interrupted native update after Godot is closed
   self-update
              Update only the installed Fennara CLI
 

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -17,6 +17,7 @@ mod release_package;
 mod release_package_tests;
 mod release_update;
 mod self_update;
+mod update_apply;
 mod update_stage;
 mod webview_prereq;
 mod webview_runtime;
@@ -41,6 +42,9 @@ fn run_tracked(args: Vec<String>) -> Result<(), String> {
     let kind = match args.first().map(String::as_str) {
         Some("install") => Some(operation::OperationKind::Install),
         Some("update") => Some(operation::OperationKind::Update),
+        Some(update_apply::COMPLETE_COMMAND | update_apply::ROLLBACK_COMMAND) => {
+            Some(operation::OperationKind::Update)
+        }
         Some("self-update") | Some(self_update::COMPLETE_COMMAND) => {
             Some(operation::OperationKind::SelfUpdate)
         }
@@ -97,6 +101,12 @@ fn run(args: Vec<String>) -> Result<(), String> {
         Some("install") => project_install::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("mcp-setup") => mcp_setup::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("update") => release_update::run(args.iter().skip(1).map(String::as_str).collect()),
+        Some(update_apply::COMPLETE_COMMAND) => {
+            update_apply::complete(args.iter().skip(1).map(String::as_str).collect())
+        }
+        Some(update_apply::ROLLBACK_COMMAND) => {
+            update_apply::rollback(args.iter().skip(1).map(String::as_str).collect())
+        }
         Some("self-update") => self_update::run(args.iter().skip(1).map(String::as_str).collect()),
         Some(self_update::COMPLETE_COMMAND) => {
             self_update::complete(args.iter().skip(1).cloned().collect())

--- a/local/crates/fennara-cli/src/operation.rs
+++ b/local/crates/fennara-cli/src/operation.rs
@@ -160,9 +160,20 @@ pub fn cancel_handoff() -> Result<(), String> {
     })
 }
 
+pub fn defer_completion() -> Result<(), String> {
+    with_current(|journal| {
+        journal.completion_deferred = true;
+        Ok(())
+    })
+}
+
 pub fn current_id() -> Option<String> {
     let slot = current_slot().lock().ok()?;
     slot.as_ref().map(|journal| journal.id.clone())
+}
+
+pub fn validate_id(id: &str) -> Result<(), String> {
+    validate_operation_id(id).map(|_| ())
 }
 
 pub fn finish_success() -> Result<(), String> {

--- a/local/crates/fennara-cli/src/operation.rs
+++ b/local/crates/fennara-cli/src/operation.rs
@@ -93,7 +93,8 @@ pub fn begin(kind: OperationKind, args: &[String]) -> Result<(), String> {
     let requested_operation_id = option_value(args, "--operation-id");
     let resume_id = env::var(OPERATION_ID_ENV)
         .ok()
-        .filter(|value| !value.is_empty());
+        .filter(|value| !value.is_empty())
+        .or_else(|| option_value(args, "--resume-operation"));
     let journal = if let Some(id) = resume_id {
         OperationJournal::resume(layout, &id, project_dir.as_deref())?
     } else if let Some(id) = requested_operation_id {

--- a/local/crates/fennara-cli/src/operation/storage.rs
+++ b/local/crates/fennara-cli/src/operation/storage.rs
@@ -3,7 +3,12 @@ use serde_json::Value;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::Path;
+use std::thread;
+use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
+
+const FILE_REPLACE_TIMEOUT: Duration = Duration::from_secs(2);
+const FILE_REPLACE_RETRY_DELAY: Duration = Duration::from_millis(20);
 
 pub(super) fn write_json_atomic(path: &Path, value: &Value) -> Result<(), String> {
     let temp = path.with_extension(format!("json.tmp-{}", std::process::id()));
@@ -24,7 +29,7 @@ pub(super) fn write_json_atomic(path: &Path, value: &Value) -> Result<(), String
 
     if path.exists() {
         let _ = fs::remove_file(&backup);
-        fs::rename(path, &backup).map_err(|err| {
+        rename_with_retry(path, &backup).map_err(|err| {
             format!(
                 "failed to back up {} as {}: {err}",
                 display_path(path),
@@ -46,6 +51,22 @@ pub(super) fn write_json_atomic(path: &Path, value: &Value) -> Result<(), String
                 display_path(&temp),
                 display_path(path)
             ))
+        }
+    }
+}
+
+fn rename_with_retry(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let deadline = std::time::Instant::now() + FILE_REPLACE_TIMEOUT;
+    loop {
+        match fs::rename(source, destination) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if error.kind() == std::io::ErrorKind::PermissionDenied
+                    && std::time::Instant::now() < deadline =>
+            {
+                thread::sleep(FILE_REPLACE_RETRY_DELAY);
+            }
+            Err(error) => return Err(error),
         }
     }
 }

--- a/local/crates/fennara-cli/src/operation/storage.rs
+++ b/local/crates/fennara-cli/src/operation/storage.rs
@@ -37,14 +37,14 @@ pub(super) fn write_json_atomic(path: &Path, value: &Value) -> Result<(), String
             )
         })?;
     }
-    match fs::rename(&temp, path) {
+    match rename_with_retry(&temp, path) {
         Ok(()) => {
             let _ = fs::remove_file(&backup);
             Ok(())
         }
         Err(error) => {
             if backup.exists() && !path.exists() {
-                let _ = fs::rename(&backup, path);
+                let _ = rename_with_retry(&backup, path);
             }
             Err(format!(
                 "failed to activate {} as {}: {error}",

--- a/local/crates/fennara-cli/src/project_addon.rs
+++ b/local/crates/fennara-cli/src/project_addon.rs
@@ -16,6 +16,18 @@ pub fn inspect(project_dir: &Path) -> Result<Option<ExistingAddon>, String> {
         return Ok(None);
     }
 
+    validate(&addon_dir).map(Some)
+}
+
+pub fn validate(addon_dir: &Path) -> Result<ExistingAddon, String> {
+    let manifest_path = addon_dir.join("fennara.gdextension");
+    if !manifest_path.is_file() {
+        return Err(format!(
+            "the Fennara addon is missing its extension manifest at {}",
+            display_path(&manifest_path)
+        ));
+    }
+
     let version_path = addon_dir.join("VERSION");
     let version = fs::read_to_string(&version_path)
         .map_err(|error| {
@@ -33,7 +45,7 @@ pub fn inspect(project_dir: &Path) -> Result<Option<ExistingAddon>, String> {
         ));
     }
 
-    let library_path = current_library_path(&addon_dir, &manifest_path)?;
+    let library_path = current_library_path(addon_dir, &manifest_path)?;
     if !library_path.is_file() {
         return Err(format!(
             "the existing Fennara addon is missing its {} {} editor library at {}",
@@ -51,7 +63,7 @@ pub fn inspect(project_dir: &Path) -> Result<Option<ExistingAddon>, String> {
         ));
     }
 
-    Ok(Some(ExistingAddon { version }))
+    Ok(ExistingAddon { version })
 }
 
 fn current_library_path(addon_dir: &Path, manifest_path: &Path) -> Result<PathBuf, String> {

--- a/local/crates/fennara-cli/src/project_install.rs
+++ b/local/crates/fennara-cli/src/project_install.rs
@@ -123,7 +123,10 @@ pub fn project_addon_dir(project_dir: &Path) -> PathBuf {
     project_dir.join("addons").join("fennara")
 }
 
-fn ensure_target_within_project(project_dir: &Path, target: &Path) -> Result<(), String> {
+pub(crate) fn ensure_target_within_project(
+    project_dir: &Path,
+    target: &Path,
+) -> Result<(), String> {
     let project_root = fs::canonicalize(project_dir).map_err(|err| {
         format!(
             "failed to resolve project path {}: {err}",

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -390,23 +390,39 @@ fn install_from_assets(
 
 pub fn activate_staged_launchers(version: &str) -> Result<(), String> {
     let layout = AppLayout::detect()?;
+    activate_staged_launchers_at(&layout, version)
+}
+
+pub(crate) fn activate_staged_launchers_at(
+    layout: &AppLayout,
+    version: &str,
+) -> Result<(), String> {
     let staged = layout.versions_dir.join(version).join("staged-launchers");
     if !staged.is_dir() {
         return Ok(());
     }
-    let mut activated_all = true;
     for launcher in ["fennara-mcp", "fennara-daemon"] {
         let source = staged.join(binary_name(launcher));
         let target = layout.bin_dir.join(binary_name(launcher));
-        if let Err(error) = copy_file(&source, &target) {
-            activated_all = false;
-            println!(
-                "warning: kept the current launcher at {}: {error}",
-                display_path(&target)
-            );
-        }
+        copy_file(&source, &target)?;
+        fs::OpenOptions::new()
+            .write(true)
+            .open(&target)
+            .and_then(|file| file.sync_all())
+            .map_err(|error| {
+                format!(
+                    "failed to flush activated launcher {}: {error}",
+                    display_path(&target)
+                )
+            })?;
     }
-    if activated_all {
+    Ok(())
+}
+
+pub(crate) fn remove_staged_launchers(version: &str) -> Result<(), String> {
+    let layout = AppLayout::detect()?;
+    let staged = layout.versions_dir.join(version).join("staged-launchers");
+    if staged.exists() {
         fs::remove_dir_all(&staged).map_err(|error| {
             format!(
                 "failed to remove activated launcher staging {}: {error}",

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -29,7 +29,7 @@ pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String>
         manifest
             .validate_for_install()
             .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
-        return ensure_manifest_package(&layout, &release, &manifest, None, true);
+        return ensure_manifest_package(&layout, &release, &manifest, None, true, true);
     }
 
     ensure_legacy_package(&layout, &release)
@@ -57,7 +57,32 @@ pub fn stage_exact_package(version: &str) -> Result<InstalledPackage, String> {
     manifest
         .validate_for_install()
         .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
-    ensure_manifest_package(&layout, &release, &manifest, Some(version), false)
+    ensure_manifest_package(&layout, &release, &manifest, Some(version), false, true)
+}
+
+pub fn prepare_package(version_request: &str) -> Result<InstalledPackage, String> {
+    let layout = AppLayout::detect()?;
+    layout.ensure_base_dirs()?;
+
+    println!("package: resolving release {version_request} for staging");
+    let release = release_client::fetch_release(version_request)?;
+    let manifest_asset = release.manifest_asset().ok_or_else(|| {
+        operation::failure(
+            FailureClass::ManifestInvalid,
+            format!(
+                "release {} has no release manifest; native updates require verified install metadata",
+                release.tag
+            ),
+        )
+    })?;
+    println!("manifest: {}", manifest_asset.name);
+    let bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
+    let manifest = ReleaseManifest::parse(&bytes)
+        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    manifest
+        .validate_for_install()
+        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    ensure_manifest_package(&layout, &release, &manifest, None, false, false)
 }
 
 fn ensure_manifest_package(
@@ -66,6 +91,7 @@ fn ensure_manifest_package(
     manifest: &ReleaseManifest,
     expected_version: Option<&str>,
     activate: bool,
+    update_launchers: bool,
 ) -> Result<InstalledPackage, String> {
     let selection = manifest
         .select_for_current_platform()
@@ -103,6 +129,7 @@ fn ensure_manifest_package(
             label: selection.addon.name.as_str(),
         },
         activate,
+        update_launchers,
     )?;
 
     for runtime in &selection.shared_runtimes {
@@ -196,6 +223,7 @@ fn ensure_legacy_package(
             label: &addon_asset.name,
         },
         true,
+        true,
     )?;
 
     if let Some(message) =
@@ -213,6 +241,7 @@ fn ensure_selected_package(
     local_asset: DownloadAsset<'_>,
     addon_asset: DownloadAsset<'_>,
     activate: bool,
+    update_launchers: bool,
 ) -> Result<InstalledPackage, String> {
     for component in ["addon", "daemon", "mcp", "runtime"] {
         operation::set_component(component, version)?;
@@ -240,6 +269,7 @@ fn ensure_selected_package(
         local_asset,
         addon_asset,
         activate,
+        update_launchers,
     );
     let _ = fs::remove_dir_all(&temp_dir);
     result
@@ -277,6 +307,7 @@ fn install_from_assets(
     local_asset: DownloadAsset<'_>,
     addon_asset: DownloadAsset<'_>,
     activate: bool,
+    update_launchers: bool,
 ) -> Result<InstalledPackage, String> {
     let local_dir = temp_dir.join("local");
     let addon_stage_dir = temp_dir.join("addon");
@@ -299,15 +330,19 @@ fn install_from_assets(
     fs::create_dir_all(&version_dir)
         .map_err(|err| format!("failed to create {}: {err}", display_path(&version_dir)))?;
 
-    println!("launchers: updating {}", display_path(&layout.bin_dir));
-    copy_existing_launcher(
-        &local_dir.join("bin").join(binary_name("fennara-mcp")),
-        &layout.bin_dir.join(binary_name("fennara-mcp")),
-    )?;
-    copy_existing_launcher(
-        &local_dir.join("bin").join(binary_name("fennara-daemon")),
-        &layout.bin_dir.join(binary_name("fennara-daemon")),
-    )?;
+    if update_launchers {
+        println!("launchers: updating {}", display_path(&layout.bin_dir));
+        copy_existing_launcher(
+            &local_dir.join("bin").join(binary_name("fennara-mcp")),
+            &layout.bin_dir.join(binary_name("fennara-mcp")),
+        )?;
+        copy_existing_launcher(
+            &local_dir.join("bin").join(binary_name("fennara-daemon")),
+            &layout.bin_dir.join(binary_name("fennara-daemon")),
+        )?;
+    } else {
+        println!("launchers: keeping the active installation unchanged during staging");
+    }
     println!("runtimes: installing to {}", display_path(&version_dir));
     copy_file(
         &local_dir

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -3,7 +3,8 @@ use crate::operation::{self, FailureClass};
 use crate::release_client::{self, DownloadAsset, Release};
 use crate::release_manifest::ReleaseManifest;
 use crate::webview_runtime;
-use std::fs;
+use std::fs::{self, File};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 pub struct InstalledPackage {
@@ -342,6 +343,13 @@ fn install_from_assets(
         )?;
     } else {
         println!("launchers: keeping the active installation unchanged during staging");
+        let staged_launchers = version_dir.join("staged-launchers");
+        for launcher in ["fennara-mcp", "fennara-daemon"] {
+            copy_file(
+                &local_dir.join("bin").join(binary_name(launcher)),
+                &staged_launchers.join(binary_name(launcher)),
+            )?;
+        }
     }
     println!("runtimes: installing to {}", display_path(&version_dir));
     copy_file(
@@ -380,6 +388,35 @@ fn install_from_assets(
     })
 }
 
+pub fn activate_staged_launchers(version: &str) -> Result<(), String> {
+    let layout = AppLayout::detect()?;
+    let staged = layout.versions_dir.join(version).join("staged-launchers");
+    if !staged.is_dir() {
+        return Ok(());
+    }
+    let mut activated_all = true;
+    for launcher in ["fennara-mcp", "fennara-daemon"] {
+        let source = staged.join(binary_name(launcher));
+        let target = layout.bin_dir.join(binary_name(launcher));
+        if let Err(error) = copy_file(&source, &target) {
+            activated_all = false;
+            println!(
+                "warning: kept the current launcher at {}: {error}",
+                display_path(&target)
+            );
+        }
+    }
+    if activated_all {
+        fs::remove_dir_all(&staged).map_err(|error| {
+            format!(
+                "failed to remove activated launcher staging {}: {error}",
+                display_path(&staged)
+            )
+        })?;
+    }
+    Ok(())
+}
+
 pub fn activate_package(version: &str) -> Result<ActivationReceipt, String> {
     let layout = AppLayout::detect()?;
     activate_package_at(&layout, version)
@@ -412,13 +449,16 @@ pub(crate) fn restore_activation_at(
     layout: &AppLayout,
     receipt: ActivationReceipt,
 ) -> Result<(), String> {
-    match receipt.previous_manifest {
-        Some(previous) => fs::write(&layout.current_manifest_path, previous).map_err(|error| {
-            format!(
-                "failed to restore {}: {error}",
-                display_path(&layout.current_manifest_path)
-            )
-        }),
+    restore_manifest_at(layout, receipt.previous_manifest.as_deref())
+}
+
+pub fn restore_manifest(previous: Option<&[u8]>) -> Result<(), String> {
+    restore_manifest_at(&AppLayout::detect()?, previous)
+}
+
+fn restore_manifest_at(layout: &AppLayout, previous: Option<&[u8]>) -> Result<(), String> {
+    match previous {
+        Some(bytes) => write_current_manifest(&layout.current_manifest_path, bytes),
         None => match fs::remove_file(&layout.current_manifest_path) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -443,12 +483,36 @@ fn write_manifest(layout: &AppLayout, version: &str) -> Result<(), String> {
     });
     let raw = serde_json::to_string_pretty(&manifest)
         .map_err(|err| format!("failed to write manifest json: {err}"))?;
-    fs::write(&layout.current_manifest_path, format!("{raw}\n")).map_err(|err| {
-        format!(
-            "failed to write {}: {err}",
-            display_path(&layout.current_manifest_path)
-        )
-    })
+    write_current_manifest(&layout.current_manifest_path, format!("{raw}\n").as_bytes())
+}
+
+fn write_current_manifest(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let next = path.with_extension("json.next");
+    let previous = path.with_extension("json.previous");
+    let mut file = File::create(&next)
+        .map_err(|err| format!("failed to create {}: {err}", display_path(&next)))?;
+    file.write_all(bytes)
+        .and_then(|_| file.sync_all())
+        .map_err(|err| format!("failed to write {}: {err}", display_path(&next)))?;
+    if previous.exists() {
+        fs::remove_file(&previous)
+            .map_err(|err| format!("failed to remove {}: {err}", display_path(&previous)))?;
+    }
+    if path.exists() {
+        fs::rename(path, &previous)
+            .map_err(|err| format!("failed to preserve {}: {err}", display_path(path)))?;
+    }
+    if let Err(err) = fs::rename(&next, path) {
+        if previous.exists() {
+            let _ = fs::rename(&previous, path);
+        }
+        return Err(format!("failed to activate {}: {err}", display_path(path)));
+    }
+    if previous.exists() {
+        fs::remove_file(&previous)
+            .map_err(|err| format!("failed to remove {}: {err}", display_path(&previous)))?;
+    }
+    Ok(())
 }
 
 fn copy_file(source: &Path, target: &Path) -> Result<(), String> {

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -7,6 +7,8 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+mod install_lock;
+
 pub struct InstalledPackage {
     pub version: String,
     pub addon_dir: PathBuf,
@@ -326,6 +328,7 @@ fn install_from_assets(
         ));
     }
 
+    let _install_lock = install_lock::acquire(layout, version)?;
     let version_dir = layout.versions_dir.join(version);
     let addon_target = version_dir.join("addon");
     fs::create_dir_all(&version_dir)
@@ -399,22 +402,32 @@ pub(crate) fn activate_staged_launchers_at(
 ) -> Result<(), String> {
     let staged = layout.versions_dir.join(version).join("staged-launchers");
     if !staged.is_dir() {
-        return Ok(());
+        return Err(format!(
+            "staged launchers are missing: {}",
+            display_path(&staged)
+        ));
     }
     for launcher in ["fennara-mcp", "fennara-daemon"] {
         let source = staged.join(binary_name(launcher));
         let target = layout.bin_dir.join(binary_name(launcher));
-        copy_file(&source, &target)?;
-        fs::OpenOptions::new()
-            .write(true)
-            .open(&target)
-            .and_then(|file| file.sync_all())
-            .map_err(|error| {
-                format!(
-                    "failed to flush activated launcher {}: {error}",
-                    display_path(&target)
-                )
-            })?;
+        let activated = if launcher == "fennara-mcp" {
+            copy_existing_launcher(&source, &target)?
+        } else {
+            copy_file(&source, &target)?;
+            true
+        };
+        if activated {
+            fs::OpenOptions::new()
+                .write(true)
+                .open(&target)
+                .and_then(|file| file.sync_all())
+                .map_err(|error| {
+                    format!(
+                        "failed to flush activated launcher {}: {error}",
+                        display_path(&target)
+                    )
+                })?;
+        }
     }
     Ok(())
 }
@@ -549,24 +562,25 @@ fn copy_file(source: &Path, target: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn copy_existing_launcher(source: &Path, target: &Path) -> Result<(), String> {
+fn copy_existing_launcher(source: &Path, target: &Path) -> Result<bool, String> {
     if !source.is_file() {
         return Err(format!("missing package file: {}", display_path(source)));
     }
 
     if !target.exists() {
-        return copy_file(source, target);
+        copy_file(source, target)?;
+        return Ok(true);
     }
 
     match copy_file(source, target) {
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(true),
         Err(error) => {
             println!(
                 "warning: kept existing launcher because it could not be replaced: {}",
                 display_path(target)
             );
             println!("warning: {error}");
-            Ok(())
+            Ok(false)
         }
     }
 }

--- a/local/crates/fennara-cli/src/release_package/install_lock.rs
+++ b/local/crates/fennara-cli/src/release_package/install_lock.rs
@@ -1,0 +1,109 @@
+use crate::app_layout::{AppLayout, display_path};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::{Duration, Instant};
+use sysinfo::{Pid, System};
+
+const WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const RETRY_DELAY: Duration = Duration::from_millis(50);
+const OWNER_WRITE_GRACE: Duration = Duration::from_secs(10);
+
+pub(super) struct InstallLock {
+    path: PathBuf,
+}
+
+pub(super) fn acquire(layout: &AppLayout, version: &str) -> Result<InstallLock, String> {
+    let lock_dir = layout.versions_dir.join(".install-locks");
+    fs::create_dir_all(&lock_dir).map_err(|error| {
+        format!(
+            "failed to create package lock directory {}: {error}",
+            display_path(&lock_dir)
+        )
+    })?;
+    let lock_path = lock_dir.join(format!("{}.lock", lock_name(version)));
+    let deadline = Instant::now() + WAIT_TIMEOUT;
+
+    loop {
+        match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&lock_path)
+        {
+            Ok(mut file) => {
+                let lock = InstallLock {
+                    path: lock_path.clone(),
+                };
+                writeln!(file, "{}", std::process::id()).map_err(|error| {
+                    format!(
+                        "failed to record package lock owner {}: {error}",
+                        display_path(&lock_path)
+                    )
+                })?;
+                file.sync_all().map_err(|error| {
+                    format!(
+                        "failed to flush package lock {}: {error}",
+                        display_path(&lock_path)
+                    )
+                })?;
+                return Ok(lock);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if lock_is_stale(&lock_path) {
+                    let _ = fs::remove_file(&lock_path);
+                    continue;
+                }
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "timed out waiting for package installation lock {}",
+                        display_path(&lock_path)
+                    ));
+                }
+                thread::sleep(RETRY_DELAY);
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to acquire package installation lock {}: {error}",
+                    display_path(&lock_path)
+                ));
+            }
+        }
+    }
+}
+
+fn lock_is_stale(path: &Path) -> bool {
+    let owner = fs::read_to_string(path)
+        .ok()
+        .and_then(|value| value.trim().parse::<u32>().ok());
+    if let Some(pid) = owner {
+        let mut system = System::new();
+        system.refresh_processes();
+        return system.process(Pid::from_u32(pid)).is_none();
+    }
+
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age > OWNER_WRITE_GRACE)
+}
+
+fn lock_name(version: &str) -> String {
+    version
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+impl Drop for InstallLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -64,12 +64,16 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
         release_package::ensure_package(&options.version)?
     };
     if project_version.as_deref() == Some(package.version.as_str()) {
-        println!("guidance: refreshing AGENTS.md and addons/fennara/ai/guidelines.md");
-        project_guidance::write(&project_dir)?;
+        if !options.prepare {
+            println!("guidance: refreshing AGENTS.md and addons/fennara/ai/guidelines.md");
+            project_guidance::write(&project_dir)?;
+        }
         println!("Fennara is already up to date.");
         println!("version: {}", package.version);
         println!("project: {}", display_path(&project_dir));
-        println!("guidance: refreshed AGENTS.md and addons/fennara/ai/guidelines.md");
+        if !options.prepare {
+            println!("guidance: refreshed AGENTS.md and addons/fennara/ai/guidelines.md");
+        }
         webview_prereq::warn_for_current_platform()?;
         return Ok(());
     }

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -8,6 +8,7 @@ use crate::self_update::{self, StartResult};
 use crate::update_stage;
 use crate::webview_prereq;
 use std::path::PathBuf;
+use sysinfo::{Pid, System};
 
 pub fn run(args: Vec<&str>) -> Result<(), String> {
     operation::phase(Phase::Checking, "Validating project update request")?;
@@ -85,6 +86,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             project_version.as_deref().unwrap_or("unknown"),
             &package,
             &operation_id,
+            observed_godot_process(options.godot_pid, options.godot_executable.as_deref())?,
         )
         .map_err(|error| operation::failure(FailureClass::StageFilesystem, error))?;
         operation::phase(
@@ -124,6 +126,8 @@ struct UpdateOptions {
     project_dir: Option<PathBuf>,
     no_self_update: bool,
     prepare: bool,
+    godot_pid: Option<u32>,
+    godot_executable: Option<PathBuf>,
 }
 
 impl UpdateOptions {
@@ -132,6 +136,8 @@ impl UpdateOptions {
         let mut project_dir = None;
         let mut no_self_update = false;
         let mut prepare = false;
+        let mut godot_pid = None;
+        let mut godot_executable = None;
         let mut index = 0;
 
         while index < args.len() {
@@ -165,6 +171,25 @@ impl UpdateOptions {
                         return Err("--operation-id requires a value".to_string());
                     }
                 }
+                "--godot-pid" => {
+                    index += 1;
+                    godot_pid = Some(parse_pid(value_arg(&args, index, "--godot-pid")?)?);
+                }
+                arg if arg.starts_with("--godot-pid=") => {
+                    godot_pid = Some(parse_pid(arg.trim_start_matches("--godot-pid="))?);
+                }
+                "--godot-executable" => {
+                    index += 1;
+                    godot_executable = Some(PathBuf::from(value_arg(
+                        &args,
+                        index,
+                        "--godot-executable",
+                    )?));
+                }
+                arg if arg.starts_with("--godot-executable=") => {
+                    godot_executable =
+                        Some(PathBuf::from(arg.trim_start_matches("--godot-executable=")));
+                }
                 "-h" | "--help" => {
                     print_help();
                     return Err("".to_string());
@@ -179,6 +204,8 @@ impl UpdateOptions {
             project_dir,
             no_self_update,
             prepare,
+            godot_pid,
+            godot_executable,
         })
     }
 
@@ -196,8 +223,53 @@ impl UpdateOptions {
         if self.prepare {
             args.push("--prepare".to_string());
         }
+        if let Some(pid) = self.godot_pid {
+            args.push("--godot-pid".to_string());
+            args.push(pid.to_string());
+        }
+        if let Some(executable) = &self.godot_executable {
+            args.push("--godot-executable".to_string());
+            args.push(executable.display().to_string());
+        }
         args
     }
+}
+
+fn parse_pid(value: &str) -> Result<u32, String> {
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|pid| *pid > 0)
+        .ok_or_else(|| format!("invalid Godot process ID: {value}"))
+}
+
+fn observed_godot_process(
+    pid: Option<u32>,
+    executable: Option<&std::path::Path>,
+) -> Result<Option<(u32, u64, &std::path::Path)>, String> {
+    match (pid, executable) {
+        (None, None) => Ok(None),
+        (Some(pid), Some(executable)) => {
+            let mut system = System::new();
+            system.refresh_processes();
+            let process = system.process(Pid::from_u32(pid)).ok_or_else(|| {
+                format!("Godot process {pid} exited before update preparation completed")
+            })?;
+            if let Some(actual) = process.exe()
+                && canonical_or_original(actual) != canonical_or_original(executable)
+            {
+                return Err(format!(
+                    "process {pid} does not match the selected Godot executable"
+                ));
+            }
+            Ok(Some((pid, process.start_time(), executable)))
+        }
+        _ => Err("--godot-pid and --godot-executable must be provided together".to_string()),
+    }
+}
+
+fn canonical_or_original(path: &std::path::Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn value_arg<'a>(args: &'a [&str], index: usize, option: &str) -> Result<&'a str, String> {
@@ -232,6 +304,8 @@ mod tests {
             project_dir: Some(PathBuf::from("demo-project")),
             no_self_update: false,
             prepare: false,
+            godot_pid: None,
+            godot_executable: None,
         };
 
         assert_eq!(
@@ -263,6 +337,8 @@ mod tests {
             project_dir: Some(PathBuf::from("demo-project")),
             no_self_update: false,
             prepare: true,
+            godot_pid: None,
+            godot_executable: None,
         };
 
         assert!(

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -1,9 +1,11 @@
 use crate::app_layout::display_path;
 use crate::operation::{self, FailureClass, Phase};
+use crate::project_addon;
 use crate::project_guidance;
 use crate::project_install;
 use crate::release_package;
 use crate::self_update::{self, StartResult};
+use crate::update_stage;
 use crate::webview_prereq;
 use std::path::PathBuf;
 
@@ -27,6 +29,21 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             ),
         ));
     }
+    let project_version = if options.prepare {
+        Some(
+            project_addon::inspect(&project_dir)
+                .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?
+                .ok_or_else(|| {
+                    operation::failure(
+                        FailureClass::ProjectInvalid,
+                        "The project does not contain a complete Fennara addon to update.",
+                    )
+                })?
+                .version,
+        )
+    } else {
+        project_install::project_addon_version(&project_dir)
+    };
 
     if !options.no_self_update {
         println!("self-update: checking installed CLI");
@@ -40,8 +57,11 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     }
 
     println!("package: resolving update package");
-    let package = release_package::ensure_package(&options.version)?;
-    let project_version = project_install::project_addon_version(&project_dir);
+    let package = if options.prepare {
+        release_package::prepare_package(&options.version)?
+    } else {
+        release_package::ensure_package(&options.version)?
+    };
     if project_version.as_deref() == Some(package.version.as_str()) {
         println!("guidance: refreshing AGENTS.md and addons/fennara/ai/guidelines.md");
         project_guidance::write(&project_dir)?;
@@ -50,6 +70,32 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
         println!("project: {}", display_path(&project_dir));
         println!("guidance: refreshed AGENTS.md and addons/fennara/ai/guidelines.md");
         webview_prereq::warn_for_current_platform()?;
+        return Ok(());
+    }
+
+    if options.prepare {
+        operation::phase(
+            Phase::Staging,
+            "Copying the verified addon into project update staging",
+        )?;
+        let operation_id = operation::current_id()
+            .ok_or_else(|| "update staging requires an operation ID".to_string())?;
+        let staged = update_stage::prepare(
+            &project_dir,
+            project_version.as_deref().unwrap_or("unknown"),
+            &package,
+            &operation_id,
+        )
+        .map_err(|error| operation::failure(FailureClass::StageFilesystem, error))?;
+        operation::phase(
+            Phase::ReadyToClose,
+            "The verified update is staged and the active installation is unchanged",
+        )?;
+        operation::defer_completion()?;
+        println!("Fennara {} is ready to install.", staged.version);
+        println!("staging: {}", display_path(&staged.root));
+        println!("receipt: {}", display_path(&staged.receipt_path));
+        println!("The active addon and runtime have not been changed.");
         return Ok(());
     }
 
@@ -77,6 +123,7 @@ struct UpdateOptions {
     version: String,
     project_dir: Option<PathBuf>,
     no_self_update: bool,
+    prepare: bool,
 }
 
 impl UpdateOptions {
@@ -84,6 +131,7 @@ impl UpdateOptions {
         let mut version = "latest".to_string();
         let mut project_dir = None;
         let mut no_self_update = false;
+        let mut prepare = false;
         let mut index = 0;
 
         while index < args.len() {
@@ -105,6 +153,18 @@ impl UpdateOptions {
                 "--no-self-update" => {
                     no_self_update = true;
                 }
+                "--prepare" => {
+                    prepare = true;
+                }
+                "--operation-id" => {
+                    index += 1;
+                    value_arg(&args, index, "--operation-id")?;
+                }
+                arg if arg.starts_with("--operation-id=") => {
+                    if arg.trim_start_matches("--operation-id=").is_empty() {
+                        return Err("--operation-id requires a value".to_string());
+                    }
+                }
                 "-h" | "--help" => {
                     print_help();
                     return Err("".to_string());
@@ -118,6 +178,7 @@ impl UpdateOptions {
             version,
             project_dir,
             no_self_update,
+            prepare,
         })
     }
 
@@ -131,6 +192,9 @@ impl UpdateOptions {
         if let Some(project_dir) = &self.project_dir {
             args.push("--project".to_string());
             args.push(project_dir.display().to_string());
+        }
+        if self.prepare {
+            args.push("--prepare".to_string());
         }
         args
     }
@@ -152,6 +216,7 @@ Usage:
   fennara update --project <path>
   fennara update --version 0.2.8 --project <path>
   fennara update --no-self-update
+  fennara update --prepare --project <path>
 "
     );
 }
@@ -166,6 +231,7 @@ mod tests {
             version: "1.2.3".to_string(),
             project_dir: Some(PathBuf::from("demo-project")),
             no_self_update: false,
+            prepare: false,
         };
 
         assert_eq!(
@@ -188,5 +254,30 @@ mod tests {
 
         assert!(options.no_self_update);
         assert_eq!(options.version, "1.2.3");
+    }
+
+    #[test]
+    fn continuation_preserves_prepare_mode() {
+        let options = UpdateOptions {
+            version: "1.2.3".to_string(),
+            project_dir: Some(PathBuf::from("demo-project")),
+            no_self_update: false,
+            prepare: true,
+        };
+
+        assert!(
+            options
+                .continuation_args()
+                .contains(&"--prepare".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_accepts_prepare_and_operation_id() {
+        let options =
+            UpdateOptions::parse(vec!["--prepare", "--operation-id", "update-123-godot-456"])
+                .unwrap();
+
+        assert!(options.prepare);
     }
 }

--- a/local/crates/fennara-cli/src/update_apply/launchers.rs
+++ b/local/crates/fennara-cli/src/update_apply/launchers.rs
@@ -1,0 +1,94 @@
+use crate::app_layout::{AppLayout, binary_name, display_path};
+use std::fs;
+use std::path::Path;
+
+const SNAPSHOT_DIR: &str = "previous-launchers";
+
+pub(super) fn snapshot(layout: &AppLayout, root: &Path) -> Result<(), String> {
+    let snapshot = root.join(SNAPSHOT_DIR);
+    if snapshot.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(&snapshot).map_err(|error| {
+        format!(
+            "failed to create launcher snapshot {}: {error}",
+            display_path(&snapshot)
+        )
+    })?;
+    for launcher in launcher_names() {
+        let source = layout.bin_dir.join(&launcher);
+        if source.is_file() {
+            copy(&source, &snapshot.join(&launcher))?;
+        } else {
+            fs::write(snapshot.join(format!("{launcher}.missing")), b"missing\n").map_err(
+                |error| format!("failed to record missing launcher {launcher}: {error}"),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn restore(layout: &AppLayout, root: &Path) -> Result<(), String> {
+    let snapshot = root.join(SNAPSHOT_DIR);
+    if !snapshot.is_dir() {
+        return Err(format!(
+            "launcher snapshot is missing at {}",
+            display_path(&snapshot)
+        ));
+    }
+    for launcher in launcher_names() {
+        let saved = snapshot.join(&launcher);
+        let missing = snapshot.join(format!("{launcher}.missing"));
+        let target = layout.bin_dir.join(&launcher);
+        if saved.is_file() {
+            copy(&saved, &target)?;
+        } else if missing.is_file() {
+            if target.exists() {
+                fs::remove_file(&target).map_err(|error| {
+                    format!(
+                        "failed to remove newly installed launcher {}: {error}",
+                        display_path(&target)
+                    )
+                })?;
+            }
+        } else {
+            return Err(format!("launcher snapshot is incomplete for {launcher}"));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn cleanup(root: &Path) -> Result<(), String> {
+    let snapshot = root.join(SNAPSHOT_DIR);
+    if snapshot.exists() {
+        fs::remove_dir_all(&snapshot).map_err(|error| {
+            format!(
+                "failed to remove launcher snapshot {}: {error}",
+                display_path(&snapshot)
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn launcher_names() -> [String; 2] {
+    [binary_name("fennara-mcp"), binary_name("fennara-daemon")]
+}
+
+fn copy(source: &Path, target: &Path) -> Result<(), String> {
+    fs::copy(source, target).map_err(|error| {
+        format!(
+            "failed to copy launcher {} to {}: {error}",
+            display_path(source),
+            display_path(target)
+        )
+    })?;
+    fs::OpenOptions::new()
+        .write(true)
+        .open(target)
+        .and_then(|file| file.sync_all())
+        .map_err(|error| format!("failed to flush launcher {}: {error}", display_path(target)))
+}
+
+#[cfg(test)]
+mod tests;

--- a/local/crates/fennara-cli/src/update_apply/launchers/tests.rs
+++ b/local/crates/fennara-cli/src/update_apply/launchers/tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+use crate::release_package;
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn restores_both_launchers_after_partial_activation() {
+    let root = TestRoot::new("partial");
+    let layout = layout(&root);
+    let transaction = root.join("transaction");
+    fs::create_dir_all(&layout.bin_dir).unwrap();
+    fs::create_dir_all(layout.versions_dir.join("1.1.0/staged-launchers")).unwrap();
+    fs::write(layout.bin_dir.join(binary_name("fennara-mcp")), b"old-mcp").unwrap();
+    fs::write(
+        layout.bin_dir.join(binary_name("fennara-daemon")),
+        b"old-daemon",
+    )
+    .unwrap();
+    fs::write(
+        layout
+            .versions_dir
+            .join("1.1.0/staged-launchers")
+            .join(binary_name("fennara-mcp")),
+        b"new-mcp",
+    )
+    .unwrap();
+
+    snapshot(&layout, &transaction).unwrap();
+    assert!(release_package::activate_staged_launchers_at(&layout, "1.1.0").is_err());
+    restore(&layout, &transaction).unwrap();
+
+    assert_eq!(
+        fs::read(layout.bin_dir.join(binary_name("fennara-mcp"))).unwrap(),
+        b"old-mcp"
+    );
+    assert_eq!(
+        fs::read(layout.bin_dir.join(binary_name("fennara-daemon"))).unwrap(),
+        b"old-daemon"
+    );
+}
+
+#[test]
+fn repeated_launcher_restore_is_idempotent() {
+    let root = TestRoot::new("repeated");
+    let layout = layout(&root);
+    let transaction = root.join("transaction");
+    fs::create_dir_all(&layout.bin_dir).unwrap();
+    fs::write(layout.bin_dir.join(binary_name("fennara-mcp")), b"old-mcp").unwrap();
+
+    snapshot(&layout, &transaction).unwrap();
+    fs::write(layout.bin_dir.join(binary_name("fennara-mcp")), b"new-mcp").unwrap();
+    fs::write(
+        layout.bin_dir.join(binary_name("fennara-daemon")),
+        b"new-daemon",
+    )
+    .unwrap();
+
+    restore(&layout, &transaction).unwrap();
+    restore(&layout, &transaction).unwrap();
+
+    assert_eq!(
+        fs::read(layout.bin_dir.join(binary_name("fennara-mcp"))).unwrap(),
+        b"old-mcp"
+    );
+    assert!(!layout.bin_dir.join(binary_name("fennara-daemon")).exists());
+}
+
+fn layout(root: &Path) -> AppLayout {
+    AppLayout {
+        app_dir: root.join("app"),
+        bin_dir: root.join("app/bin"),
+        versions_dir: root.join("app/versions"),
+        cache_dir: root.join("app/cache"),
+        logs_dir: root.join("app/logs"),
+        operation_logs_dir: root.join("app/logs/operations"),
+        operations_dir: root.join("app/operations"),
+        tools_dir: root.join("app/tools"),
+        webview_dir: root.join("app/webview"),
+        current_manifest_path: root.join("app/current.json"),
+    }
+}
+
+struct TestRoot(PathBuf);
+
+impl TestRoot {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        Self(std::env::temp_dir().join(format!(
+            "fennara-update-launchers-{name}-{}-{nonce}",
+            std::process::id()
+        )))
+    }
+}
+
+impl Deref for TestRoot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/local/crates/fennara-cli/src/update_apply/launchers/tests.rs
+++ b/local/crates/fennara-cli/src/update_apply/launchers/tests.rs
@@ -66,6 +66,14 @@ fn repeated_launcher_restore_is_idempotent() {
     assert!(!layout.bin_dir.join(binary_name("fennara-daemon")).exists());
 }
 
+#[test]
+fn activation_requires_staged_launchers() {
+    let root = TestRoot::new("missing-staged");
+    let layout = layout(&root);
+
+    assert!(release_package::activate_staged_launchers_at(&layout, "1.1.0").is_err());
+}
+
 fn layout(root: &Path) -> AppLayout {
     AppLayout {
         app_dir: root.join("app"),

--- a/local/crates/fennara-cli/src/update_apply/mod.rs
+++ b/local/crates/fennara-cli/src/update_apply/mod.rs
@@ -1,9 +1,13 @@
+mod launchers;
 mod options;
 mod process;
+mod recovery;
 mod transaction;
 
 use self::options::ApplyOptions;
-use self::process::{observe_process, reopen_godot, wait_for_process_exit};
+use self::process::{
+    current_process_started_at, observe_process, reopen_godot, wait_for_process_exit,
+};
 use crate::operation::{self, FailureClass, Phase};
 use crate::project_guidance;
 use crate::release_package;
@@ -14,6 +18,10 @@ use std::time::Duration;
 pub const COMPLETE_COMMAND: &str = "__complete-project-update";
 pub const ROLLBACK_COMMAND: &str = "__rollback-project-update";
 const GODOT_EXIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+pub fn recover(args: Vec<&str>) -> Result<(), String> {
+    recovery::run(args)
+}
 
 pub fn complete(args: Vec<&str>) -> Result<(), String> {
     let options = ApplyOptions::parse(args)?;
@@ -26,6 +34,7 @@ pub fn complete(args: Vec<&str>) -> Result<(), String> {
     receipt.godot_started_at = Some(process.started_at);
     receipt.godot_executable = Some(options.godot_executable.display().to_string());
     receipt.updater_pid = Some(std::process::id());
+    receipt.updater_started_at = current_process_started_at();
     set_state(&receipt_path, &mut receipt, "waiting_for_godot")?;
     operation::phase(
         Phase::WaitingForGodot,
@@ -51,6 +60,7 @@ pub fn rollback(args: Vec<&str>) -> Result<(), String> {
     validate_receipt_identity(&receipt, &options.operation_id)?;
     let process = observe_process(options.wait_for_pid, &options.godot_executable)?;
     receipt.updater_pid = Some(std::process::id());
+    receipt.updater_started_at = current_process_started_at();
     set_state(&receipt_path, &mut receipt, "waiting_for_godot")?;
     operation::phase(
         Phase::WaitingForGodot,
@@ -71,13 +81,15 @@ pub fn rollback(args: Vec<&str>) -> Result<(), String> {
         "Restoring the previous Fennara addon and runtime",
     )?;
     transaction::restore_previous(&options.project_dir, &root)?;
-    set_state(&receipt_path, &mut receipt, "rolled_back")?;
-    operation::phase(
+    let state_result = set_state(&receipt_path, &mut receipt, "rolled_back");
+    let phase_result = operation::phase(
         Phase::RolledBack,
         "The previous Fennara version was restored",
-    )?;
+    );
     reopen_godot(&options.godot_executable, &options.project_dir)
         .map_err(|error| operation::failure(FailureClass::HandoffFailed, error))?;
+    state_result?;
+    phase_result?;
     operation::defer_completion()?;
     Ok(())
 }

--- a/local/crates/fennara-cli/src/update_apply/mod.rs
+++ b/local/crates/fennara-cli/src/update_apply/mod.rs
@@ -1,0 +1,126 @@
+mod options;
+mod process;
+mod transaction;
+
+use self::options::ApplyOptions;
+use self::process::{observe_process, reopen_godot, wait_for_process_exit};
+use crate::operation::{self, FailureClass, Phase};
+use crate::project_guidance;
+use crate::release_package;
+use crate::update_stage::{self, UpdateReceipt};
+use std::path::Path;
+use std::time::Duration;
+
+pub const COMPLETE_COMMAND: &str = "__complete-project-update";
+pub const ROLLBACK_COMMAND: &str = "__rollback-project-update";
+const GODOT_EXIT_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+
+pub fn complete(args: Vec<&str>) -> Result<(), String> {
+    let options = ApplyOptions::parse(args)?;
+    let root = update_stage::staging_root(&options.project_dir, &options.operation_id)?;
+    let receipt_path = root.join("receipt.json");
+    let mut receipt = update_stage::read_receipt(&receipt_path)?;
+    validate_receipt_identity(&receipt, &options.operation_id)?;
+    let process = observe_process(options.wait_for_pid, &options.godot_executable)?;
+    receipt.godot_pid = Some(process.pid);
+    receipt.godot_started_at = Some(process.started_at);
+    receipt.godot_executable = Some(options.godot_executable.display().to_string());
+    receipt.updater_pid = Some(std::process::id());
+    set_state(&receipt_path, &mut receipt, "waiting_for_godot")?;
+    operation::phase(
+        Phase::WaitingForGodot,
+        "Waiting for the confirmed Godot editor process to close",
+    )?;
+    if !wait_for_process_exit(&process, &root.join("cancel"), GODOT_EXIT_TIMEOUT) {
+        set_state(&receipt_path, &mut receipt, "ready_to_close")?;
+        operation::phase(
+            Phase::ReadyToClose,
+            "Godot stayed open, so the staged update remains ready for another attempt",
+        )?;
+        operation::defer_completion()?;
+        return Ok(());
+    }
+    transaction::apply_after_exit(&options, &root, &receipt_path, &mut receipt)
+}
+
+pub fn rollback(args: Vec<&str>) -> Result<(), String> {
+    let options = ApplyOptions::parse(args)?;
+    let root = update_stage::staging_root(&options.project_dir, &options.operation_id)?;
+    let receipt_path = root.join("receipt.json");
+    let mut receipt = update_stage::read_receipt(&receipt_path)?;
+    validate_receipt_identity(&receipt, &options.operation_id)?;
+    let process = observe_process(options.wait_for_pid, &options.godot_executable)?;
+    receipt.updater_pid = Some(std::process::id());
+    set_state(&receipt_path, &mut receipt, "waiting_for_godot")?;
+    operation::phase(
+        Phase::WaitingForGodot,
+        "Waiting for Godot to close before restoring the previous version",
+    )?;
+    if !wait_for_process_exit(&process, &root.join("cancel"), GODOT_EXIT_TIMEOUT) {
+        set_state(&receipt_path, &mut receipt, "recovery_required")?;
+        operation::phase(
+            Phase::RecoveryRequired,
+            "Godot stayed open, so recovery still requires editor shutdown",
+        )?;
+        operation::defer_completion()?;
+        return Ok(());
+    }
+
+    operation::phase(
+        Phase::Applying,
+        "Restoring the previous Fennara addon and runtime",
+    )?;
+    transaction::restore_previous(&options.project_dir, &root)?;
+    set_state(&receipt_path, &mut receipt, "rolled_back")?;
+    operation::phase(
+        Phase::RolledBack,
+        "The previous Fennara version was restored",
+    )?;
+    reopen_godot(&options.godot_executable, &options.project_dir)
+        .map_err(|error| operation::failure(FailureClass::HandoffFailed, error))?;
+    operation::defer_completion()?;
+    Ok(())
+}
+
+pub(super) fn set_state(
+    path: &Path,
+    receipt: &mut UpdateReceipt,
+    state: &str,
+) -> Result<(), String> {
+    receipt.state = state.to_string();
+    update_stage::write_receipt(path, receipt)
+}
+
+fn validate_receipt_identity(receipt: &UpdateReceipt, operation_id: &str) -> Result<(), String> {
+    if receipt.operation_id == operation_id {
+        Ok(())
+    } else {
+        Err(format!(
+            "update receipt belongs to operation {}, not {operation_id}",
+            receipt.operation_id
+        ))
+    }
+}
+
+pub(super) fn recovery_required(
+    receipt_path: &Path,
+    receipt: &mut UpdateReceipt,
+    error: String,
+) -> Result<(), String> {
+    set_state(receipt_path, receipt, "recovery_required")?;
+    operation::phase(
+        Phase::RecoveryRequired,
+        "The updated editor is open but validation failed; user-confirmed recovery is required",
+    )?;
+    operation::defer_completion()?;
+    eprintln!("update validation failed: {error}");
+    Ok(())
+}
+
+pub(super) fn activate_runtime_and_guidance(
+    project_dir: &Path,
+    version: &str,
+) -> Result<(), String> {
+    release_package::activate_package(version)?;
+    project_guidance::write(project_dir)
+}

--- a/local/crates/fennara-cli/src/update_apply/options.rs
+++ b/local/crates/fennara-cli/src/update_apply/options.rs
@@ -1,0 +1,66 @@
+use crate::operation;
+use std::path::PathBuf;
+
+pub(super) struct ApplyOptions {
+    pub project_dir: PathBuf,
+    pub operation_id: String,
+    pub wait_for_pid: u32,
+    pub godot_executable: PathBuf,
+}
+
+impl ApplyOptions {
+    pub(super) fn parse(args: Vec<&str>) -> Result<Self, String> {
+        let mut project_dir = None;
+        let mut operation_id = None;
+        let mut wait_for_pid = None;
+        let mut godot_executable = None;
+        let mut index = 0;
+        while index < args.len() {
+            match args[index] {
+                "--project" => {
+                    index += 1;
+                    project_dir = Some(PathBuf::from(value(&args, index, "--project")?));
+                }
+                "--resume-operation" => {
+                    index += 1;
+                    operation_id = Some(value(&args, index, "--resume-operation")?.to_string());
+                }
+                "--wait-for-pid" => {
+                    index += 1;
+                    wait_for_pid = Some(parse_pid(value(&args, index, "--wait-for-pid")?)?);
+                }
+                "--godot-executable" => {
+                    index += 1;
+                    godot_executable =
+                        Some(PathBuf::from(value(&args, index, "--godot-executable")?));
+                }
+                other => return Err(format!("unknown update completion option: {other}")),
+            }
+            index += 1;
+        }
+        let operation_id =
+            operation_id.ok_or_else(|| "--resume-operation is required".to_string())?;
+        operation::validate_id(&operation_id)?;
+        Ok(Self {
+            project_dir: project_dir.ok_or_else(|| "--project is required".to_string())?,
+            operation_id,
+            wait_for_pid: wait_for_pid.ok_or_else(|| "--wait-for-pid is required".to_string())?,
+            godot_executable: godot_executable
+                .ok_or_else(|| "--godot-executable is required".to_string())?,
+        })
+    }
+}
+
+fn value<'a>(args: &'a [&str], index: usize, option: &str) -> Result<&'a str, String> {
+    args.get(index)
+        .copied()
+        .ok_or_else(|| format!("{option} requires a value"))
+}
+
+fn parse_pid(value: &str) -> Result<u32, String> {
+    value
+        .parse::<u32>()
+        .ok()
+        .filter(|pid| *pid > 0)
+        .ok_or_else(|| format!("invalid process ID: {value}"))
+}

--- a/local/crates/fennara-cli/src/update_apply/process.rs
+++ b/local/crates/fennara-cli/src/update_apply/process.rs
@@ -105,6 +105,25 @@ fn pid_exists(pid: u32) -> bool {
     system.process(Pid::from_u32(pid)).is_some()
 }
 
+pub(super) fn identity_is_running(pid: Option<u32>, started_at: Option<u64>) -> bool {
+    let (Some(pid), Some(started_at)) = (pid, started_at) else {
+        return false;
+    };
+    let mut system = System::new();
+    system.refresh_processes();
+    system
+        .process(Pid::from_u32(pid))
+        .is_some_and(|process| process.start_time() == started_at)
+}
+
+pub(super) fn current_process_started_at() -> Option<u64> {
+    let mut system = System::new();
+    system.refresh_processes();
+    system
+        .process(Pid::from_u32(std::process::id()))
+        .map(|process| process.start_time())
+}
+
 fn canonical_or_original(path: &Path) -> PathBuf {
     fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/local/crates/fennara-cli/src/update_apply/process.rs
+++ b/local/crates/fennara-cli/src/update_apply/process.rs
@@ -1,0 +1,110 @@
+use crate::app_layout::display_path;
+use serde_json::Value;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+use sysinfo::{Pid, System};
+
+const ACTIVATION_TIMEOUT: Duration = Duration::from_secs(90);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+pub(super) struct ProcessIdentity {
+    pub pid: u32,
+    pub started_at: u64,
+}
+
+pub(super) fn observe_process(pid: u32, executable: &Path) -> Result<ProcessIdentity, String> {
+    let mut system = System::new();
+    system.refresh_processes();
+    let process = system
+        .process(Pid::from_u32(pid))
+        .ok_or_else(|| format!("Godot process {pid} is not running"))?;
+    if let Some(actual) = process.exe()
+        && canonical_or_original(actual) != canonical_or_original(executable)
+    {
+        return Err(format!(
+            "process {pid} does not match the selected Godot executable"
+        ));
+    }
+    Ok(ProcessIdentity {
+        pid,
+        started_at: process.start_time(),
+    })
+}
+
+pub(super) fn wait_for_process_exit(
+    process: &ProcessIdentity,
+    cancel: &Path,
+    timeout: Duration,
+) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if cancel.exists() {
+            let _ = fs::remove_file(cancel);
+            return false;
+        }
+        let mut system = System::new();
+        system.refresh_processes();
+        match system.process(Pid::from_u32(process.pid)) {
+            Some(current) if current.start_time() == process.started_at => {
+                thread::sleep(POLL_INTERVAL)
+            }
+            _ => return true,
+        }
+    }
+    false
+}
+
+pub(super) fn reopen_godot(executable: &Path, project_dir: &Path) -> Result<u32, String> {
+    let child = Command::new(executable)
+        .arg("--editor")
+        .arg("--path")
+        .arg(project_dir)
+        .spawn()
+        .map_err(|error| {
+            format!(
+                "failed to reopen Godot through {}: {error}",
+                display_path(executable)
+            )
+        })?;
+    Ok(child.id())
+}
+
+pub(super) fn wait_for_handshake(
+    root: &Path,
+    operation_id: &str,
+    expected_version: &str,
+    reopened_pid: u32,
+) -> Result<(), String> {
+    let path = root.join("activation-handshake.json");
+    let deadline = Instant::now() + ACTIVATION_TIMEOUT;
+    while Instant::now() < deadline {
+        if let Ok(raw) = fs::read(&path)
+            && let Ok(value) = serde_json::from_slice::<Value>(&raw)
+            && value.get("operation_id").and_then(Value::as_str) == Some(operation_id)
+            && value.get("addon_version").and_then(Value::as_str) == Some(expected_version)
+        {
+            return Ok(());
+        }
+        if !pid_exists(reopened_pid) {
+            return Err("Godot exited before the updated addon reported activation".to_string());
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+    Err(format!(
+        "updated addon did not report activation within {} seconds",
+        ACTIVATION_TIMEOUT.as_secs()
+    ))
+}
+
+fn pid_exists(pid: u32) -> bool {
+    let mut system = System::new();
+    system.refresh_processes();
+    system.process(Pid::from_u32(pid)).is_some()
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}

--- a/local/crates/fennara-cli/src/update_apply/recovery.rs
+++ b/local/crates/fennara-cli/src/update_apply/recovery.rs
@@ -1,0 +1,126 @@
+use super::process::{identity_is_running, reopen_godot};
+use super::{set_state, transaction};
+use crate::app_layout::display_path;
+use crate::operation::{self, Phase};
+use crate::update_stage::{self, UpdateReceipt};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+pub(super) fn run(args: Vec<&str>) -> Result<(), String> {
+    let options = RecoveryOptions::parse(args)?;
+    let (root, mut receipt) =
+        find_operation(&options.project_dir, options.operation_id.as_deref())?;
+    if identity_is_running(receipt.updater_pid, receipt.updater_started_at) {
+        return Err(
+            "the update process is still running; wait for it to finish before recovery"
+                .to_string(),
+        );
+    }
+    if identity_is_running(receipt.godot_pid, receipt.godot_started_at) {
+        return Err("close the Godot editor for this project before recovery".to_string());
+    }
+
+    operation::phase(Phase::Applying, "Restoring an interrupted Fennara update")?;
+    transaction::restore_previous(&options.project_dir, &root)?;
+    set_state(&root.join("receipt.json"), &mut receipt, "rolled_back")?;
+    operation::phase(Phase::RolledBack, "The interrupted update was restored")?;
+    if let Some(executable) = receipt.godot_executable.as_deref().map(Path::new)
+        && executable.is_file()
+    {
+        reopen_godot(executable, &options.project_dir)?;
+    }
+    println!(
+        "restored Fennara {} for {}",
+        receipt.from_version,
+        display_path(&options.project_dir)
+    );
+    Ok(())
+}
+
+fn find_operation(
+    project_dir: &Path,
+    operation_id: Option<&str>,
+) -> Result<(PathBuf, UpdateReceipt), String> {
+    if let Some(operation_id) = operation_id {
+        let root = update_stage::staging_root(project_dir, operation_id)?;
+        let receipt = update_stage::read_receipt(&root.join("receipt.json"))?;
+        return Ok((root, receipt));
+    }
+
+    let parent = project_dir.join(".godot/fennara-update");
+    let mut candidates = Vec::new();
+    for entry in fs::read_dir(&parent).map_err(|error| {
+        format!(
+            "failed to read update recovery directory {}: {error}",
+            display_path(&parent)
+        )
+    })? {
+        let entry =
+            entry.map_err(|error| format!("failed to read update recovery entry: {error}"))?;
+        if !entry.path().is_dir() || entry.file_name().to_string_lossy().ends_with(".preparing") {
+            continue;
+        }
+        let Ok(receipt) = update_stage::read_receipt(&entry.path().join("receipt.json")) else {
+            continue;
+        };
+        if !matches!(
+            receipt.state.as_str(),
+            "applying" | "reopening" | "validating" | "recovery_required"
+        ) {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        candidates.push((modified, entry.path(), receipt));
+    }
+    candidates
+        .into_iter()
+        .max_by_key(|candidate| candidate.0)
+        .map(|(_, root, receipt)| (root, receipt))
+        .ok_or_else(|| "no interrupted Fennara update is available to recover".to_string())
+}
+
+struct RecoveryOptions {
+    project_dir: PathBuf,
+    operation_id: Option<String>,
+}
+
+impl RecoveryOptions {
+    fn parse(args: Vec<&str>) -> Result<Self, String> {
+        let mut project_dir = None;
+        let mut operation_id = None;
+        let mut index = 0;
+        while index < args.len() {
+            match args[index] {
+                "--project" => {
+                    index += 1;
+                    project_dir = Some(PathBuf::from(value(&args, index, "--project")?));
+                }
+                "--operation" => {
+                    index += 1;
+                    let value = value(&args, index, "--operation")?;
+                    operation::validate_id(value)?;
+                    operation_id = Some(value.to_string());
+                }
+                other => return Err(format!("unknown recovery option: {other}")),
+            }
+            index += 1;
+        }
+        Ok(Self {
+            project_dir: project_dir.ok_or_else(|| "--project is required".to_string())?,
+            operation_id,
+        })
+    }
+}
+
+fn value<'a>(args: &'a [&str], index: usize, option: &str) -> Result<&'a str, String> {
+    args.get(index)
+        .copied()
+        .ok_or_else(|| format!("{option} requires a value"))
+}
+
+#[cfg(test)]
+mod tests;

--- a/local/crates/fennara-cli/src/update_apply/recovery.rs
+++ b/local/crates/fennara-cli/src/update_apply/recovery.rs
@@ -27,8 +27,9 @@ pub(super) fn run(args: Vec<&str>) -> Result<(), String> {
     operation::phase(Phase::RolledBack, "The interrupted update was restored")?;
     if let Some(executable) = receipt.godot_executable.as_deref().map(Path::new)
         && executable.is_file()
+        && let Err(error) = reopen_godot(executable, &options.project_dir)
     {
-        reopen_godot(executable, &options.project_dir)?;
+        eprintln!("warning: restored Fennara but failed to reopen Godot: {error}");
     }
     println!(
         "restored Fennara {} for {}",
@@ -45,6 +46,12 @@ fn find_operation(
     if let Some(operation_id) = operation_id {
         let root = update_stage::staging_root(project_dir, operation_id)?;
         let receipt = update_stage::read_receipt(&root.join("receipt.json"))?;
+        if !is_recoverable(&receipt) {
+            return Err(format!(
+                "Fennara update {operation_id} is not recoverable from state {}",
+                receipt.state
+            ));
+        }
         return Ok((root, receipt));
     }
 
@@ -64,10 +71,7 @@ fn find_operation(
         let Ok(receipt) = update_stage::read_receipt(&entry.path().join("receipt.json")) else {
             continue;
         };
-        if !matches!(
-            receipt.state.as_str(),
-            "applying" | "reopening" | "validating" | "recovery_required"
-        ) {
+        if !is_recoverable(&receipt) {
             continue;
         }
         let modified = entry
@@ -81,6 +85,13 @@ fn find_operation(
         .max_by_key(|candidate| candidate.0)
         .map(|(_, root, receipt)| (root, receipt))
         .ok_or_else(|| "no interrupted Fennara update is available to recover".to_string())
+}
+
+fn is_recoverable(receipt: &UpdateReceipt) -> bool {
+    matches!(
+        receipt.state.as_str(),
+        "applying" | "reopening" | "validating" | "recovery_required"
+    )
 }
 
 struct RecoveryOptions {

--- a/local/crates/fennara-cli/src/update_apply/recovery/tests.rs
+++ b/local/crates/fennara-cli/src/update_apply/recovery/tests.rs
@@ -1,0 +1,84 @@
+use super::*;
+use crate::app_layout::{arch_name, platform_name};
+use crate::update_stage::{BACKUP_ADDON_NAME, STAGED_ADDON_NAME};
+use std::ops::Deref;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn finds_interrupted_operation_without_loading_addon() {
+    let root = TestRoot::new("find");
+    let project = root.join("project");
+    let operation = update_stage::staging_root(&project, "update-123-recovery").unwrap();
+    fs::create_dir_all(&operation).unwrap();
+    let receipt = receipt("update-123-recovery", "recovery_required");
+    update_stage::write_receipt(&operation.join("receipt.json"), &receipt).unwrap();
+
+    let (found_root, found_receipt) = find_operation(&project, None).unwrap();
+
+    assert_eq!(found_root, operation);
+    assert_eq!(found_receipt.operation_id, "update-123-recovery");
+}
+
+#[test]
+fn ignores_updates_that_are_only_ready_to_close() {
+    let root = TestRoot::new("ready");
+    let project = root.join("project");
+    let operation = update_stage::staging_root(&project, "update-456-ready").unwrap();
+    fs::create_dir_all(&operation).unwrap();
+    let receipt = receipt("update-456-ready", "ready_to_close");
+    update_stage::write_receipt(&operation.join("receipt.json"), &receipt).unwrap();
+
+    assert!(find_operation(&project, None).is_err());
+}
+
+fn receipt(operation_id: &str, state: &str) -> UpdateReceipt {
+    UpdateReceipt {
+        schema_version: 2,
+        operation_id: operation_id.to_string(),
+        state: state.to_string(),
+        from_version: "1.0.0".to_string(),
+        to_version: "1.1.0".to_string(),
+        platform: platform_name().to_string(),
+        architecture: arch_name().to_string(),
+        addon: STAGED_ADDON_NAME.to_string(),
+        backup_addon: BACKUP_ADDON_NAME.to_string(),
+        addon_sha256: "a".repeat(64),
+        godot_pid: None,
+        godot_started_at: None,
+        godot_executable: None,
+        had_current_manifest: None,
+        launchers_snapshotted: false,
+        addon_replaced: false,
+        updater_pid: None,
+        updater_started_at: None,
+    }
+}
+
+struct TestRoot(PathBuf);
+
+impl TestRoot {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        Self(std::env::temp_dir().join(format!(
+            "fennara-update-recovery-{name}-{}-{nonce}",
+            std::process::id()
+        )))
+    }
+}
+
+impl Deref for TestRoot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/local/crates/fennara-cli/src/update_apply/recovery/tests.rs
+++ b/local/crates/fennara-cli/src/update_apply/recovery/tests.rs
@@ -31,6 +31,19 @@ fn ignores_updates_that_are_only_ready_to_close() {
     assert!(find_operation(&project, None).is_err());
 }
 
+#[test]
+fn rejects_explicit_update_that_is_only_ready_to_close() {
+    let root = TestRoot::new("explicit-ready");
+    let project = root.join("project");
+    fs::create_dir_all(&project).unwrap();
+    let operation = update_stage::staging_root(&project, "update-456-ready").unwrap();
+    fs::create_dir_all(&operation).unwrap();
+    let receipt = receipt("update-456-ready", "ready_to_close");
+    update_stage::write_receipt(&operation.join("receipt.json"), &receipt).unwrap();
+
+    assert!(find_operation(&project, Some("update-456-ready")).is_err());
+}
+
 fn receipt(operation_id: &str, state: &str) -> UpdateReceipt {
     UpdateReceipt {
         schema_version: 2,

--- a/local/crates/fennara-cli/src/update_apply/transaction.rs
+++ b/local/crates/fennara-cli/src/update_apply/transaction.rs
@@ -1,0 +1,234 @@
+use super::options::ApplyOptions;
+use super::process::{reopen_godot, wait_for_handshake};
+use super::{activate_runtime_and_guidance, recovery_required, set_state};
+use crate::app_layout::{AppLayout, display_path};
+use crate::daemon_setup;
+use crate::operation::{self, FailureClass, Phase};
+use crate::project_addon;
+use crate::project_install;
+use crate::release_package;
+use crate::update_stage::{self, UpdateReceipt};
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::Path;
+
+pub(super) fn apply_after_exit(
+    options: &ApplyOptions,
+    root: &Path,
+    receipt_path: &Path,
+    receipt: &mut UpdateReceipt,
+) -> Result<(), String> {
+    operation::phase(
+        Phase::Applying,
+        "Replacing the project addon with the verified update",
+    )?;
+    set_state(receipt_path, receipt, "applying")?;
+    let layout = AppLayout::detect()?;
+    daemon_setup::shutdown_if_running(&layout)
+        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+    release_package::activate_staged_launchers(&receipt.to_version)
+        .map_err(|error| operation::failure(FailureClass::StageFilesystem, error))?;
+    persist_previous_manifest(&layout, root, receipt)?;
+    replace_addon(&options.project_dir, root, receipt)?;
+
+    if let Err(error) = activate_runtime_and_guidance(&options.project_dir, &receipt.to_version) {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
+    operation::phase(Phase::Reopening, "Reopening Godot with the updated addon")?;
+    set_state(receipt_path, receipt, "reopening")?;
+    let reopened_pid = match reopen_godot(&options.godot_executable, &options.project_dir) {
+        Ok(pid) => pid,
+        Err(error) => return rollback_before_reopen(options, root, receipt_path, receipt, error),
+    };
+    operation::phase(
+        Phase::Validating,
+        "Waiting for the updated GDExtension activation handshake",
+    )?;
+    set_state(receipt_path, receipt, "validating")?;
+    if let Err(error) = wait_for_handshake(
+        root,
+        &receipt.operation_id,
+        &receipt.to_version,
+        reopened_pid,
+    ) {
+        return recovery_required(receipt_path, receipt, error);
+    }
+    if let Err(error) = daemon_setup::ensure_running(&layout, &receipt.to_version) {
+        return recovery_required(receipt_path, receipt, error);
+    }
+    remove_validated_backup(root, receipt)?;
+    set_state(receipt_path, receipt, "succeeded")?;
+    operation::phase(
+        Phase::Succeeded,
+        "The updated addon and runtime were validated",
+    )
+}
+
+fn replace_addon(project_dir: &Path, root: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
+    let active = project_install::project_addon_dir(project_dir);
+    let staged = root.join(&receipt.addon);
+    let backup = root.join(&receipt.backup_addon);
+    project_addon::validate(&staged)
+        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+    if backup.exists() {
+        return Err(operation::failure(
+            FailureClass::RollbackFailed,
+            format!("update backup already exists at {}", display_path(&backup)),
+        ));
+    }
+    fs::rename(&active, &backup).map_err(|error| {
+        operation::failure(
+            FailureClass::StageFilesystem,
+            format!(
+                "failed to move the current addon {} to its update backup: {error}",
+                display_path(&active)
+            ),
+        )
+    })?;
+    if let Err(error) = fs::rename(&staged, &active) {
+        let restore = fs::rename(&backup, &active);
+        return Err(if let Err(restore_error) = restore {
+            operation::failure(
+                FailureClass::RollbackFailed,
+                format!(
+                    "failed to activate staged addon: {error}; failed to restore previous addon: {restore_error}"
+                ),
+            )
+        } else {
+            operation::failure(
+                FailureClass::StageFilesystem,
+                format!("failed to activate the staged addon: {error}"),
+            )
+        });
+    }
+    Ok(())
+}
+
+fn rollback_before_reopen(
+    options: &ApplyOptions,
+    root: &Path,
+    receipt_path: &Path,
+    receipt: &mut UpdateReceipt,
+    original_error: String,
+) -> Result<(), String> {
+    match restore_previous(&options.project_dir, root) {
+        Ok(()) => {
+            set_state(receipt_path, receipt, "rolled_back")?;
+            operation::phase(Phase::RolledBack, "The failed update was rolled back")?;
+            let _ = reopen_godot(&options.godot_executable, &options.project_dir);
+            let error = operation::failure(
+                FailureClass::ValidationFailed,
+                format!("update failed and the previous version was restored: {original_error}"),
+            );
+            operation::defer_completion()?;
+            Err(error)
+        }
+        Err(rollback_error) => {
+            set_state(receipt_path, receipt, "recovery_required")?;
+            operation::phase(
+                Phase::RecoveryRequired,
+                "The update and automatic rollback failed; manual recovery is required",
+            )?;
+            let error = operation::failure(
+                FailureClass::RollbackFailed,
+                format!("update failed: {original_error}; rollback failed: {rollback_error}"),
+            );
+            operation::defer_completion()?;
+            Err(error)
+        }
+    }
+}
+
+pub(super) fn restore_previous(project_dir: &Path, root: &Path) -> Result<(), String> {
+    let receipt = update_stage::read_receipt(&root.join("receipt.json"))?;
+    let active = project_install::project_addon_dir(project_dir);
+    let backup = root.join(&receipt.backup_addon);
+    if !backup.is_dir() {
+        return Err(format!(
+            "update backup is missing at {}",
+            display_path(&backup)
+        ));
+    }
+    if active.exists() {
+        fs::remove_dir_all(&active).map_err(|error| {
+            format!(
+                "failed to remove failed addon {}: {error}",
+                display_path(&active)
+            )
+        })?;
+    }
+    fs::rename(&backup, &active).map_err(|error| {
+        format!(
+            "failed to restore addon backup {}: {error}",
+            display_path(&backup)
+        )
+    })?;
+    restore_previous_manifest(root)
+}
+
+fn persist_previous_manifest(
+    layout: &AppLayout,
+    root: &Path,
+    receipt: &mut UpdateReceipt,
+) -> Result<(), String> {
+    let snapshot = root.join("previous-current.json");
+    let missing = root.join("previous-current.missing");
+    if layout.current_manifest_path.is_file() {
+        let bytes = fs::read(&layout.current_manifest_path)
+            .map_err(|error| format!("failed to read current runtime manifest: {error}"))?;
+        write_synced(&snapshot, &bytes)?;
+        receipt.had_current_manifest = Some(true);
+    } else {
+        write_synced(&missing, b"missing\n")?;
+        receipt.had_current_manifest = Some(false);
+    }
+    update_stage::write_receipt(&root.join("receipt.json"), receipt)
+}
+
+fn restore_previous_manifest(root: &Path) -> Result<(), String> {
+    let snapshot = root.join("previous-current.json");
+    let missing = root.join("previous-current.missing");
+    if snapshot.is_file() {
+        let bytes = fs::read(&snapshot)
+            .map_err(|error| format!("failed to read previous runtime manifest: {error}"))?;
+        release_package::restore_manifest(Some(&bytes))
+    } else if missing.is_file() {
+        release_package::restore_manifest(None)
+    } else {
+        Err("previous runtime manifest snapshot is missing".to_string())
+    }
+}
+
+fn remove_validated_backup(root: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
+    let backup = root.join(&receipt.backup_addon);
+    if backup.exists() {
+        fs::remove_dir_all(&backup).map_err(|error| {
+            operation::failure(
+                FailureClass::StageFilesystem,
+                format!(
+                    "failed to remove validated update backup {}: {error}",
+                    display_path(&backup)
+                ),
+            )
+        })?;
+    }
+    for path in [
+        root.join("previous-current.json"),
+        root.join("previous-current.missing"),
+    ] {
+        if path.exists() {
+            fs::remove_file(&path)
+                .map_err(|error| format!("failed to remove {}: {error}", display_path(&path)))?;
+        }
+    }
+    Ok(())
+}
+
+fn write_synced(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut file = File::create(path)
+        .map_err(|error| format!("failed to create {}: {error}", display_path(path)))?;
+    file.write_all(bytes)
+        .map_err(|error| format!("failed to write {}: {error}", display_path(path)))?;
+    file.sync_all()
+        .map_err(|error| format!("failed to flush {}: {error}", display_path(path)))
+}

--- a/local/crates/fennara-cli/src/update_apply/transaction.rs
+++ b/local/crates/fennara-cli/src/update_apply/transaction.rs
@@ -1,3 +1,4 @@
+use super::launchers;
 use super::options::ApplyOptions;
 use super::process::{reopen_godot, wait_for_handshake};
 use super::{activate_runtime_and_guidance, recovery_required, set_state};
@@ -26,16 +27,34 @@ pub(super) fn apply_after_exit(
     let layout = AppLayout::detect()?;
     daemon_setup::shutdown_if_running(&layout)
         .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
-    release_package::activate_staged_launchers(&receipt.to_version)
+    update_stage::verify_staged_addon(root, receipt)
+        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+    launchers::snapshot(&layout, root)
         .map_err(|error| operation::failure(FailureClass::StageFilesystem, error))?;
+    receipt.launchers_snapshotted = true;
+    update_stage::write_receipt(receipt_path, receipt)?;
     persist_previous_manifest(&layout, root, receipt)?;
-    replace_addon(&options.project_dir, root, receipt)?;
+    if let Err(error) = release_package::activate_staged_launchers(&receipt.to_version) {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
+    if let Err(error) = replace_addon(&options.project_dir, root) {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
+    receipt.addon_replaced = true;
+    if let Err(error) = update_stage::write_receipt(receipt_path, receipt) {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
 
     if let Err(error) = activate_runtime_and_guidance(&options.project_dir, &receipt.to_version) {
         return rollback_before_reopen(options, root, receipt_path, receipt, error);
     }
-    operation::phase(Phase::Reopening, "Reopening Godot with the updated addon")?;
-    set_state(receipt_path, receipt, "reopening")?;
+    if let Err(error) = operation::phase(Phase::Reopening, "Reopening Godot with the updated addon")
+    {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
+    if let Err(error) = set_state(receipt_path, receipt, "reopening") {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
     let reopened_pid = match reopen_godot(&options.godot_executable, &options.project_dir) {
         Ok(pid) => pid,
         Err(error) => return rollback_before_reopen(options, root, receipt_path, receipt, error),
@@ -56,18 +75,21 @@ pub(super) fn apply_after_exit(
     if let Err(error) = daemon_setup::ensure_running(&layout, &receipt.to_version) {
         return recovery_required(receipt_path, receipt, error);
     }
-    remove_validated_backup(root, receipt)?;
     set_state(receipt_path, receipt, "succeeded")?;
     operation::phase(
         Phase::Succeeded,
         "The updated addon and runtime were validated",
-    )
+    )?;
+    if let Err(error) = remove_validated_backup(root, &receipt.to_version) {
+        eprintln!("warning: validated update cleanup is pending: {error}");
+    }
+    Ok(())
 }
 
-fn replace_addon(project_dir: &Path, root: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
+fn replace_addon(project_dir: &Path, root: &Path) -> Result<(), String> {
     let active = project_install::project_addon_dir(project_dir);
-    let staged = root.join(&receipt.addon);
-    let backup = root.join(&receipt.backup_addon);
+    let staged = root.join(update_stage::STAGED_ADDON_NAME);
+    let backup = root.join(update_stage::BACKUP_ADDON_NAME);
     project_addon::validate(&staged)
         .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
     if backup.exists() {
@@ -113,27 +135,32 @@ fn rollback_before_reopen(
 ) -> Result<(), String> {
     match restore_previous(&options.project_dir, root) {
         Ok(()) => {
-            set_state(receipt_path, receipt, "rolled_back")?;
-            operation::phase(Phase::RolledBack, "The failed update was rolled back")?;
+            let state_error = set_state(receipt_path, receipt, "rolled_back").err();
+            let phase_error =
+                operation::phase(Phase::RolledBack, "The failed update was rolled back").err();
             let _ = reopen_godot(&options.godot_executable, &options.project_dir);
-            let error = operation::failure(
-                FailureClass::ValidationFailed,
-                format!("update failed and the previous version was restored: {original_error}"),
-            );
-            operation::defer_completion()?;
+            let mut detail =
+                format!("update failed and the previous version was restored: {original_error}");
+            for persistence_error in [state_error, phase_error].into_iter().flatten() {
+                detail.push_str(&format!(
+                    "; rollback status persistence failed: {persistence_error}"
+                ));
+            }
+            let error = operation::failure(FailureClass::ValidationFailed, detail);
+            let _ = operation::defer_completion();
             Err(error)
         }
         Err(rollback_error) => {
-            set_state(receipt_path, receipt, "recovery_required")?;
-            operation::phase(
+            let _ = set_state(receipt_path, receipt, "recovery_required");
+            let _ = operation::phase(
                 Phase::RecoveryRequired,
                 "The update and automatic rollback failed; manual recovery is required",
-            )?;
+            );
             let error = operation::failure(
                 FailureClass::RollbackFailed,
                 format!("update failed: {original_error}; rollback failed: {rollback_error}"),
             );
-            operation::defer_completion()?;
+            let _ = operation::defer_completion();
             Err(error)
         }
     }
@@ -141,29 +168,68 @@ fn rollback_before_reopen(
 
 pub(super) fn restore_previous(project_dir: &Path, root: &Path) -> Result<(), String> {
     let receipt = update_stage::read_receipt(&root.join("receipt.json"))?;
+    let layout = AppLayout::detect()?;
     let active = project_install::project_addon_dir(project_dir);
-    let backup = root.join(&receipt.backup_addon);
-    if !backup.is_dir() {
-        return Err(format!(
-            "update backup is missing at {}",
-            display_path(&backup)
-        ));
+    let backup = root.join(update_stage::BACKUP_ADDON_NAME);
+    let mut errors = match restore_addon(&active, &backup, &receipt.from_version) {
+        Ok(()) => Vec::new(),
+        Err(error) => vec![error],
+    };
+    if receipt.had_current_manifest.is_some()
+        && let Err(error) = restore_previous_manifest(root)
+    {
+        errors.push(error);
     }
-    if active.exists() {
-        fs::remove_dir_all(&active).map_err(|error| {
+    if receipt.launchers_snapshotted
+        && let Err(error) = launchers::restore(&layout, root)
+    {
+        errors.push(error);
+    }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; "))
+    }
+}
+
+fn restore_addon(active: &Path, backup: &Path, from_version: &str) -> Result<(), String> {
+    if backup.is_dir() {
+        if active.exists() {
+            fs::remove_dir_all(active).map_err(|error| {
+                format!(
+                    "failed to remove failed addon {}: {error}",
+                    display_path(active)
+                )
+            })?;
+        }
+        if let Some(parent) = active.parent() {
+            fs::create_dir_all(parent).map_err(|error| {
+                format!(
+                    "failed to create addon parent {}: {error}",
+                    display_path(parent)
+                )
+            })?;
+        }
+        fs::rename(backup, active).map_err(|error| {
             format!(
-                "failed to remove failed addon {}: {error}",
-                display_path(&active)
+                "failed to restore addon backup {}: {error}",
+                display_path(backup)
             )
         })?;
+    } else if !active_has_version(active, from_version) {
+        return Err(format!(
+            "update backup is missing at {} and the active addon is not version {}",
+            display_path(backup),
+            from_version
+        ));
     }
-    fs::rename(&backup, &active).map_err(|error| {
-        format!(
-            "failed to restore addon backup {}: {error}",
-            display_path(&backup)
-        )
-    })?;
-    restore_previous_manifest(root)
+    Ok(())
+}
+
+fn active_has_version(active: &Path, expected: &str) -> bool {
+    project_addon::validate(active)
+        .map(|addon| addon.version == expected)
+        .unwrap_or(false)
 }
 
 fn persist_previous_manifest(
@@ -199,8 +265,8 @@ fn restore_previous_manifest(root: &Path) -> Result<(), String> {
     }
 }
 
-fn remove_validated_backup(root: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
-    let backup = root.join(&receipt.backup_addon);
+fn remove_validated_backup(root: &Path, version: &str) -> Result<(), String> {
+    let backup = root.join(update_stage::BACKUP_ADDON_NAME);
     if backup.exists() {
         fs::remove_dir_all(&backup).map_err(|error| {
             operation::failure(
@@ -221,6 +287,8 @@ fn remove_validated_backup(root: &Path, receipt: &UpdateReceipt) -> Result<(), S
                 .map_err(|error| format!("failed to remove {}: {error}", display_path(&path)))?;
         }
     }
+    launchers::cleanup(root)?;
+    release_package::remove_staged_launchers(version)?;
     Ok(())
 }
 
@@ -232,3 +300,6 @@ fn write_synced(path: &Path, bytes: &[u8]) -> Result<(), String> {
     file.sync_all()
         .map_err(|error| format!("failed to flush {}: {error}", display_path(path)))
 }
+
+#[cfg(test)]
+mod tests;

--- a/local/crates/fennara-cli/src/update_apply/transaction.rs
+++ b/local/crates/fennara-cli/src/update_apply/transaction.rs
@@ -32,8 +32,12 @@ pub(super) fn apply_after_exit(
     launchers::snapshot(&layout, root)
         .map_err(|error| operation::failure(FailureClass::StageFilesystem, error))?;
     receipt.launchers_snapshotted = true;
-    update_stage::write_receipt(receipt_path, receipt)?;
-    persist_previous_manifest(&layout, root, receipt)?;
+    if let Err(error) = update_stage::write_receipt(receipt_path, receipt) {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
+    if let Err(error) = persist_previous_manifest(&layout, root, receipt) {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
     if let Err(error) = release_package::activate_staged_launchers(&receipt.to_version) {
         return rollback_before_reopen(options, root, receipt_path, receipt, error);
     }
@@ -138,12 +142,17 @@ fn rollback_before_reopen(
             let state_error = set_state(receipt_path, receipt, "rolled_back").err();
             let phase_error =
                 operation::phase(Phase::RolledBack, "The failed update was rolled back").err();
-            let _ = reopen_godot(&options.godot_executable, &options.project_dir);
+            let reopen_error = reopen_godot(&options.godot_executable, &options.project_dir).err();
             let mut detail =
                 format!("update failed and the previous version was restored: {original_error}");
             for persistence_error in [state_error, phase_error].into_iter().flatten() {
                 detail.push_str(&format!(
                     "; rollback status persistence failed: {persistence_error}"
+                ));
+            }
+            if let Some(reopen_error) = reopen_error {
+                detail.push_str(&format!(
+                    "; Godot did not reopen after rollback: {reopen_error}"
                 ));
             }
             let error = operation::failure(FailureClass::ValidationFailed, detail);

--- a/local/crates/fennara-cli/src/update_apply/transaction/tests.rs
+++ b/local/crates/fennara-cli/src/update_apply/transaction/tests.rs
@@ -1,0 +1,105 @@
+use super::*;
+use crate::app_layout::{arch_name, platform_name};
+use crate::update_stage::{BACKUP_ADDON_NAME, STAGED_ADDON_NAME};
+use std::ops::Deref;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn replace_and_restore_addon_round_trip() {
+    let root = TestRoot::new("round-trip");
+    let project = root.join("project");
+    let transaction = root.join("transaction");
+    write_addon(&project.join("addons/fennara"), "1.0.0");
+    write_addon(&transaction.join(STAGED_ADDON_NAME), "1.1.0");
+
+    replace_addon(&project, &transaction).unwrap();
+    assert!(active_has_version(&project.join("addons/fennara"), "1.1.0"));
+
+    restore_addon(
+        &project.join("addons/fennara"),
+        &transaction.join(BACKUP_ADDON_NAME),
+        "1.0.0",
+    )
+    .unwrap();
+    assert!(active_has_version(&project.join("addons/fennara"), "1.0.0"));
+}
+
+#[test]
+fn restore_resumes_when_active_addon_is_missing() {
+    let root = TestRoot::new("missing-active");
+    let active = root.join("project/addons/fennara");
+    let backup = root.join("transaction").join(BACKUP_ADDON_NAME);
+    write_addon(&backup, "1.0.0");
+
+    restore_addon(&active, &backup, "1.0.0").unwrap();
+
+    assert!(active_has_version(&active, "1.0.0"));
+    assert!(!backup.exists());
+}
+
+#[test]
+fn repeated_restore_accepts_already_restored_version() {
+    let root = TestRoot::new("repeated");
+    let active = root.join("project/addons/fennara");
+    let backup = root.join("transaction").join(BACKUP_ADDON_NAME);
+    write_addon(&active, "1.0.0");
+
+    restore_addon(&active, &backup, "1.0.0").unwrap();
+}
+
+#[test]
+fn restore_rejects_new_addon_without_backup() {
+    let root = TestRoot::new("missing-backup");
+    let active = root.join("project/addons/fennara");
+    let backup = root.join("transaction").join(BACKUP_ADDON_NAME);
+    write_addon(&active, "1.1.0");
+
+    assert!(restore_addon(&active, &backup, "1.0.0").is_err());
+}
+
+fn write_addon(addon: &Path, version: &str) {
+    fs::create_dir_all(addon.join("bin")).unwrap();
+    fs::create_dir_all(addon.join("ai")).unwrap();
+    fs::write(addon.join("VERSION"), format!("{version}\n")).unwrap();
+    fs::write(addon.join("ai/guidelines.md"), "guidance\n").unwrap();
+    fs::write(addon.join("bin/fennara-test-library"), "library").unwrap();
+    fs::write(
+        addon.join("fennara.gdextension"),
+        format!(
+            "[libraries]\n{}.editor.{} = \"res://addons/fennara/bin/fennara-test-library\"\n",
+            platform_name(),
+            arch_name()
+        ),
+    )
+    .unwrap();
+}
+
+struct TestRoot(PathBuf);
+
+impl TestRoot {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        Self(std::env::temp_dir().join(format!(
+            "fennara-update-transaction-{name}-{}-{nonce}",
+            std::process::id()
+        )))
+    }
+}
+
+impl Deref for TestRoot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/local/crates/fennara-cli/src/update_stage.rs
+++ b/local/crates/fennara-cli/src/update_stage.rs
@@ -8,7 +8,11 @@ use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-const RECEIPT_SCHEMA_VERSION: u64 = 1;
+mod integrity;
+
+const RECEIPT_SCHEMA_VERSION: u64 = 2;
+pub(crate) const STAGED_ADDON_NAME: &str = "addon";
+pub(crate) const BACKUP_ADDON_NAME: &str = "previous-addon";
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdateReceipt {
@@ -21,11 +25,15 @@ pub struct UpdateReceipt {
     pub architecture: String,
     pub addon: String,
     pub backup_addon: String,
+    pub addon_sha256: String,
     pub godot_pid: Option<u32>,
     pub godot_started_at: Option<u64>,
     pub godot_executable: Option<String>,
     pub had_current_manifest: Option<bool>,
+    pub launchers_snapshotted: bool,
+    pub addon_replaced: bool,
     pub updater_pid: Option<u32>,
+    pub updater_started_at: Option<u64>,
 }
 
 pub struct StagedUpdate {
@@ -86,7 +94,7 @@ pub fn prepare(
     }
 
     let mut cleanup = PreparingCleanup::new(preparing_root.clone());
-    let staged_addon = preparing_root.join("addon");
+    let staged_addon = preparing_root.join(STAGED_ADDON_NAME);
     copy_dir_without_links(&package.addon_dir, &staged_addon)?;
     let staged = project_addon::validate(&staged_addon)?;
     if staged.version != package.version {
@@ -105,13 +113,17 @@ pub fn prepare(
         to_version: package.version.clone(),
         platform: platform_name().to_string(),
         architecture: arch_name().to_string(),
-        addon: "addon".to_string(),
-        backup_addon: "previous-addon".to_string(),
+        addon: STAGED_ADDON_NAME.to_string(),
+        backup_addon: BACKUP_ADDON_NAME.to_string(),
+        addon_sha256: integrity::hash_directory(&staged_addon)?,
         godot_pid: godot_process.map(|value| value.0),
         godot_started_at: godot_process.map(|value| value.1),
         godot_executable: godot_process.map(|value| value.2.display().to_string()),
         had_current_manifest: None,
+        launchers_snapshotted: false,
+        addon_replaced: false,
         updater_pid: None,
+        updater_started_at: None,
     };
     write_receipt(&receipt_path, &receipt)?;
     fs::rename(&preparing_root, &final_root).map_err(|error| {
@@ -146,13 +158,61 @@ pub fn read_receipt(path: &Path) -> Result<UpdateReceipt, String> {
                 display_path(candidate)
             ));
         }
-        operation::validate_id(&receipt.operation_id)?;
+        validate_receipt(&receipt)?;
         return Ok(receipt);
     }
     Err(format!(
         "update receipt was not found at {}",
         display_path(path)
     ))
+}
+
+pub(crate) fn verify_staged_addon(root: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
+    let staged = root.join(STAGED_ADDON_NAME);
+    let actual = integrity::hash_directory(&staged)?;
+    if actual.eq_ignore_ascii_case(&receipt.addon_sha256) {
+        Ok(())
+    } else {
+        Err(format!(
+            "staged addon integrity check failed: expected {}, got {actual}",
+            receipt.addon_sha256
+        ))
+    }
+}
+
+fn validate_receipt(receipt: &UpdateReceipt) -> Result<(), String> {
+    operation::validate_id(&receipt.operation_id)?;
+    if receipt.addon != STAGED_ADDON_NAME || receipt.backup_addon != BACKUP_ADDON_NAME {
+        return Err("update receipt contains unsafe addon paths".to_string());
+    }
+    if receipt.platform != platform_name() || receipt.architecture != arch_name() {
+        return Err("update receipt targets a different platform or architecture".to_string());
+    }
+    validate_version_component(&receipt.from_version)?;
+    validate_version_component(&receipt.to_version)?;
+    if receipt.addon_sha256.len() != 64
+        || !receipt
+            .addon_sha256
+            .chars()
+            .all(|ch| ch.is_ascii_hexdigit())
+    {
+        return Err("update receipt contains an invalid addon digest".to_string());
+    }
+    Ok(())
+}
+
+fn validate_version_component(version: &str) -> Result<(), String> {
+    if version.is_empty()
+        || version.len() > 128
+        || version == "."
+        || version == ".."
+        || !version
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '-' | '+' | '_'))
+    {
+        return Err(format!("unsafe update version in receipt: {version}"));
+    }
+    Ok(())
 }
 
 pub fn write_receipt(path: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
@@ -270,115 +330,4 @@ impl Drop for PreparingCleanup {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::app_layout::{arch_name, platform_name};
-    use std::ops::Deref;
-    use std::time::{SystemTime, UNIX_EPOCH};
-
-    #[test]
-    fn stages_valid_addon_without_touching_active_addon() {
-        let root = TestRoot::new("success");
-        let project = root.join("project");
-        let source = root.join("package");
-        write_project(&project);
-        write_addon(&project.join("addons/fennara"), "1.0.0");
-        write_addon(&source, "1.1.0");
-        let active_before = fs::read(project.join("addons/fennara/VERSION")).unwrap();
-        let package = InstalledPackage {
-            version: "1.1.0".to_string(),
-            addon_dir: source,
-        };
-
-        let staged = prepare(&project, "1.0.0", &package, "update-123-test", None).unwrap();
-
-        assert_eq!(staged.version, "1.1.0");
-        assert!(staged.root.join("addon/fennara.gdextension").is_file());
-        assert_eq!(
-            fs::read(project.join("addons/fennara/VERSION")).unwrap(),
-            active_before
-        );
-        let receipt: serde_json::Value =
-            serde_json::from_str(&fs::read_to_string(staged.receipt_path).unwrap()).unwrap();
-        assert_eq!(receipt["state"], "ready_to_close");
-        assert_eq!(receipt["from_version"], "1.0.0");
-        assert_eq!(receipt["to_version"], "1.1.0");
-    }
-
-    #[test]
-    fn failed_validation_leaves_no_staging_directory() {
-        let root = TestRoot::new("invalid");
-        let project = root.join("project");
-        let source = root.join("package");
-        write_project(&project);
-        fs::create_dir_all(&source).unwrap();
-        fs::write(source.join("VERSION"), "1.1.0\n").unwrap();
-        let package = InstalledPackage {
-            version: "1.1.0".to_string(),
-            addon_dir: source,
-        };
-
-        assert!(prepare(&project, "1.0.0", &package, "update-456-test", None,).is_err());
-        assert!(
-            !project
-                .join(".godot/fennara-update/update-456-test")
-                .exists()
-        );
-        assert!(
-            !project
-                .join(".godot/fennara-update/update-456-test.preparing")
-                .exists()
-        );
-    }
-
-    fn write_project(project: &Path) {
-        fs::create_dir_all(project).unwrap();
-        fs::write(project.join("project.godot"), "[application]\n").unwrap();
-    }
-
-    fn write_addon(addon: &Path, version: &str) {
-        fs::create_dir_all(addon.join("bin")).unwrap();
-        fs::create_dir_all(addon.join("ai")).unwrap();
-        fs::write(addon.join("VERSION"), format!("{version}\n")).unwrap();
-        fs::write(addon.join("ai/guidelines.md"), "guidance\n").unwrap();
-        fs::write(addon.join("bin/fennara-test-library"), "library").unwrap();
-        fs::write(
-            addon.join("fennara.gdextension"),
-            format!(
-                "[libraries]\n{}.editor.{} = \"res://addons/fennara/bin/fennara-test-library\"\n",
-                platform_name(),
-                arch_name()
-            ),
-        )
-        .unwrap();
-    }
-
-    struct TestRoot(PathBuf);
-
-    impl TestRoot {
-        fn new(name: &str) -> Self {
-            let nonce = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_nanos();
-            Self(std::env::temp_dir().join(format!(
-                "fennara-update-stage-{name}-{}-{nonce}",
-                std::process::id()
-            )))
-        }
-    }
-
-    impl Deref for TestRoot {
-        type Target = Path;
-
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl Drop for TestRoot {
-        fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.0);
-        }
-    }
-}
+mod tests;

--- a/local/crates/fennara-cli/src/update_stage.rs
+++ b/local/crates/fennara-cli/src/update_stage.rs
@@ -1,0 +1,307 @@
+use crate::app_layout::{arch_name, display_path, platform_name};
+use crate::operation;
+use crate::project_addon;
+use crate::project_install;
+use crate::release_package::InstalledPackage;
+use serde_json::json;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+const RECEIPT_SCHEMA_VERSION: u64 = 1;
+
+pub struct StagedUpdate {
+    pub root: PathBuf,
+    pub receipt_path: PathBuf,
+    pub version: String,
+}
+
+pub fn prepare(
+    project_dir: &Path,
+    current_version: &str,
+    package: &InstalledPackage,
+    operation_id: &str,
+) -> Result<StagedUpdate, String> {
+    operation::validate_id(operation_id)?;
+    let source = project_addon::validate(&package.addon_dir)?;
+    if source.version != package.version {
+        return Err(format!(
+            "staged addon version {} did not match package version {}",
+            source.version, package.version
+        ));
+    }
+
+    let staging_parent = project_dir.join(".godot").join("fennara-update");
+    let final_root = staging_parent.join(operation_id);
+    let preparing_root = staging_parent.join(format!("{operation_id}.preparing"));
+    project_install::ensure_target_within_project(project_dir, &staging_parent)?;
+    project_install::ensure_target_within_project(project_dir, &final_root)?;
+    project_install::ensure_target_within_project(project_dir, &preparing_root)?;
+    fs::create_dir_all(&staging_parent).map_err(|error| {
+        format!(
+            "failed to create update staging directory {}: {error}",
+            display_path(&staging_parent)
+        )
+    })?;
+    if final_root.exists() {
+        return Err(format!(
+            "update staging directory already exists at {}",
+            display_path(&final_root)
+        ));
+    }
+    if preparing_root.exists() {
+        fs::remove_dir_all(&preparing_root).map_err(|error| {
+            format!(
+                "failed to clean incomplete update staging directory {}: {error}",
+                display_path(&preparing_root)
+            )
+        })?;
+    }
+
+    let mut cleanup = PreparingCleanup::new(preparing_root.clone());
+    let staged_addon = preparing_root.join("addon");
+    copy_dir_without_links(&package.addon_dir, &staged_addon)?;
+    let staged = project_addon::validate(&staged_addon)?;
+    if staged.version != package.version {
+        return Err(format!(
+            "copied addon version {} did not match package version {}",
+            staged.version, package.version
+        ));
+    }
+
+    let receipt_path = preparing_root.join("receipt.json");
+    write_receipt(
+        &receipt_path,
+        operation_id,
+        current_version,
+        &package.version,
+    )?;
+    fs::rename(&preparing_root, &final_root).map_err(|error| {
+        format!(
+            "failed to finalize update staging directory {}: {error}",
+            display_path(&final_root)
+        )
+    })?;
+    cleanup.disarm();
+
+    Ok(StagedUpdate {
+        receipt_path: final_root.join("receipt.json"),
+        root: final_root,
+        version: package.version.clone(),
+    })
+}
+
+fn write_receipt(
+    path: &Path,
+    operation_id: &str,
+    current_version: &str,
+    target_version: &str,
+) -> Result<(), String> {
+    let receipt = json!({
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "operation_id": operation_id,
+        "state": "ready_to_close",
+        "from_version": current_version,
+        "to_version": target_version,
+        "platform": platform_name(),
+        "architecture": arch_name(),
+        "addon": "addon",
+    });
+    let mut bytes = serde_json::to_vec_pretty(&receipt)
+        .map_err(|error| format!("failed to serialize update staging receipt: {error}"))?;
+    bytes.push(b'\n');
+    let mut file = File::create(path)
+        .map_err(|error| format!("failed to create {}: {error}", display_path(path)))?;
+    file.write_all(&bytes)
+        .map_err(|error| format!("failed to write {}: {error}", display_path(path)))?;
+    file.sync_all()
+        .map_err(|error| format!("failed to flush {}: {error}", display_path(path)))
+}
+
+fn copy_dir_without_links(source: &Path, target: &Path) -> Result<(), String> {
+    let metadata = fs::symlink_metadata(source)
+        .map_err(|error| format!("failed to inspect {}: {error}", display_path(source)))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(format!(
+            "refusing to stage non-directory or linked addon path {}",
+            display_path(source)
+        ));
+    }
+    fs::create_dir_all(target)
+        .map_err(|error| format!("failed to create {}: {error}", display_path(target)))?;
+    for entry in fs::read_dir(source)
+        .map_err(|error| format!("failed to read {}: {error}", display_path(source)))?
+    {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read an entry in {}: {error}",
+                display_path(source)
+            )
+        })?;
+        let source_path = entry.path();
+        let target_path = target.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path).map_err(|error| {
+            format!("failed to inspect {}: {error}", display_path(&source_path))
+        })?;
+        if metadata.file_type().is_symlink() {
+            return Err(format!(
+                "refusing to stage linked addon entry {}",
+                display_path(&source_path)
+            ));
+        }
+        if metadata.is_dir() {
+            copy_dir_without_links(&source_path, &target_path)?;
+        } else if metadata.is_file() {
+            fs::copy(&source_path, &target_path).map_err(|error| {
+                format!(
+                    "failed to copy {} to {}: {error}",
+                    display_path(&source_path),
+                    display_path(&target_path)
+                )
+            })?;
+        } else {
+            return Err(format!(
+                "refusing to stage unsupported addon entry {}",
+                display_path(&source_path)
+            ));
+        }
+    }
+    Ok(())
+}
+
+struct PreparingCleanup {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl PreparingCleanup {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PreparingCleanup {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_layout::{arch_name, platform_name};
+    use std::ops::Deref;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn stages_valid_addon_without_touching_active_addon() {
+        let root = TestRoot::new("success");
+        let project = root.join("project");
+        let source = root.join("package");
+        write_project(&project);
+        write_addon(&project.join("addons/fennara"), "1.0.0");
+        write_addon(&source, "1.1.0");
+        let active_before = fs::read(project.join("addons/fennara/VERSION")).unwrap();
+        let package = InstalledPackage {
+            version: "1.1.0".to_string(),
+            addon_dir: source,
+        };
+
+        let staged = prepare(&project, "1.0.0", &package, "update-123-test").unwrap();
+
+        assert_eq!(staged.version, "1.1.0");
+        assert!(staged.root.join("addon/fennara.gdextension").is_file());
+        assert_eq!(
+            fs::read(project.join("addons/fennara/VERSION")).unwrap(),
+            active_before
+        );
+        let receipt: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(staged.receipt_path).unwrap()).unwrap();
+        assert_eq!(receipt["state"], "ready_to_close");
+        assert_eq!(receipt["from_version"], "1.0.0");
+        assert_eq!(receipt["to_version"], "1.1.0");
+    }
+
+    #[test]
+    fn failed_validation_leaves_no_staging_directory() {
+        let root = TestRoot::new("invalid");
+        let project = root.join("project");
+        let source = root.join("package");
+        write_project(&project);
+        fs::create_dir_all(&source).unwrap();
+        fs::write(source.join("VERSION"), "1.1.0\n").unwrap();
+        let package = InstalledPackage {
+            version: "1.1.0".to_string(),
+            addon_dir: source,
+        };
+
+        assert!(prepare(&project, "1.0.0", &package, "update-456-test").is_err());
+        assert!(
+            !project
+                .join(".godot/fennara-update/update-456-test")
+                .exists()
+        );
+        assert!(
+            !project
+                .join(".godot/fennara-update/update-456-test.preparing")
+                .exists()
+        );
+    }
+
+    fn write_project(project: &Path) {
+        fs::create_dir_all(project).unwrap();
+        fs::write(project.join("project.godot"), "[application]\n").unwrap();
+    }
+
+    fn write_addon(addon: &Path, version: &str) {
+        fs::create_dir_all(addon.join("bin")).unwrap();
+        fs::create_dir_all(addon.join("ai")).unwrap();
+        fs::write(addon.join("VERSION"), format!("{version}\n")).unwrap();
+        fs::write(addon.join("ai/guidelines.md"), "guidance\n").unwrap();
+        fs::write(addon.join("bin/fennara-test-library"), "library").unwrap();
+        fs::write(
+            addon.join("fennara.gdextension"),
+            format!(
+                "[libraries]\n{}.editor.{} = \"res://addons/fennara/bin/fennara-test-library\"\n",
+                platform_name(),
+                arch_name()
+            ),
+        )
+        .unwrap();
+    }
+
+    struct TestRoot(PathBuf);
+
+    impl TestRoot {
+        fn new(name: &str) -> Self {
+            let nonce = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            Self(std::env::temp_dir().join(format!(
+                "fennara-update-stage-{name}-{}-{nonce}",
+                std::process::id()
+            )))
+        }
+    }
+
+    impl Deref for TestRoot {
+        type Target = Path;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl Drop for TestRoot {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+}

--- a/local/crates/fennara-cli/src/update_stage.rs
+++ b/local/crates/fennara-cli/src/update_stage.rs
@@ -3,12 +3,30 @@ use crate::operation;
 use crate::project_addon;
 use crate::project_install;
 use crate::release_package::InstalledPackage;
-use serde_json::json;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
 const RECEIPT_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UpdateReceipt {
+    pub schema_version: u64,
+    pub operation_id: String,
+    pub state: String,
+    pub from_version: String,
+    pub to_version: String,
+    pub platform: String,
+    pub architecture: String,
+    pub addon: String,
+    pub backup_addon: String,
+    pub godot_pid: Option<u32>,
+    pub godot_started_at: Option<u64>,
+    pub godot_executable: Option<String>,
+    pub had_current_manifest: Option<bool>,
+    pub updater_pid: Option<u32>,
+}
 
 pub struct StagedUpdate {
     pub root: PathBuf,
@@ -16,11 +34,20 @@ pub struct StagedUpdate {
     pub version: String,
 }
 
+pub fn staging_root(project_dir: &Path, operation_id: &str) -> Result<PathBuf, String> {
+    operation::validate_id(operation_id)?;
+    Ok(project_dir
+        .join(".godot")
+        .join("fennara-update")
+        .join(operation_id))
+}
+
 pub fn prepare(
     project_dir: &Path,
     current_version: &str,
     package: &InstalledPackage,
     operation_id: &str,
+    godot_process: Option<(u32, u64, &Path)>,
 ) -> Result<StagedUpdate, String> {
     operation::validate_id(operation_id)?;
     let source = project_addon::validate(&package.addon_dir)?;
@@ -32,7 +59,7 @@ pub fn prepare(
     }
 
     let staging_parent = project_dir.join(".godot").join("fennara-update");
-    let final_root = staging_parent.join(operation_id);
+    let final_root = staging_root(project_dir, operation_id)?;
     let preparing_root = staging_parent.join(format!("{operation_id}.preparing"));
     project_install::ensure_target_within_project(project_dir, &staging_parent)?;
     project_install::ensure_target_within_project(project_dir, &final_root)?;
@@ -70,12 +97,23 @@ pub fn prepare(
     }
 
     let receipt_path = preparing_root.join("receipt.json");
-    write_receipt(
-        &receipt_path,
-        operation_id,
-        current_version,
-        &package.version,
-    )?;
+    let receipt = UpdateReceipt {
+        schema_version: RECEIPT_SCHEMA_VERSION,
+        operation_id: operation_id.to_string(),
+        state: "ready_to_close".to_string(),
+        from_version: current_version.to_string(),
+        to_version: package.version.clone(),
+        platform: platform_name().to_string(),
+        architecture: arch_name().to_string(),
+        addon: "addon".to_string(),
+        backup_addon: "previous-addon".to_string(),
+        godot_pid: godot_process.map(|value| value.0),
+        godot_started_at: godot_process.map(|value| value.1),
+        godot_executable: godot_process.map(|value| value.2.display().to_string()),
+        had_current_manifest: None,
+        updater_pid: None,
+    };
+    write_receipt(&receipt_path, &receipt)?;
     fs::rename(&preparing_root, &final_root).map_err(|error| {
         format!(
             "failed to finalize update staging directory {}: {error}",
@@ -91,31 +129,70 @@ pub fn prepare(
     })
 }
 
-fn write_receipt(
-    path: &Path,
-    operation_id: &str,
-    current_version: &str,
-    target_version: &str,
-) -> Result<(), String> {
-    let receipt = json!({
-        "schema_version": RECEIPT_SCHEMA_VERSION,
-        "operation_id": operation_id,
-        "state": "ready_to_close",
-        "from_version": current_version,
-        "to_version": target_version,
-        "platform": platform_name(),
-        "architecture": arch_name(),
-        "addon": "addon",
-    });
+pub fn read_receipt(path: &Path) -> Result<UpdateReceipt, String> {
+    let fallback = path.with_extension("json.previous");
+    for candidate in [path, fallback.as_path()] {
+        if !candidate.is_file() {
+            continue;
+        }
+        let raw = fs::read(candidate)
+            .map_err(|error| format!("failed to read {}: {error}", display_path(candidate)))?;
+        let receipt: UpdateReceipt = serde_json::from_slice(&raw)
+            .map_err(|error| format!("failed to parse {}: {error}", display_path(candidate)))?;
+        if receipt.schema_version != RECEIPT_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported update receipt schema {} in {}",
+                receipt.schema_version,
+                display_path(candidate)
+            ));
+        }
+        operation::validate_id(&receipt.operation_id)?;
+        return Ok(receipt);
+    }
+    Err(format!(
+        "update receipt was not found at {}",
+        display_path(path)
+    ))
+}
+
+pub fn write_receipt(path: &Path, receipt: &UpdateReceipt) -> Result<(), String> {
     let mut bytes = serde_json::to_vec_pretty(&receipt)
         .map_err(|error| format!("failed to serialize update staging receipt: {error}"))?;
     bytes.push(b'\n');
-    let mut file = File::create(path)
-        .map_err(|error| format!("failed to create {}: {error}", display_path(path)))?;
+    let next = path.with_extension("json.next");
+    let previous = path.with_extension("json.previous");
+    let mut file = File::create(&next)
+        .map_err(|error| format!("failed to create {}: {error}", display_path(&next)))?;
     file.write_all(&bytes)
-        .map_err(|error| format!("failed to write {}: {error}", display_path(path)))?;
+        .map_err(|error| format!("failed to write {}: {error}", display_path(&next)))?;
     file.sync_all()
-        .map_err(|error| format!("failed to flush {}: {error}", display_path(path)))
+        .map_err(|error| format!("failed to flush {}: {error}", display_path(&next)))?;
+    if previous.exists() {
+        fs::remove_file(&previous)
+            .map_err(|error| format!("failed to remove {}: {error}", display_path(&previous)))?;
+    }
+    if path.exists() {
+        fs::rename(path, &previous).map_err(|error| {
+            format!(
+                "failed to preserve update receipt {}: {error}",
+                display_path(path)
+            )
+        })?;
+    }
+    if let Err(error) = fs::rename(&next, path) {
+        if previous.exists() {
+            let _ = fs::rename(&previous, path);
+        }
+        return Err(format!(
+            "failed to activate update receipt {}: {error}",
+            display_path(path)
+        ));
+    }
+    if previous.exists() {
+        fs::remove_file(previous)
+            .map_err(|error| format!("failed to remove previous update receipt: {error}"))?;
+    }
+    Ok(())
 }
 
 fn copy_dir_without_links(source: &Path, target: &Path) -> Result<(), String> {
@@ -213,7 +290,7 @@ mod tests {
             addon_dir: source,
         };
 
-        let staged = prepare(&project, "1.0.0", &package, "update-123-test").unwrap();
+        let staged = prepare(&project, "1.0.0", &package, "update-123-test", None).unwrap();
 
         assert_eq!(staged.version, "1.1.0");
         assert!(staged.root.join("addon/fennara.gdextension").is_file());
@@ -241,7 +318,7 @@ mod tests {
             addon_dir: source,
         };
 
-        assert!(prepare(&project, "1.0.0", &package, "update-456-test").is_err());
+        assert!(prepare(&project, "1.0.0", &package, "update-456-test", None,).is_err());
         assert!(
             !project
                 .join(".godot/fennara-update/update-456-test")

--- a/local/crates/fennara-cli/src/update_stage/integrity.rs
+++ b/local/crates/fennara-cli/src/update_stage/integrity.rs
@@ -1,0 +1,72 @@
+use crate::app_layout::display_path;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub(super) fn hash_directory(root: &Path) -> Result<String, String> {
+    let metadata = fs::symlink_metadata(root)
+        .map_err(|error| format!("failed to inspect {}: {error}", display_path(root)))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(format!(
+            "refusing to hash non-directory or linked addon path {}",
+            display_path(root)
+        ));
+    }
+
+    let mut files = Vec::new();
+    collect_files(root, root, &mut files)?;
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut digest = Sha256::new();
+    for (relative, path) in files {
+        let bytes = fs::read(&path)
+            .map_err(|error| format!("failed to read {}: {error}", display_path(&path)))?;
+        digest.update((relative.len() as u64).to_le_bytes());
+        digest.update(relative.as_bytes());
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(&bytes);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn collect_files(
+    root: &Path,
+    current: &Path,
+    files: &mut Vec<(String, PathBuf)>,
+) -> Result<(), String> {
+    for entry in fs::read_dir(current)
+        .map_err(|error| format!("failed to read {}: {error}", display_path(current)))?
+    {
+        let entry = entry.map_err(|error| {
+            format!(
+                "failed to read an entry in {}: {error}",
+                display_path(current)
+            )
+        })?;
+        let path = entry.path();
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| format!("failed to inspect {}: {error}", display_path(&path)))?;
+        if metadata.file_type().is_symlink() {
+            return Err(format!(
+                "refusing to hash linked addon entry {}",
+                display_path(&path)
+            ));
+        }
+        if metadata.is_dir() {
+            collect_files(root, &path, files)?;
+        } else if metadata.is_file() {
+            let relative = path
+                .strip_prefix(root)
+                .map_err(|error| format!("failed to normalize addon path: {error}"))?
+                .to_string_lossy()
+                .replace('\\', "/");
+            files.push((relative, path));
+        } else {
+            return Err(format!(
+                "refusing to hash unsupported addon entry {}",
+                display_path(&path)
+            ));
+        }
+    }
+    Ok(())
+}

--- a/local/crates/fennara-cli/src/update_stage/tests.rs
+++ b/local/crates/fennara-cli/src/update_stage/tests.rs
@@ -1,0 +1,169 @@
+use super::*;
+use crate::app_layout::{arch_name, platform_name};
+use std::ops::Deref;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn stages_valid_addon_without_touching_active_addon() {
+    let root = TestRoot::new("success");
+    let project = root.join("project");
+    let source = root.join("package");
+    write_project(&project);
+    write_addon(&project.join("addons/fennara"), "1.0.0");
+    write_addon(&source, "1.1.0");
+    let active_before = fs::read(project.join("addons/fennara/VERSION")).unwrap();
+    let package = InstalledPackage {
+        version: "1.1.0".to_string(),
+        addon_dir: source,
+    };
+
+    let staged = prepare(&project, "1.0.0", &package, "update-123-test", None).unwrap();
+
+    assert_eq!(staged.version, "1.1.0");
+    assert!(staged.root.join("addon/fennara.gdextension").is_file());
+    assert_eq!(
+        fs::read(project.join("addons/fennara/VERSION")).unwrap(),
+        active_before
+    );
+    let receipt = read_receipt(&staged.receipt_path).unwrap();
+    assert_eq!(receipt.state, "ready_to_close");
+    assert_eq!(receipt.from_version, "1.0.0");
+    assert_eq!(receipt.to_version, "1.1.0");
+    verify_staged_addon(&staged.root, &receipt).unwrap();
+}
+
+#[test]
+fn detects_staged_addon_mutation() {
+    let root = TestRoot::new("mutation");
+    let project = root.join("project");
+    let source = root.join("package");
+    write_project(&project);
+    write_addon(&project.join("addons/fennara"), "1.0.0");
+    write_addon(&source, "1.1.0");
+    let package = InstalledPackage {
+        version: "1.1.0".to_string(),
+        addon_dir: source,
+    };
+    let staged = prepare(&project, "1.0.0", &package, "update-789-test", None).unwrap();
+    let receipt = read_receipt(&staged.receipt_path).unwrap();
+
+    fs::write(staged.root.join("addon/ai/guidelines.md"), "changed\n").unwrap();
+
+    assert!(verify_staged_addon(&staged.root, &receipt).is_err());
+}
+
+#[test]
+fn rejects_unsafe_receipt_paths_and_versions() {
+    let root = TestRoot::new("receipt");
+    fs::create_dir_all(&*root).unwrap();
+    let receipt_path = root.join("receipt.json");
+    let mut receipt = valid_receipt();
+    receipt.backup_addon = "../fennara".to_string();
+    write_receipt(&receipt_path, &receipt).unwrap();
+    assert!(read_receipt(&receipt_path).is_err());
+
+    receipt.backup_addon = BACKUP_ADDON_NAME.to_string();
+    receipt.to_version = "../../outside".to_string();
+    write_receipt(&receipt_path, &receipt).unwrap();
+    assert!(read_receipt(&receipt_path).is_err());
+}
+
+#[test]
+fn failed_validation_leaves_no_staging_directory() {
+    let root = TestRoot::new("invalid");
+    let project = root.join("project");
+    let source = root.join("package");
+    write_project(&project);
+    fs::create_dir_all(&source).unwrap();
+    fs::write(source.join("VERSION"), "1.1.0\n").unwrap();
+    let package = InstalledPackage {
+        version: "1.1.0".to_string(),
+        addon_dir: source,
+    };
+
+    assert!(prepare(&project, "1.0.0", &package, "update-456-test", None).is_err());
+    assert!(
+        !project
+            .join(".godot/fennara-update/update-456-test")
+            .exists()
+    );
+    assert!(
+        !project
+            .join(".godot/fennara-update/update-456-test.preparing")
+            .exists()
+    );
+}
+
+fn valid_receipt() -> UpdateReceipt {
+    UpdateReceipt {
+        schema_version: RECEIPT_SCHEMA_VERSION,
+        operation_id: "update-123-test".to_string(),
+        state: "ready_to_close".to_string(),
+        from_version: "1.0.0".to_string(),
+        to_version: "1.1.0".to_string(),
+        platform: platform_name().to_string(),
+        architecture: arch_name().to_string(),
+        addon: STAGED_ADDON_NAME.to_string(),
+        backup_addon: BACKUP_ADDON_NAME.to_string(),
+        addon_sha256: "a".repeat(64),
+        godot_pid: None,
+        godot_started_at: None,
+        godot_executable: None,
+        had_current_manifest: None,
+        launchers_snapshotted: false,
+        addon_replaced: false,
+        updater_pid: None,
+        updater_started_at: None,
+    }
+}
+
+fn write_project(project: &Path) {
+    fs::create_dir_all(project).unwrap();
+    fs::write(project.join("project.godot"), "[application]\n").unwrap();
+}
+
+fn write_addon(addon: &Path, version: &str) {
+    fs::create_dir_all(addon.join("bin")).unwrap();
+    fs::create_dir_all(addon.join("ai")).unwrap();
+    fs::write(addon.join("VERSION"), format!("{version}\n")).unwrap();
+    fs::write(addon.join("ai/guidelines.md"), "guidance\n").unwrap();
+    fs::write(addon.join("bin/fennara-test-library"), "library").unwrap();
+    fs::write(
+        addon.join("fennara.gdextension"),
+        format!(
+            "[libraries]\n{}.editor.{} = \"res://addons/fennara/bin/fennara-test-library\"\n",
+            platform_name(),
+            arch_name()
+        ),
+    )
+    .unwrap();
+}
+
+struct TestRoot(PathBuf);
+
+impl TestRoot {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        Self(std::env::temp_dir().join(format!(
+            "fennara-update-stage-{name}-{}-{nonce}",
+            std::process::id()
+        )))
+    }
+}
+
+impl Deref for TestRoot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for TestRoot {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs
@@ -274,6 +274,22 @@ where
             .await
         }
         "get_project_status" => send_project_status(sender, request_id, state, bound_project).await,
+        "prepare_fennara_update" => {
+            match godot_bridge::request_fennara_update(state, &bound_project.session_id).await {
+                Ok(()) => {
+                    send_json(
+                        sender,
+                        json!({
+                            "type": "fennara_update_requested",
+                            "request_id": request_id,
+                            "ok": true
+                        }),
+                    )
+                    .await
+                }
+                Err(error) => send_error(sender, request_id, "update_start_failed", &error).await,
+            }
+        }
         "set_mcp_target" => {
             match godot_bridge::set_active_project_session(state, &bound_project.session_id).await {
                 Ok(()) => send_project_status(sender, request_id, state, bound_project).await,

--- a/local/crates/fennara-daemon/src/runtime_daemon/godot_bridge.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/godot_bridge.rs
@@ -64,6 +64,22 @@ pub(crate) async fn set_active_project_session(
     Ok(())
 }
 
+pub(crate) async fn request_fennara_update(
+    state: &AppState,
+    session_id: &str,
+) -> Result<(), String> {
+    let (_, sender) = select_session(state, Some(session_id)).await?;
+    sender
+        .send(Message::Text(
+            json!({ "type": "prepare_fennara_update" })
+                .to_string()
+                .into(),
+        ))
+        .map_err(|_| {
+            "The Godot project disconnected before update preparation started.".to_string()
+        })
+}
+
 pub(crate) async fn call_tool(
     State(state): State<AppState>,
     Json(request): Json<ToolCallRequest>,

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -135,7 +135,9 @@
     }
     versionWarning.disabled = true;
     versionWarning.setAttribute("aria-busy", "true");
-    updateStartOverlay.hidden = false;
+    if (updateStartOverlay) {
+      updateStartOverlay.hidden = false;
+    }
     const sent = send({
       type: "prepare_fennara_update",
       request_id: nextRequestId("prepare-fennara-update"),
@@ -143,7 +145,9 @@
     if (!sent) {
       versionWarning.disabled = false;
       versionWarning.removeAttribute("aria-busy");
-      updateStartOverlay.hidden = true;
+      if (updateStartOverlay) {
+        updateStartOverlay.hidden = true;
+      }
       appendSystem("Godot is not connected, so the update could not start.");
     }
   });
@@ -1427,6 +1431,9 @@
     if (message.type === "fennara_update_requested") {
       versionWarning.disabled = false;
       versionWarning.removeAttribute("aria-busy");
+      if (updateStartOverlay) {
+        updateStartOverlay.hidden = true;
+      }
       return;
     }
     if (message.type === "chat_context_snippet") {
@@ -1586,7 +1593,9 @@
       if (requestId.startsWith("prepare-fennara-update")) {
         versionWarning.disabled = false;
         versionWarning.removeAttribute("aria-busy");
-        updateStartOverlay.hidden = true;
+        if (updateStartOverlay) {
+          updateStartOverlay.hidden = true;
+        }
       }
       if (requestId.startsWith("open-project-file")) {
         appendSystem(errorText);

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -70,7 +70,7 @@
   const versionWarning = document.querySelector("[data-version-warning]");
   const versionPopover = document.querySelector("[data-version-popover]");
   const versionWarningText = document.querySelector("[data-version-warning-text]");
-  const versionCommand = document.querySelector("[data-version-command]");
+  const prepareFennaraUpdateButton = document.querySelector("[data-prepare-fennara-update]");
   const usageContainer = document.querySelector(".composer-usage");
   const usagePopover = document.querySelector("[data-usage-popover]");
   const usageTotalCost = document.querySelector("[data-usage-total-cost]");
@@ -125,10 +125,21 @@
     versionWarning,
     versionPopover,
     versionWarningText,
-    versionCommand,
     escapeHtml: markdown.utils.escapeHtml,
   });
   const applyProjectStatus = projectStatusController.applyProjectStatus;
+
+  prepareFennaraUpdateButton?.addEventListener("click", () => {
+    prepareFennaraUpdateButton.disabled = true;
+    const sent = send({
+      type: "prepare_fennara_update",
+      request_id: nextRequestId("prepare-fennara-update"),
+    });
+    if (!sent) {
+      prepareFennaraUpdateButton.disabled = false;
+      appendSystem("Godot is not connected, so the update could not start.");
+    }
+  });
 
   let activeChatId = null;
   let currentModel = "";
@@ -1406,6 +1417,12 @@
       applyProjectStatus(message);
       return;
     }
+    if (message.type === "fennara_update_requested") {
+      prepareFennaraUpdateButton.disabled = false;
+      appendSystem("Update preparation opened in the Fennara Godot dock.");
+      window.setTimeout(clearSystemStatus, 3000);
+      return;
+    }
     if (message.type === "chat_context_snippet") {
       addContextSnippet(message);
       return;
@@ -1560,6 +1577,9 @@
       const errorText = message.message || "Chat request failed.";
       transcriptRenderer.updateContextCompaction("failed");
       const requestId = String(message.request_id || "");
+      if (requestId.startsWith("prepare-fennara-update")) {
+        prepareFennaraUpdateButton.disabled = false;
+      }
       if (requestId.startsWith("open-project-file")) {
         appendSystem(errorText);
         window.setTimeout(clearSystemStatus, 2400);

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -70,7 +70,7 @@
   const versionWarning = document.querySelector("[data-version-warning]");
   const versionPopover = document.querySelector("[data-version-popover]");
   const versionWarningText = document.querySelector("[data-version-warning-text]");
-  const prepareFennaraUpdateButton = document.querySelector("[data-prepare-fennara-update]");
+  const updateStartOverlay = document.querySelector("[data-update-start-overlay]");
   const usageContainer = document.querySelector(".composer-usage");
   const usagePopover = document.querySelector("[data-usage-popover]");
   const usageTotalCost = document.querySelector("[data-usage-total-cost]");
@@ -129,14 +129,21 @@
   });
   const applyProjectStatus = projectStatusController.applyProjectStatus;
 
-  prepareFennaraUpdateButton?.addEventListener("click", () => {
-    prepareFennaraUpdateButton.disabled = true;
+  versionWarning?.addEventListener("click", () => {
+    if (versionWarning.disabled) {
+      return;
+    }
+    versionWarning.disabled = true;
+    versionWarning.setAttribute("aria-busy", "true");
+    updateStartOverlay.hidden = false;
     const sent = send({
       type: "prepare_fennara_update",
       request_id: nextRequestId("prepare-fennara-update"),
     });
     if (!sent) {
-      prepareFennaraUpdateButton.disabled = false;
+      versionWarning.disabled = false;
+      versionWarning.removeAttribute("aria-busy");
+      updateStartOverlay.hidden = true;
       appendSystem("Godot is not connected, so the update could not start.");
     }
   });
@@ -1418,9 +1425,8 @@
       return;
     }
     if (message.type === "fennara_update_requested") {
-      prepareFennaraUpdateButton.disabled = false;
-      appendSystem("Update preparation opened in the Fennara Godot dock.");
-      window.setTimeout(clearSystemStatus, 3000);
+      versionWarning.disabled = false;
+      versionWarning.removeAttribute("aria-busy");
       return;
     }
     if (message.type === "chat_context_snippet") {
@@ -1578,7 +1584,9 @@
       transcriptRenderer.updateContextCompaction("failed");
       const requestId = String(message.request_id || "");
       if (requestId.startsWith("prepare-fennara-update")) {
-        prepareFennaraUpdateButton.disabled = false;
+        versionWarning.disabled = false;
+        versionWarning.removeAttribute("aria-busy");
+        updateStartOverlay.hidden = true;
       }
       if (requestId.startsWith("open-project-file")) {
         appendSystem(errorText);

--- a/ui/chat/index.html
+++ b/ui/chat/index.html
@@ -27,16 +27,16 @@
             </div>
           </div>
           <div class="version-menu" data-version-menu hidden>
-            <button class="icon-button version-button" type="button" aria-label="Fennara update available" aria-expanded="false" data-version-warning>
+            <button class="version-button" type="button" aria-label="Update Fennara" aria-expanded="false" data-version-warning>
               <svg class="svg-icon" viewBox="0 0 24 24" aria-hidden="true">
                 <path d="M12 19V5"></path>
                 <path d="m6.5 10.5 5.5-5.5 5.5 5.5"></path>
               </svg>
+              <span>Update</span>
             </button>
             <div class="version-popover" role="tooltip" data-version-popover>
               <strong>Update available</strong>
-              <span data-version-warning-text>Prepare the update while Godot stays open.</span>
-              <button class="version-update-action" type="button" data-prepare-fennara-update>Prepare Update</button>
+              <span data-version-warning-text>Press Update to start.</span>
             </div>
           </div>
           <button class="icon-button" type="button" title="Settings" aria-label="Settings" data-open-settings>
@@ -55,6 +55,14 @@
           </button>
         </div>
       </header>
+
+      <section class="update-start-overlay" aria-live="polite" data-update-start-overlay hidden>
+        <div class="update-start-card">
+          <span class="update-start-spinner" aria-hidden="true"></span>
+          <strong>Starting Fennara update</strong>
+          <span>Opening verified update preparation in Godot...</span>
+        </div>
+      </section>
 
       <aside class="chat-drawer" aria-label="Chats drawer" data-chat-drawer>
         <div class="drawer-top">

--- a/ui/chat/index.html
+++ b/ui/chat/index.html
@@ -35,8 +35,8 @@
             </button>
             <div class="version-popover" role="tooltip" data-version-popover>
               <strong>Update available</strong>
-              <span data-version-warning-text>Close Godot, then run this command in the current project.</span>
-              <code data-version-command>fennara update</code>
+              <span data-version-warning-text>Prepare the update while Godot stays open.</span>
+              <button class="version-update-action" type="button" data-prepare-fennara-update>Prepare Update</button>
             </div>
           </div>
           <button class="icon-button" type="button" title="Settings" aria-label="Settings" data-open-settings>

--- a/ui/chat/project-status.js
+++ b/ui/chat/project-status.js
@@ -71,12 +71,13 @@
       }
       const current = version.current_version || "installed";
       const latest = version.latest_version || "latest";
+      versionWarning.title = `Update Fennara ${current} to ${latest}`;
       if (versionWarningText) {
         versionWarningText.innerHTML = [
           `Current: ${escapeHtml(current)}`,
           `Available: ${escapeHtml(latest)}`,
           "",
-          "The update will be verified before Godot asks to close.",
+          "Press Update to start.",
         ].join("<br>");
       }
       if (versionPopover) {

--- a/ui/chat/project-status.js
+++ b/ui/chat/project-status.js
@@ -17,7 +17,6 @@
     const versionWarning = options.versionWarning || null;
     const versionPopover = options.versionPopover || null;
     const versionWarningText = options.versionWarningText || null;
-    const versionCommand = options.versionCommand || null;
     const escapeHtml = options.escapeHtml || defaultEscapeHtml;
 
     function basename(path) {
@@ -77,11 +76,8 @@
           `Current: ${escapeHtml(current)}`,
           `Available: ${escapeHtml(latest)}`,
           "",
-          "Close Godot, then run this in the current project.",
+          "The update will be verified before Godot asks to close.",
         ].join("<br>");
-      }
-      if (versionCommand) {
-        versionCommand.textContent = "fennara update";
       }
       if (versionPopover) {
         versionPopover.hidden = false;

--- a/ui/chat/styles/controls.css
+++ b/ui/chat/styles/controls.css
@@ -21,6 +21,49 @@
   display: none !important;
 }
 
+.update-start-overlay[hidden] {
+  display: none;
+}
+
+.update-start-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background: #242424;
+}
+
+.update-start-card {
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  max-width: 420px;
+  text-align: center;
+  color: #c8c8c8;
+}
+
+.update-start-card strong {
+  color: #f0f0f0;
+  font-size: 20px;
+}
+
+.update-start-spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid #4b4b4b;
+  border-top-color: #6ea8e5;
+  border-radius: 50%;
+  animation: fennara-update-spin 0.8s linear infinite;
+}
+
+@keyframes fennara-update-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .target-pill {
   display: flex;
   align-items: center;
@@ -117,9 +160,23 @@
 }
 
 .version-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  min-height: 30px;
+  padding: 0 10px;
   border-color: #4f93d2;
+  border-style: solid;
+  border-width: 1px;
+  border-radius: var(--radius);
   background: #478ec9;
   color: #f2f8ff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 700;
+  box-shadow: 0 0 0 1px rgba(112, 188, 255, 0.12);
 }
 
 .version-button:hover {
@@ -170,22 +227,7 @@
   white-space: nowrap;
 }
 
-.version-update-action {
-  border: 1px solid rgba(112, 188, 255, 0.45);
-  border-radius: 7px;
-  background: rgba(55, 132, 210, 0.22);
-  color: var(--text-primary);
-  padding: 7px 10px;
-  cursor: pointer;
-  font: inherit;
-}
-
-.version-update-action:hover,
-.version-update-action:focus-visible {
-  background: rgba(55, 132, 210, 0.36);
-}
-
-.version-update-action:disabled {
+.version-button:disabled {
   cursor: wait;
   opacity: 0.6;
 }

--- a/ui/chat/styles/controls.css
+++ b/ui/chat/styles/controls.css
@@ -170,6 +170,26 @@
   white-space: nowrap;
 }
 
+.version-update-action {
+  border: 1px solid rgba(112, 188, 255, 0.45);
+  border-radius: 7px;
+  background: rgba(55, 132, 210, 0.22);
+  color: var(--text-primary);
+  padding: 7px 10px;
+  cursor: pointer;
+  font: inherit;
+}
+
+.version-update-action:hover,
+.version-update-action:focus-visible {
+  background: rgba(55, 132, 210, 0.36);
+}
+
+.version-update-action:disabled {
+  cursor: wait;
+  opacity: 0.6;
+}
+
 .icon-button,
 .secondary-button,
 .primary-button {


### PR DESCRIPTION
## Summary

- prepare manifest-backed updates while Godot remains open and keep the active addon, runtime selection, daemon, and launchers unchanged during preparation
- expose **Prepare Update** in chat and route it through the authenticated project-bound daemon connection to a native Godot progress panel
- require explicit **Close Godot and Install** or **Not Now** confirmation after the operation reaches `ready_to_close`
- launch a detached CLI that waits for the exact Godot PID and process start time before changing files
- move the current addon to an operation-specific backup and move the staged addon into `addons/fennara` using same-filesystem directory renames
- stop the previous daemon, activate staged launchers and the matching runtime manifest, refresh project guidance, and reopen the same executable and project
- require a reopened GDExtension activation handshake and matching daemon health before deleting the backup
- retain durable recovery state and expose **Restore Previous Version**, **Open Logs**, and **Copy Report** when validation cannot finish
- preserve resumable operation state, atomic runtime manifest writes, sanitized diagnostics, cancellation, automatic pre-reopen rollback, and user-confirmed post-reopen recovery

## User impact

A user can start an update from the Fennara chat dock without using a terminal. Downloads and verification happen while Godot remains open. Godot closes only after explicit confirmation, only one addon is active under `addons/fennara`, and the previous version remains under `.godot` until the reopened installation proves that the new addon and daemon work together.

## Safety behavior

- no loaded GDExtension is overwritten
- no editor process is force-killed
- active files are unchanged until every release asset is verified and staged
- process waiting rejects PID reuse by comparing the observed process start time
- runtime manifest activation and staging receipts use durable replacement writes
- failure before reopen restores the prior addon and runtime automatically
- failure after reopen preserves recovery state and requires explicit confirmation before rollback closes Godot
- operation logs and copied reports remain sanitized

## Issue

Closes #94.

## Validation

```bash
cd local
cargo test --workspace
cargo fmt --all -- --check
cargo clippy -p fennara-cli --all-targets -- -D warnings
cargo check --workspace

cd ../fennara-cpp
scons target=editor

cd ..
node --check ui/chat/app.js
node --check ui/chat/project-status.js
git diff --check
```

Manual interruption and full packaged-release update testing remain required before merge.

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app update preparation with verified staging, user-confirmed installation, and automatic Godot reopening.
  * Added update status actions, including **Not Now**, **Restore Previous Version**, **Open Logs**, and **Copy Report**.
  * Added recovery for interrupted updates through `fennara recover`.
  * Update notifications now offer a simpler **Update** action and progress feedback.

* **Bug Fixes**
  * Improved update safety with validation, rollback support, and recovery after interrupted installations.

* **Documentation**
  * Updated setup, usage, architecture, and release guidance for the native update and recovery workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->