### PR TITLE
feat(mcp): add in-chat app setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,12 @@ The built-in chat dock uses the platform webview: Microsoft Edge WebView2 on Win
 
 ## Quick Start
 
-Install the Fennara addon from the Godot Asset Library or copy its
-`addons/fennara/` folder into the project. Open the project and select the
-Fennara dock. On a clean machine the native setup panel appears before chat:
+Get the addon using either option:
+
+- Install **Fennara** from the Godot Asset Library.
+- Open the [Latest Release](https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest), download `fennara-addon-latest.zip`, and extract its `addons/fennara/` folder into your Godot project.
+
+Open the project, select the Fennara dock, and use the native setup panel:
 
 ```text
 Fennara needs to finish setup.
@@ -66,161 +69,50 @@ Fennara needs to finish setup.
 [Set Up Fennara]
 ```
 
-The panel downloads and verifies the exact CLI for the addon version. The CLI
-then installs the matching daemon, MCP server, local runtimes, project guidance,
-and optional shared webview runtime. The existing addon files remain unchanged.
+The addon verifies and installs the matching CLI, then the CLI installs the
+local components required by that addon. The active project addon is left
+unchanged during first-run setup.
 
-After setup, choose the MCP app path, the built-in chat path, or both.
+After setup, use the built-in chat, connect an external MCP app, or use both.
+The full user walkthrough is in [Setup](docs/setup.md).
 
-### Terminal Setup Alternative
+### Prefer The Terminal?
 
-Use the terminal flow when native first-run setup cannot start or when you are
-preparing a project non-interactively.
-
-#### 1. Install The CLI
-
-Windows:
-
-```powershell
-irm https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.ps1 | iex
-```
-
-macOS / Linux:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh
-```
-
-Check the install:
-
-```bash
-fennara doctor
-```
-
-#### 2. Add Fennara To A Godot Project
-
-When the chat toolbar shows an available release, select **Prepare Update**.
-Fennara downloads and verifies the update while Godot stays open. After staging
-finishes, choose **Close Godot and Install** or **Not Now**. The external updater
-waits for that exact editor process to exit, replaces the addon using
-same-filesystem directory renames, reopens the same project, and keeps the
-previous addon until the new GDExtension and daemon validate successfully.
-
-The terminal flow remains available:
-
-```bash
-cd path/to/your-godot-project
-fennara install
-```
-
-You can also run install and update commands from a separate tooling folder by
-passing the Godot project explicitly:
+The terminal uses the same installer and maintenance logic as the Godot setup
+panel. Follow [Fennara CLI](docs/cli.md#install-the-cli) to install it, then run:
 
 ```bash
 fennara install --project path/to/your-godot-project
-fennara update --project path/to/your-godot-project
 ```
 
-Your MCP app can point at the global Fennara launcher from anywhere. It does not
-need config files inside the Godot project. Fennara uses the Godot project you
-open in the editor.
+Configure an external MCP app only if you want one. The supported app commands
+and manual configuration path are in [MCP Setup](docs/mcp-setup.md).
 
-For a C# project, use the same `fennara install` command. C# project scans and
-runtime preflight checks use the project's installed .NET SDK.
-
-Then open the project in Godot.
-
-If `addons/fennara` already contains a complete addon from the Godot Asset
-Library or a release archive, `fennara install` reads its `VERSION`, validates
-the editor library for the current platform, and installs that exact matching
-local runtime. It keeps the existing addon files unchanged, starts the matching
-daemon when needed, and confirms the daemon connection.
-
-`fennara install` also writes project guidance for AI coding agents:
-
-```text
-AGENTS.md
-addons/fennara/ai/guidelines.md
-```
-
-### 3. Optional: Configure Your MCP App
-
-Skip this step if you only want to use the built-in Fennara chat dock.
-
-Claude Code and Claude Desktop:
-
-```bash
-fennara mcp-setup --claude
-```
-
-Gemini and Antigravity:
-
-```bash
-fennara mcp-setup --gemini
-```
-
-Cursor:
-
-```bash
-fennara mcp-setup --cursor
-```
-
-Codex:
-
-```bash
-fennara mcp-setup --codex
-```
-
-More targets:
-
-```bash
-fennara mcp-setup --help
-```
-
-Restart the MCP app after setup so it reloads the Fennara server.
-
-If your app is not listed, or if you need to edit an MCP config by hand, see
-[MCP Setup](docs/mcp-setup.md).
-
-This step only configures the external MCP app. It does not configure the built-in Fennara chat model. See [MCP Apps And Built-In Chat](docs/chat-vs-mcp.md) if you are wondering why the dock asks for a provider even after `mcp-setup --claude`.
-
-### 4. Optional: Verify External MCP Works
-
-With the Godot project open, ask your MCP app:
+With Godot open, verify the connection from your MCP app:
 
 ```text
 Use Fennara MCP to run fennara_status and tell me which Godot project is connected.
 ```
 
-If the project path is correct, the MCP server and Godot plugin are talking.
+For every CLI command, update behavior, recovery, diagnostics, app-data paths,
+and automation guidance, see [Fennara CLI](docs/cli.md).
 
-If more than one Godot project is open, use the Fennara dock's MCP target control to choose which project receives external MCP tool calls.
+## Updates
 
-### 5. Update Later
+When an update is available, the Fennara dock shows an **Update** button. It
+verifies and stages the release while Godot remains open, then asks before
+closing the editor. The detached updater replaces the addon, reopens the same
+project, validates the new addon and daemon, and retains the previous working
+version until validation succeeds.
 
-Run this from the Godot project folder:
-
-```bash
-cd path/to/your-godot-project
-fennara update
-```
-
-`fennara update` reads the release manifest, updates the installed CLI when a newer release requires it, then refreshes the project addon, local runtime package, generated Fennara guidance files, and any release-managed shared webview runtime needed by the current platform. On Windows/macOS it also checks the platform webview prerequisite and warns if the built-in chat dock may not start. Rerun the install script only if CLI self-update is not available for the selected release or install location.
-
-When an update has to replace the running CLI before continuing, Fennara prints
-the updater log path so CI and agent runs can inspect the resumed project-update
-output.
-
-If validation cannot finish, the reopened dock offers **Restore Previous
-Version**, **Open Logs**, and **Copy Report**. Rollback also waits for explicit
-confirmation before closing Godot.
-
-If an interrupted native update prevents the addon from loading, close Godot
-and restore the recorded transaction with the same installed CLI:
+Terminal users can close Godot and run:
 
 ```bash
-fennara recover --project path/to/your-godot-project
+fennara update --project path/to/your-godot-project
 ```
+
+See [Setup](docs/setup.md#update-fennara) for the user-facing flow and
+[Fennara CLI](docs/cli.md#update-a-project) for terminal and recovery commands.
 
 ## Tools
 
@@ -276,6 +168,7 @@ See [Demos](docs/demos.md) for more videos from the Fennara channel.
 Useful starting points:
 
 - [Setup](docs/setup.md)
+- [Fennara CLI](docs/cli.md)
 - [MCP setup](docs/mcp-setup.md)
 - [Repo map](docs/repo-map.md)
 - [Architecture](docs/architecture.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,214 @@
+# Fennara CLI
+
+The Fennara CLI is the shared installer and maintenance layer behind both the
+Godot setup panel and terminal workflows. The addon bootstrap downloads the
+matching CLI, verifies it, and asks it to finish setup. Users who prefer a
+terminal can run the same operations directly.
+
+Use [Setup](setup.md) for the normal Godot user journey. This page is the CLI
+reference.
+
+## Install The CLI
+
+Windows:
+
+```powershell
+irm https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.ps1 | iex
+```
+
+macOS and Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh
+```
+
+Open a new terminal if `fennara` is not immediately available, then check the
+installation:
+
+```bash
+fennara --version
+fennara doctor
+```
+
+The CLI is installed per user. Project addons stay inside their Godot projects;
+shared launchers, versioned runtimes, operation records, logs, and Linux CEF
+stay in Fennara app data:
+
+```text
+Windows: %LOCALAPPDATA%\Fennara
+macOS: ~/Library/Application Support/Fennara
+Linux: ~/.local/share/fennara
+```
+
+## Command Summary
+
+```text
+fennara doctor [--repair]
+fennara diagnostics [--operation <operation-id>] [--json]
+fennara install [--project <path>] [--version <version>]
+fennara mcp-setup <target flags>
+fennara update [--project <path>] [--version <version>] [--no-self-update] [--prepare]
+fennara recover --project <path> [--operation <operation-id>]
+fennara self-update [--version <version>]
+```
+
+Run `fennara <command> --help` for the options supported by the installed CLI.
+
+## Install A Project
+
+Run inside a folder containing `project.godot`:
+
+```bash
+fennara install
+```
+
+Or identify the project explicitly:
+
+```bash
+fennara install --project path/to/project
+```
+
+Without `--version`, the CLI selects the current release manifest. Use an exact
+release when reproducibility matters:
+
+```bash
+fennara install --project path/to/project --version 0.3.8
+```
+
+Installation has two safe paths:
+
+- If no complete addon exists, the CLI downloads and verifies the selected
+  release, installs `addons/fennara`, installs the matching local components,
+  and writes Fennara project guidance.
+- If a complete addon already exists, the CLI reads its `VERSION`, validates
+  the current platform library, and installs that exact version's CLI-managed
+  components. It keeps the project addon unchanged. An explicit `--version`
+  must match the existing addon.
+
+This second path is what the Godot **Set Up Fennara** panel uses after it has
+bootstrapped the CLI.
+
+## Update A Project
+
+For a normal terminal update, close Godot for that project and run:
+
+```bash
+fennara update --project path/to/project
+```
+
+The CLI resolves the selected release, self-updates when the release requires a
+newer CLI, verifies the release assets, refreshes the addon and versioned local
+components, updates project guidance, and checks the platform webview
+prerequisite. Use `--version <version>` to select an exact release.
+
+`--no-self-update` is intended for controlled automation or continuation after
+the CLI has already been replaced. Do not use it to bypass a release's minimum
+CLI requirement.
+
+### Prepare While Godot Is Open
+
+The in-editor update button uses the staging form:
+
+```bash
+fennara update --prepare --project path/to/project
+```
+
+Preparation downloads, verifies, and durably stages the addon. It does not
+close Godot, replace the live addon, switch the active runtime manifest, or
+restart the daemon. The Godot dock observes the operation receipt and asks the
+user before starting the detached close, replace, reopen, and validation step.
+
+`--prepare` is a low-level primitive for the Godot integration. Terminal users
+normally use `fennara update` with Godot already closed.
+
+## Recover An Interrupted Update
+
+If the updated addon cannot load far enough to show the recovery panel, close
+Godot and run:
+
+```bash
+fennara recover --project path/to/project
+```
+
+The CLI restores only operations in a recoverable state. It restores the
+previous addon, shared launchers, and active runtime manifest, then attempts to
+reopen the recorded Godot executable. Select a particular transaction when
+support gives you its operation ID:
+
+```bash
+fennara recover --project path/to/project --operation <operation-id>
+```
+
+Completed, merely prepared, and already rolled-back operations are rejected.
+
+## Inspect Health And Failures
+
+`doctor` reports the detected platform, app-data layout, active version,
+launchers, runtimes, daemon state, and webview prerequisite:
+
+```bash
+fennara doctor
+```
+
+Use `--repair` to recreate missing base app-data directories. On Linux it also
+cleans stale CEF process profiles and repairs the current-runtime marker when a
+complete managed runtime is already installed:
+
+```bash
+fennara doctor --repair
+```
+
+Install, update, recovery, and self-update operations write durable state and
+events. Show the newest sanitized report with:
+
+```bash
+fennara diagnostics
+```
+
+For an older operation or machine-readable output:
+
+```bash
+fennara diagnostics --operation <operation-id>
+fennara diagnostics --operation <operation-id> --json
+```
+
+Reports include stable error codes, phases, component versions, selected asset
+names, and hash verification results. They redact project, home, and Fennara
+app-data paths, credentials, bearer tokens, and URL queries. They do not include
+chat messages, provider keys, or project file contents.
+
+## Configure An External MCP App
+
+The Godot chat dock exposes these commands under **Chat Settings > MCP Apps**.
+Its Set Up button asks the local daemon to invoke the installed CLI, so the dock
+and terminal workflows use the same configuration and backup implementation.
+
+Run `fennara mcp-setup --help` to choose a supported target. Restart the MCP app
+after changing its configuration. This command connects an external app to the
+Fennara MCP server; it does not select the model provider used by the built-in
+Godot chat dock. [MCP Setup](mcp-setup.md) owns the target list, config
+locations, and manual configuration examples.
+
+## Update Only The CLI
+
+Normal project updates handle CLI self-update automatically. To update only the
+installed CLI:
+
+```bash
+fennara self-update
+fennara self-update --version <version>
+```
+
+Use this when support requests it or when a project update reports that the
+installed CLI is too old to continue safely.
+
+## Automation Guidance
+
+- Pass `--project` instead of relying on the current directory.
+- Pin `--version` when a build must be reproducible.
+- Preserve the printed operation ID and log path on failure.
+- Use `fennara diagnostics --operation <id> --json` for structured reporting.
+- Do not edit `current.json`, version directories, update receipts, or staged
+  addon folders by hand.
+- Do not run a normal addon-replacing update while that project is open in
+  Godot. Use the in-editor update flow or close Godot first.

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -10,9 +10,17 @@ configured separately inside Godot.
 
 ## Preferred Setup
 
-Run `fennara install` inside your Godot project first. This installs the Godot
-addon, downloads the local runtime package, and creates the stable MCP launcher
-that external apps should call.
+Finish **Set Up Fennara** in the Godot dock first. Then open **Chat Settings >
+MCP Apps**, find the external app, and press **Set Up**. The dock asks the local
+daemon to run the matching `fennara mcp-setup` command. The CLI remains the only
+component that edits MCP app configuration and creates backups.
+
+Restart the selected MCP app after setup so it reloads Fennara. The combined
+**Claude** option configures Claude Code and Claude Desktop. **Gemini &
+Antigravity** configures the shared Gemini and Antigravity targets.
+
+The terminal workflow remains available. Run `fennara install` inside the Godot
+project first, then configure the external app directly:
 
 Then configure your MCP app:
 
@@ -35,8 +43,6 @@ fennara mcp-setup --windsurf
 fennara mcp-setup --kiro
 fennara mcp-setup --help
 ```
-
-Restart the MCP app after setup so it reloads Fennara.
 
 ## Manual Setup
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -20,6 +20,8 @@ This is the quick map for contributors and coding agents working in this reposit
 | `install.ps1` / `install.sh` | Bootstrap scripts that install the Fennara CLI from GitHub releases. |
 | `VERSION` | Version source of truth. |
 | `README.md` | Short human-facing overview and quick start. |
+| `docs/setup.md` | User-facing addon-first setup, chat prerequisites, MCP connection, update flow, and troubleshooting. |
+| `docs/cli.md` | Terminal command reference, CLI-owned install/update behavior, recovery, diagnostics, app-data layout, and automation guidance. |
 | `CONTRIBUTING.md` | Contribution rules. |
 | `SECURITY.md` | Security reporting policy. |
 | `LICENSE.md` | Project license. |
@@ -120,6 +122,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | Add or change a Godot tool | `fennara-cpp/src/tools/` and `local/schemas/tools/` |
 | Change MCP schema text | `local/schemas/tools/` |
 | Change `fennara install` or `fennara update` | `local/crates/fennara-cli/src/`; native staging and detached apply/rollback are owned by `release_update.rs`, `update_stage.rs`, `update_stage/`, and `update_apply/` |
+| Change CLI commands or terminal behavior | `local/crates/fennara-cli/src/` and `docs/cli.md` |
 | Change native update progress, shutdown confirmation, activation handshake, or recovery | `fennara-cpp/src/update/`, `fennara-cpp/src/ui/update_panel.cpp`, `fennara-cpp/src/ui/dock.cpp`, `local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs`, and `ui/chat/` |
 | Change native first-run setup or CLI bootstrap | `fennara-cpp/src/setup/`, `fennara-cpp/src/ui/setup_panel.cpp`, and `fennara-cpp/src/ui/dock.cpp` |
 | Change install/update operation logs, phases, error codes, or diagnostic reports | `local/crates/fennara-cli/src/operation.rs`, `local/crates/fennara-cli/src/operation/`, and `local/crates/fennara-cli/src/diagnostics.rs` |
@@ -142,3 +145,4 @@ This is the quick map for contributors and coding agents working in this reposit
 - Keep this file current when adding or moving major source areas.
 - Keep release steps in [release.md](release.md).
 - Keep setup steps in [setup.md](setup.md).
+- Keep terminal command behavior in [cli.md](cli.md).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -246,9 +246,10 @@ fix.
 ### Release Requires A Newer CLI
 
 If `fennara install` or `fennara update` says the release requires a newer
-Fennara CLI and self-update could not run, rerun the install script from step 1,
-then run the command again. This should be rare; normal package, runtime, and
-CLI changes are handled by the release manifest.
+Fennara CLI and self-update could not run, rerun the install script from
+[Install the CLI](cli.md#install-the-cli), then run the command again. This
+should be rare; normal package, runtime, and CLI changes are handled by the
+release manifest.
 
 ### The Addon Is Not Visible In Godot
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -14,8 +14,8 @@ This guide walks through a normal Fennara setup from a clean machine to a Godot 
 
 ## Default: Set Up From Godot
 
-Install the Fennara addon from the Godot Asset Library or copy its
-`addons/fennara/` folder into the project. Open the project and select the
+Add Fennara to the project using one of the download options in the
+[README Quick Start](../README.md#quick-start). Open the project and select the
 Fennara dock. If the matching local components are missing, Fennara shows a
 native setup panel that does not depend on chat, the daemon, or a webview.
 
@@ -38,104 +38,33 @@ or updater inside the project addon.
 ## Terminal Setup Alternative
 
 Use this flow for non-interactive setup or when the native setup panel cannot
-download or launch the CLI.
+download or launch the CLI. It uses the same CLI that the Godot panel
+bootstraps.
 
-### 1. Install The Fennara CLI
-
-Windows:
-
-```powershell
-irm https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.ps1 | iex
-```
-
-macOS / Linux:
+Install the CLI using the platform command in
+[Fennara CLI](cli.md#install-the-cli), then install the Godot project:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh
+fennara install --project path/to/your-godot-project
 ```
 
-Check that the CLI is available:
-
-```bash
-fennara doctor
-```
-
-If `fennara` is not found, open a new terminal. The installer may have updated your shell PATH for future sessions.
-
-Fennara installs the CLI here by default:
-
-```text
-Windows: %LOCALAPPDATA%\Fennara\bin
-macOS: ~/Library/Application Support/Fennara/bin
-Linux: ~/.local/share/fennara/bin
-```
-
-The install script installs the small outer CLI. In normal releases,
-`fennara update` can update that CLI itself before refreshing project assets.
-Rerun the install script only when CLI self-update is not available for the
-selected release or install location.
-
-### 2. Install Fennara In A Godot Project
-
-Run this inside the Godot project folder:
+Running inside the project works too:
 
 ```bash
 cd path/to/your-godot-project
 fennara install
 ```
 
-If you keep MCP or agent config in a separate tooling repo, pass the Godot
-project path explicitly instead:
-
-```bash
-fennara install --project path/to/your-godot-project
-fennara update --project path/to/your-godot-project
-```
-
-Your MCP app can point at the global Fennara launcher from anywhere. It does not
-need config files inside the Godot project. `--project` tells Fennara which
-Godot project to install or update.
-
 For a C# Godot project, use the same `fennara install` command. Ensure the .NET
 SDK required by the project is available through `dotnet`; Fennara uses project
 builds for C# diagnostics and runtime preflight.
 
-When the project does not have a complete addon, `fennara install` copies the
-selected Godot addon into:
+If the project already has a complete Asset Library or release addon, the CLI
+keeps it and installs its exact matching local components. Otherwise it installs
+the selected release addon. See [Fennara CLI](cli.md#install-a-project) for
+version selection, repeat-install behavior, and automation options.
 
-```text
-addons/fennara
-```
-
-If that directory exists from a failed or partial installation but does not
-contain `fennara.gdextension`, `fennara install` treats it as incomplete and
-replaces it with the selected addon package.
-
-If the directory already contains a complete addon from the Godot Asset
-Library or a release archive, install adopts it instead. The CLI reads its
-`VERSION`, validates the matching editor library, resolves that exact release,
-checks the release's minimum CLI version, and installs the matching daemon, MCP
-server, local runtime, and optional shared webview runtime. It does not replace
-or rewrite the existing addon. It starts the daemon when needed and confirms
-that the running daemon version matches the addon. Repeating the same install
-is safe.
-
-Install also reads the release manifest, downloads and verifies the local
-Fennara runtime package into your user app-data folder, and writes project
-guidance for AI coding agents. Fresh addon installs write both paths below.
-Existing-addon adoption only writes the project-level `AGENTS.md`, because the
-addon already contains its matching guidance:
-
-```text
-AGENTS.md
-addons/fennara/ai/guidelines.md
-```
-
-If `AGENTS.md` already exists, Fennara only updates the generated block between its own markers.
-Existing-addon adoption may also update an existing project `.gitignore` with
-Fennara-managed local state entries.
-
-### Built-In Chat Webview Prerequisites
+## Built-In Chat Webview Prerequisites
 
 Fennara MCP tools work without the built-in Godot chat dock. The chat dock needs
 the platform webview:
@@ -189,7 +118,7 @@ script editor, open the script editor context menu, and choose **Add to Chat**.
 The selected script range is attached to the next chat message as removable code
 context.
 
-## 3. Configure Your MCP App
+## Configure Your MCP App
 
 Claude Code and Claude Desktop:
 
@@ -231,7 +160,7 @@ see [MCP Setup](mcp-setup.md) for manual JSON/TOML config examples.
 the built-in Fennara dock use Claude or your Claude subscription. The dock uses
 the provider configured in Fennara chat settings. See [MCP Apps And Built-In Chat](chat-vs-mcp.md).
 
-## 4. Verify The Connection
+## Verify The Connection
 
 Open the Godot project, then ask your MCP app:
 
@@ -243,65 +172,25 @@ The result should show the project path you expect.
 
 If the wrong project is shown, use the Fennara dock in Godot to set the current project as the MCP target.
 
-## 5. Update Fennara
+## Update Fennara
 
-Run this inside the Godot project folder:
+When the dock shows **Update**, select it to download and verify the release
+while Godot stays open. The dock shows progress, then asks whether to close
+Godot and install. Choosing **Not Now** leaves the current installation running.
 
-```bash
-cd path/to/your-godot-project
-fennara update
-```
-
-This reads the release manifest, updates the installed CLI when needed, and
-then updates the project addon, the local runtime package, any shared runtime
-assets needed by your platform, and the generated Fennara guidance files.
-
-If an MCP app is currently running a Fennara launcher, `fennara update` may keep that launcher and continue. That is okay. The versioned runtime package is still updated.
-
-When an update has to replace the running CLI before continuing, Fennara prints
-the updater log path. Use that log to inspect the resumed project-update output
-in CI or agent-driven runs.
-
-The native update flow separates preparation from user-confirmed shutdown. Its
-CLI staging primitive is:
-
-```bash
-fennara update --prepare --project path/to/your-godot-project
-```
-
-Preparation downloads and verifies manifest-backed release assets, validates
-the packaged addon, and copies it to an operation-specific directory under
-`.godot/fennara-update/`. It records `ready_to_close` only after the staging
-receipt and a digest covering every staged addon file are durable. Preparation
-does not ask Godot to close, replace `addons/fennara`, switch `current.json`, or
-restart the running daemon.
-
-The chat update action runs this preparation command and displays native
-progress in the Godot dock. Once the operation reaches `ready_to_close`, the
-dock asks the user to choose **Close Godot and Install** or **Not Now**. On
-confirmation, a detached CLI waits for the exact Godot process to exit, moves
-the current addon into the operation directory as `previous-addon`, renames the
-verified staged addon into `addons/fennara`, activates the matching runtime and
-shared launchers, and reopens the same executable and project. Immediately
-before replacement, the CLI recomputes the full staged-addon digest and rejects
-any changed or missing file.
-
-The previous addon, shared launchers, and runtime manifest remain available until the reopened
-GDExtension writes its activation handshake and the CLI confirms the matching
-daemon. Failed validation records `recovery_required`; the dock then offers
+After confirmation, Fennara closes the editor normally, installs the staged
+release, and reopens the same project. It keeps the previous working version
+until the new addon and daemon validate. If validation fails, the dock offers
 **Restore Previous Version**, **Open Logs**, and **Copy Report**.
 
-If a machine loses power during the brief addon replacement and the addon
-cannot load far enough to show the recovery panel, close Godot and run:
+Terminal users can close Godot and run:
 
 ```bash
-fennara recover --project path/to/your-godot-project
+fennara update --project path/to/your-godot-project
 ```
 
-The installed CLI finds the newest interrupted operation, restores its addon,
-shared launchers, and runtime manifest, then reopens the recorded Godot
-executable when it is still available. Pass `--operation <operation-id>` to
-select a specific interrupted operation.
+See [Fennara CLI](cli.md#update-a-project) for exact-version updates, the
+prepare primitive, interrupted-update recovery, and diagnostics.
 
 ## Troubleshooting
 
@@ -314,21 +203,9 @@ operation ID and durable event-log path. Show the latest sanitized report with:
 fennara diagnostics
 ```
 
-Use a specific ID when reporting or revisiting an older failure:
-
-```bash
-fennara diagnostics --operation <operation-id>
-```
-
-Operation state is stored under the Fennara app-data `operations/` directory,
-with JSONL events under `logs/operations/`. Reports include the phase, stable
-error code, platform, architecture, and component versions known to the CLI.
-Downloaded artifacts also record their selected asset name, expected hash,
-actual hash, and verification status. Operation failures use stable typed codes
-so support does not depend on matching the wording of an error message.
-They replace the project, home, and Fennara app-data paths with placeholders
-and redact common credential fields, bearer tokens, and URL query strings.
-They do not collect chat messages, provider keys, or project file contents.
+The report is safe to copy into a support request. See
+[CLI diagnostics](cli.md#inspect-health-and-failures) for operation selection,
+JSON output, recorded fields, and redaction guarantees.
 
 ### `fennara` Is Not Found
 
@@ -343,14 +220,7 @@ older than the version selected by `current.json`; restart Godot or the MCP app
 when it prints that warning.
 
 If it still fails, add the Fennara `bin` directory to PATH manually.
-
-Default paths:
-
-```text
-Windows: %LOCALAPPDATA%\Fennara\bin
-macOS: ~/Library/Application Support/Fennara/bin
-Linux: ~/.local/share/fennara/bin
-```
+The platform paths are listed in [Fennara CLI](cli.md#install-the-cli).
 
 ### Windows CLI Fails Before It Starts
 

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -184,6 +184,7 @@
   let providerPopovers = null;
   let projectFileLinks = null;
   let settingsPanel = null;
+  let mcpAppsSettings = null;
   let storedTranscript = null;
   let composerActions = null;
   let effortControls = null;
@@ -255,6 +256,7 @@
     onClose() {
       appShell?.setAttribute("data-connection", "offline");
       stopProjectStatusPolling();
+      mcpAppsSettings?.handleDisconnect();
     },
     onSendUnavailable() {
       appendSystem("Local daemon is not connected yet.");
@@ -268,6 +270,15 @@
   const ensureDaemonConnected = daemonClient.ensureConnected;
   const nextRequestId = daemonClient.nextRequestId;
   const send = daemonClient.send;
+
+  mcpAppsSettings = window.FennaraMcpAppsSettings.createMcpAppsSettings({
+    callbacks: {
+      ensureDaemonConnected,
+      nextRequestId,
+      send,
+    },
+    previewMode: new URLSearchParams(window.location.search).get("preview") === "mcp",
+  });
 
   projectFileLinks = window.FennaraProjectFileLinks.createProjectFileLinks({
     send,
@@ -1327,6 +1338,9 @@
   }
 
   function handleDaemonMessage(message) {
+    if (mcpAppsSettings?.handleMessage(message)) {
+      return;
+    }
     if (message.type === "settings" || message.type === "settings_saved") {
       const requestId = String(message.request_id || "");
       const isKeySave = requestId.startsWith("save-settings-key");

--- a/godot_demo/addons/fennara/dist/index.html
+++ b/godot_demo/addons/fennara/dist/index.html
@@ -457,63 +457,63 @@
               <article class="mcp-app-card" data-mcp-app="codex" data-mcp-search="codex">
                 <div class="mcp-app-copy">
                   <strong>Codex</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="claude" data-mcp-search="claude code desktop" data-mcp-restart="Claude Code and Claude Desktop">
                 <div class="mcp-app-copy">
                   <strong>Claude</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="gemini" data-mcp-search="gemini antigravity" data-mcp-restart="Gemini CLI and Antigravity">
                 <div class="mcp-app-copy">
                   <strong>Gemini &amp; Antigravity</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="cline" data-mcp-search="cline">
                 <div class="mcp-app-copy">
                   <strong>Cline</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="cursor" data-mcp-search="cursor">
                 <div class="mcp-app-copy">
                   <strong>Cursor</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="vscode" data-mcp-search="vs code vscode visual studio code">
                 <div class="mcp-app-copy">
                   <strong>VS Code</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="opencode" data-mcp-search="opencode open code">
                 <div class="mcp-app-copy">
                   <strong>OpenCode</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="windsurf" data-mcp-search="windsurf">
                 <div class="mcp-app-copy">
                   <strong>Windsurf</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="kiro" data-mcp-search="kiro">
                 <div class="mcp-app-copy">
                   <strong>Kiro</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>

--- a/godot_demo/addons/fennara/dist/index.html
+++ b/godot_demo/addons/fennara/dist/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Fennara Chat</title>
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./styles.css?v=mcp-apps-7" />
   </head>
   <body>
     <main class="app-shell" data-connection="offline">
@@ -393,49 +393,139 @@
             <h2>Chat Settings</h2>
             <button class="icon-button" type="submit" aria-label="Close settings">x</button>
           </header>
-          <fieldset class="settings-group">
-            <legend>Providers</legend>
-            <p class="settings-note">
-              Choose a provider and configure the connection details it requires.
-            </p>
-            <button class="secondary-button settings-provider-button" type="button" data-open-settings-providers>
-              Open providers
-            </button>
-          </fieldset>
-          <fieldset class="settings-group">
-            <legend>Tool approvals</legend>
-            <label class="settings-radio">
-              <input type="radio" name="approval_mode" value="ask" data-approval-mode checked />
-              <span>
-                <strong>Ask for approval</strong>
-                <small>Read-only tools run. Project changes and runtime actions wait for you.</small>
-              </span>
+          <nav class="settings-tabs" aria-label="Settings sections">
+            <button class="settings-tab is-active" type="button" aria-selected="true" data-settings-tab="chat">Chat</button>
+            <button class="settings-tab" type="button" aria-selected="false" data-settings-tab="mcp">MCP Apps</button>
+          </nav>
+          <section class="settings-page" data-settings-page="chat">
+            <fieldset class="settings-group">
+              <legend>Providers</legend>
+              <p class="settings-note">
+                Choose a provider and configure the connection details it requires.
+              </p>
+              <button class="secondary-button settings-provider-button" type="button" data-open-settings-providers>
+                Open providers
+              </button>
+            </fieldset>
+            <fieldset class="settings-group">
+              <legend>Tool approvals</legend>
+              <label class="settings-radio">
+                <input type="radio" name="approval_mode" value="ask" data-approval-mode checked />
+                <span>
+                  <strong>Ask for approval</strong>
+                  <small>Read-only tools run. Project changes and runtime actions wait for you.</small>
+                </span>
+              </label>
+              <label class="settings-radio">
+                <input type="radio" name="approval_mode" value="full_access" data-approval-mode />
+                <span>
+                  <strong>Full access</strong>
+                  <small>Project changes and runtime actions run without prompting. Hard safety blocks still apply.</small>
+                </span>
+              </label>
+            </fieldset>
+            <fieldset class="settings-group">
+              <legend>Chat display</legend>
+              <label class="settings-check">
+                <input type="checkbox" data-chat-surface-browser />
+                <span>Open chat in my system browser next time</span>
+              </label>
+              <p class="settings-note">
+                This keeps the Godot dock lightweight and can reduce editor GPU and memory usage.
+              </p>
+              <p class="settings-status settings-restart" data-chat-surface-restart hidden>
+                Restart Godot for this change to take effect.
+              </p>
+            </fieldset>
+          </section>
+          <section class="settings-page mcp-apps-page" data-settings-page="mcp" hidden>
+            <div class="mcp-apps-intro">
+              <div>
+                <h3>Use Fennara from your AI apps</h3>
+                <p>Connect an app once, then choose this Godot project from the MCP target button.</p>
+              </div>
+              <span class="mcp-ready-badge"><span></span> Fennara ready</span>
+            </div>
+            <label class="mcp-app-search">
+              <svg class="svg-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="M20 20l-3.5-3.5"></path>
+              </svg>
+              <input type="search" placeholder="Search supported apps..." aria-label="Search supported MCP apps" data-mcp-app-search />
             </label>
-            <label class="settings-radio">
-              <input type="radio" name="approval_mode" value="full_access" data-approval-mode />
-              <span>
-                <strong>Full access</strong>
-                <small>Project changes and runtime actions run without prompting. Hard safety blocks still apply.</small>
-              </span>
-            </label>
-          </fieldset>
-          <fieldset class="settings-group">
-            <legend>Chat display</legend>
-            <label class="settings-check">
-              <input type="checkbox" data-chat-surface-browser />
-              <span>Open chat in my system browser next time</span>
-            </label>
-            <p class="settings-note">
-              This keeps the Godot dock lightweight and can reduce editor GPU and memory usage.
-            </p>
-            <p class="settings-status settings-restart" data-chat-surface-restart hidden>
-              Restart Godot for this change to take effect.
-            </p>
-          </fieldset>
+            <div class="mcp-app-list" aria-label="MCP applications">
+              <article class="mcp-app-card" data-mcp-app="codex" data-mcp-search="codex">
+                <div class="mcp-app-copy">
+                  <strong>Codex</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="claude" data-mcp-search="claude code desktop" data-mcp-restart="Claude Code and Claude Desktop">
+                <div class="mcp-app-copy">
+                  <strong>Claude</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="gemini" data-mcp-search="gemini antigravity" data-mcp-restart="Gemini CLI and Antigravity">
+                <div class="mcp-app-copy">
+                  <strong>Gemini &amp; Antigravity</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="cline" data-mcp-search="cline">
+                <div class="mcp-app-copy">
+                  <strong>Cline</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="cursor" data-mcp-search="cursor">
+                <div class="mcp-app-copy">
+                  <strong>Cursor</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="vscode" data-mcp-search="vs code vscode visual studio code">
+                <div class="mcp-app-copy">
+                  <strong>VS Code</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="opencode" data-mcp-search="opencode open code">
+                <div class="mcp-app-copy">
+                  <strong>OpenCode</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="windsurf" data-mcp-search="windsurf">
+                <div class="mcp-app-copy">
+                  <strong>Windsurf</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="kiro" data-mcp-search="kiro">
+                <div class="mcp-app-copy">
+                  <strong>Kiro</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+            </div>
+            <p class="mcp-app-empty" data-mcp-app-empty hidden>No supported apps match your search.</p>
+            <div class="mcp-app-result" role="status" aria-live="polite" data-mcp-app-result hidden></div>
+            <p class="mcp-apps-footnote">Fennara creates a backup before changing an app's MCP configuration.</p>
+          </section>
           <p class="settings-toast" role="status" aria-live="polite" data-settings-saved-toast hidden>
             Settings saved
           </p>
-          <menu>
+          <menu data-settings-actions>
             <button class="secondary-button" value="cancel">Cancel</button>
             <button class="primary-button" value="default" data-save-settings disabled>Save</button>
           </menu>
@@ -457,11 +547,12 @@
     <script src="./project-file-links.js"></script>
     <script src="./provider-popovers.js"></script>
     <script src="./settings-panel.js"></script>
+    <script src="./mcp-apps-settings.js?v=mcp-apps-8"></script>
     <script src="./chat-navigation.js"></script>
     <script src="./composer-actions.js"></script>
     <script src="./effort-controls.js"></script>
     <script src="./overlay-manager.js"></script>
     <script src="./shell-bindings.js"></script>
-    <script src="./app.js"></script>
+    <script src="./app.js?v=mcp-apps-8"></script>
   </body>
 </html>

--- a/godot_demo/addons/fennara/dist/mcp-apps-settings.js
+++ b/godot_demo/addons/fennara/dist/mcp-apps-settings.js
@@ -1,0 +1,208 @@
+(function () {
+  const REQUEST_TIMEOUT_MS = 65_000;
+
+  function createMcpAppsSettings(options = {}) {
+    const callbacks = options.callbacks || {};
+    const dialog = document.querySelector("[data-settings]");
+    const tabs = Array.from(document.querySelectorAll("[data-settings-tab]"));
+    const pages = Array.from(document.querySelectorAll("[data-settings-page]"));
+    const result = document.querySelector("[data-mcp-app-result]");
+    const appSearch = document.querySelector("[data-mcp-app-search]");
+    const appCards = Array.from(document.querySelectorAll("[data-mcp-app]"));
+    const emptySearch = document.querySelector("[data-mcp-app-empty]");
+    const settingsActions = document.querySelector("[data-settings-actions]");
+    const previewMode = Boolean(options.previewMode);
+    const pendingRequests = new Map();
+
+    function selectPage(pageName) {
+      tabs.forEach((tab) => {
+        const selected = tab.dataset.settingsTab === pageName;
+        tab.classList.toggle("is-active", selected);
+        tab.setAttribute("aria-selected", String(selected));
+      });
+      pages.forEach((page) => {
+        page.hidden = page.dataset.settingsPage !== pageName;
+      });
+      if (settingsActions) {
+        settingsActions.hidden = pageName === "mcp";
+      }
+    }
+
+    function renderResult(title, detail, failed = false) {
+      if (!result) {
+        return;
+      }
+      const heading = document.createElement("strong");
+      const message = document.createElement("span");
+      heading.textContent = title;
+      message.textContent = detail;
+      result.replaceChildren(heading, message);
+      result.classList.toggle("is-error", failed);
+      result.hidden = false;
+    }
+
+    function lockSetupActions(activeButton) {
+      appCards.forEach((card) => {
+        const button = card.querySelector("[data-mcp-app-action]");
+        if (button) {
+          button.disabled = true;
+          button.setAttribute("aria-busy", String(button === activeButton));
+        }
+      });
+    }
+
+    function restoreSetupActions() {
+      appCards.forEach((card) => {
+        const button = card.querySelector("[data-mcp-app-action]");
+        const status = card.querySelector("[data-mcp-app-status]");
+        if (!button) {
+          return;
+        }
+        const completed = status?.classList.contains("is-configured");
+        const retryable = status?.classList.contains("is-warning") || status?.classList.contains("is-error");
+        button.disabled = Boolean(completed && !retryable);
+        button.removeAttribute("aria-busy");
+      });
+    }
+
+    function setRunning(card, button) {
+      const status = card.querySelector("[data-mcp-app-status]");
+      lockSetupActions(button);
+      button.textContent = "Setting up...";
+      status.textContent = "Running Fennara CLI";
+      status.classList.remove("is-configured", "is-error", "is-warning");
+      result.hidden = true;
+    }
+
+    function setCompleted(card, warning = "") {
+      const appName = card.querySelector("strong")?.textContent || "App";
+      const restartName = card.dataset.mcpRestart || appName;
+      const status = card.querySelector("[data-mcp-app-status]");
+      const button = card.querySelector("[data-mcp-app-action]");
+      status.textContent = warning ? "Configured with warning" : "Configured, restart required";
+      status.classList.add("is-configured");
+      status.classList.toggle("is-warning", Boolean(warning));
+      status.classList.remove("is-error");
+      button.textContent = warning ? "Retry" : "Configured";
+      button.disabled = !warning;
+      card.classList.add("is-configured");
+      if (warning) {
+        renderResult(`${appName} setup needs attention.`, warning, true);
+      } else {
+        renderResult(`${appName} is connected.`, `Restart ${restartName} so it can load Fennara.`);
+      }
+      restoreSetupActions();
+    }
+
+    function setFailed(card, error) {
+      const appName = card.querySelector("strong")?.textContent || "App";
+      const status = card.querySelector("[data-mcp-app-status]");
+      const button = card.querySelector("[data-mcp-app-action]");
+      status.textContent = "Setup failed";
+      status.classList.add("is-error");
+      status.classList.remove("is-configured", "is-warning");
+      button.textContent = "Retry";
+      renderResult(`${appName} could not be configured.`, error || "Try again or run Fennara MCP setup from the CLI.", true);
+      restoreSetupActions();
+    }
+
+    function completeRequest(requestId, message) {
+      const pending = pendingRequests.get(requestId);
+      if (!pending) {
+        return false;
+      }
+      window.clearTimeout(pending.timeoutId);
+      pendingRequests.delete(requestId);
+      if (message.type === "mcp_setup_completed") {
+        setCompleted(pending.card, message.warning || "");
+      } else {
+        setFailed(pending.card, message.message);
+      }
+      return true;
+    }
+
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => selectPage(tab.dataset.settingsTab));
+    });
+
+    appSearch?.addEventListener("input", () => {
+      const query = appSearch.value.trim().toLowerCase();
+      let visibleCount = 0;
+      appCards.forEach((card) => {
+        const searchText = `${card.dataset.mcpSearch || ""} ${card.textContent || ""}`.toLowerCase();
+        const visible = !query || searchText.includes(query);
+        card.hidden = !visible;
+        if (visible) {
+          visibleCount += 1;
+        }
+      });
+      if (emptySearch) {
+        emptySearch.hidden = visibleCount > 0;
+      }
+    });
+
+    document.querySelectorAll("[data-mcp-app-action]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const card = button.closest("[data-mcp-app]");
+        if (!card) {
+          return;
+        }
+        setRunning(card, button);
+
+        if (previewMode) {
+          window.setTimeout(() => setCompleted(card), 850);
+          return;
+        }
+        if (!callbacks.ensureDaemonConnected?.()) {
+          setFailed(card, "The local Fennara daemon is not connected yet.");
+          return;
+        }
+
+        const requestId = callbacks.nextRequestId?.("mcp-setup");
+        if (!requestId || !callbacks.send?.({
+          type: "setup_mcp_app",
+          request_id: requestId,
+          mcp_target: card.dataset.mcpApp,
+        })) {
+          setFailed(card, "The setup request could not be sent to the local daemon.");
+          return;
+        }
+        const timeoutId = window.setTimeout(() => {
+          if (pendingRequests.delete(requestId)) {
+            setFailed(card, "Fennara MCP setup timed out. Try again.");
+          }
+        }, REQUEST_TIMEOUT_MS);
+        pendingRequests.set(requestId, { card, timeoutId });
+      });
+    });
+
+    if (previewMode) {
+      selectPage("mcp");
+      window.setTimeout(() => dialog?.showModal(), 0);
+    }
+
+    return {
+      handleDisconnect() {
+        pendingRequests.forEach((pending) => {
+          window.clearTimeout(pending.timeoutId);
+          setFailed(pending.card, "The local Fennara daemon disconnected during setup.");
+        });
+        pendingRequests.clear();
+      },
+      handleMessage(message) {
+        const requestId = String(message?.request_id || "");
+        if (!pendingRequests.has(requestId)) {
+          return false;
+        }
+        if (message.type !== "mcp_setup_completed" && message.type !== "error") {
+          return false;
+        }
+        return completeRequest(requestId, message);
+      },
+    };
+  }
+
+  window.FennaraMcpAppsSettings = {
+    createMcpAppsSettings,
+  };
+})();

--- a/godot_demo/addons/fennara/dist/styles.css
+++ b/godot_demo/addons/fennara/dist/styles.css
@@ -4,5 +4,5 @@
 @import "./styles/drawer.css";
 @import "./styles/chat.css";
 @import "./styles/model-picker.css";
-@import "./styles/settings.css";
+@import "./styles/settings.css?v=mcp-apps-7";
 @import "./styles/responsive.css";

--- a/godot_demo/addons/fennara/dist/styles/settings.css
+++ b/godot_demo/addons/fennara/dist/styles/settings.css
@@ -1,11 +1,13 @@
 .settings-dialog {
-  width: min(420px, calc(100vw - 24px));
+  width: min(520px, calc(100vw - 24px));
+  height: min(520px, calc(100vh - 24px));
   padding: 0;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
   background: var(--surface);
   color: var(--text);
   box-shadow: 0 16px 48px var(--shadow);
+  overflow: hidden;
 }
 
 .settings-dialog::backdrop {
@@ -15,8 +17,245 @@
 .settings-panel {
   position: relative;
   display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   gap: 10px;
+  height: 100%;
   padding: 10px;
+  overflow: hidden;
+}
+
+.settings-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 7px;
+  background: var(--surface-raised);
+}
+
+.settings-tab {
+  flex: 1;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--faint);
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+}
+
+.settings-tab.is-active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 4px var(--shadow);
+}
+
+.settings-page {
+  display: grid;
+  gap: 10px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.settings-page[hidden] {
+  display: none;
+}
+
+.mcp-apps-page {
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.settings-panel .mcp-app-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 0 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--field);
+}
+
+.settings-panel .mcp-app-search:focus-within {
+  border-color: #4f93d2;
+}
+
+.settings-panel .mcp-app-search .svg-icon {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  color: var(--faint);
+}
+
+.settings-panel .mcp-app-search input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+.settings-panel .mcp-app-search input::placeholder {
+  color: var(--faint);
+}
+
+.mcp-apps-intro {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 5px 2px 2px;
+}
+
+.mcp-apps-intro h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+}
+
+.mcp-apps-intro p {
+  max-width: 330px;
+  margin: 0;
+  color: var(--faint);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.mcp-ready-badge {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 7px;
+  border: 1px solid rgba(79, 147, 210, 0.42);
+  border-radius: 999px;
+  color: #68a8ff;
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.mcp-ready-badge span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #68a8ff;
+}
+
+.mcp-app-list {
+  display: grid;
+  align-content: start;
+  gap: 7px;
+  min-height: 0;
+  padding-right: 3px;
+  overflow-y: auto;
+}
+
+.mcp-app-card[hidden] {
+  display: none;
+}
+
+.mcp-app-empty {
+  align-self: center;
+  margin: 0;
+  color: var(--faint);
+  text-align: center;
+}
+
+.mcp-app-empty[hidden] {
+  display: none;
+}
+
+.mcp-app-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface-raised);
+}
+
+.mcp-app-card.is-configured {
+  border-color: rgba(79, 147, 210, 0.48);
+}
+
+.mcp-app-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mcp-app-copy strong {
+  font-size: 12.5px;
+}
+
+.mcp-app-status {
+  overflow: hidden;
+  color: var(--faint);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mcp-app-status.is-configured {
+  color: #68a8ff;
+}
+
+.mcp-app-status.is-error {
+  color: #d98686;
+}
+
+.mcp-app-status.is-warning {
+  color: var(--warning);
+}
+
+.mcp-app-action {
+  width: 88px;
+  min-width: 88px;
+  max-width: 88px;
+  justify-self: end;
+  padding: 6px 9px;
+  font-size: 11.5px;
+}
+
+.mcp-app-result {
+  display: grid;
+  gap: 2px;
+  padding: 9px 10px;
+  border: 1px solid rgba(79, 147, 210, 0.46);
+  border-radius: 7px;
+  background: rgba(71, 142, 201, 0.12);
+  color: #68a8ff;
+  font-size: 11.5px;
+}
+
+.mcp-app-result[hidden] {
+  display: none;
+}
+
+.mcp-app-result span {
+  color: var(--muted);
+}
+
+.mcp-app-result.is-error {
+  border-color: rgba(217, 134, 134, 0.46);
+  background: rgba(152, 66, 66, 0.12);
+  color: #e39a9a;
+}
+
+.mcp-apps-footnote {
+  margin: 0;
+  color: var(--faint);
+  font-size: 10.5px;
+  line-height: 1.4;
 }
 
 .settings-panel header {
@@ -118,6 +357,10 @@
   justify-content: flex-end;
   margin: 0;
   padding: 0;
+}
+
+.settings-panel menu[hidden] {
+  display: none;
 }
 
 .settings-panel .primary-button:disabled,

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,8 @@ Start here:
 - README.md
 - AGENTS.md
 - CONTEXT.md
+- docs/setup.md
+- docs/cli.md
 - docs/repo-map.md
 - docs/architecture.md
 - docs/mcp-setup.md

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/assets.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/assets.rs
@@ -142,6 +142,9 @@ fn asset(path: &str) -> Option<Asset> {
         "model-picker.js" => js(include_bytes!(
             "../../../../../../godot_demo/addons/fennara/dist/model-picker.js"
         )),
+        "mcp-apps-settings.js" => js(include_bytes!(
+            "../../../../../../godot_demo/addons/fennara/dist/mcp-apps-settings.js"
+        )),
         "overlay-manager.js" => js(include_bytes!(
             "../../../../../../godot_demo/addons/fennara/dist/overlay-manager.js"
         )),
@@ -328,7 +331,11 @@ mod tests {
         let Some(path_end) = line[path_start..].find('"') else {
             return;
         };
-        let path = &line[path_start..path_start + path_end];
-        assert!(asset(path).is_some(), "missing embedded chat asset: {path}");
+        let reference = &line[path_start..path_start + path_end];
+        let path = reference.split(['?', '#']).next().unwrap_or(reference);
+        assert!(
+            asset(path).is_some(),
+            "missing embedded chat asset: {reference}"
+        );
     }
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/mcp_setup.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/mcp_setup.rs
@@ -1,0 +1,127 @@
+use serde::Serialize;
+use std::{
+    env,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+    time::Duration,
+};
+use tokio::{
+    process::Command,
+    sync::{Mutex, MutexGuard},
+    time::timeout,
+};
+
+const SETUP_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_REPORT_CHARS: usize = 16_000;
+
+static SETUP_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[derive(Serialize)]
+pub(crate) struct SetupResult {
+    pub(crate) target: String,
+    pub(crate) report: String,
+    pub(crate) warning: Option<String>,
+}
+
+pub(crate) async fn run(target: &str) -> Result<SetupResult, String> {
+    let flag = target_flag(target).ok_or_else(|| format!("Unsupported MCP app: {target}."))?;
+    let _guard = try_setup_guard()?;
+    let cli_path = resolve_cli_path()?;
+    let mut command = Command::new(&cli_path);
+    command.arg("mcp-setup").arg(flag).kill_on_drop(true);
+
+    let output = timeout(SETUP_TIMEOUT, command.output())
+        .await
+        .map_err(|_| "Fennara CLI setup timed out after 60 seconds.".to_string())?
+        .map_err(|error| format!("Could not start Fennara CLI: {error}"))?;
+
+    let stdout = bounded_text(&output.stdout);
+    let stderr = bounded_text(&output.stderr);
+    if !output.status.success() {
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            format!("Fennara CLI exited with status {}.", output.status)
+        } else {
+            detail
+        });
+    }
+
+    let warning = stdout
+        .lines()
+        .find(|line| line.contains(" skipped:"))
+        .map(str::to_string);
+    Ok(SetupResult {
+        target: target.to_string(),
+        report: stdout,
+        warning,
+    })
+}
+
+fn try_setup_guard() -> Result<MutexGuard<'static, ()>, String> {
+    SETUP_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .try_lock()
+        .map_err(|_| "Another Fennara MCP setup is already running. Try again shortly.".to_string())
+}
+
+fn target_flag(target: &str) -> Option<&'static str> {
+    match target {
+        "claude" => Some("--claude"),
+        "gemini" => Some("--gemini"),
+        "cline" => Some("--cline"),
+        "cursor" => Some("--cursor"),
+        "vscode" => Some("--vscode"),
+        "opencode" => Some("--opencode"),
+        "windsurf" => Some("--windsurf"),
+        "kiro" => Some("--kiro"),
+        "codex" => Some("--codex"),
+        _ => None,
+    }
+}
+
+fn resolve_cli_path() -> Result<PathBuf, String> {
+    let binary = format!("fennara{}", env::consts::EXE_SUFFIX);
+    let current_exe = env::current_exe()
+        .map_err(|error| format!("Could not locate the Fennara daemon: {error}"))?;
+
+    if let Some(app_dir) = current_exe
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+    {
+        let installed = app_dir.join("bin").join(&binary);
+        if installed.is_file() {
+            return Ok(installed);
+        }
+    }
+
+    if let Some(sibling) = current_exe.parent().map(|dir| dir.join(&binary))
+        && sibling.is_file()
+    {
+        return Ok(sibling);
+    }
+
+    if let Some(path) = find_on_path(&binary) {
+        return Ok(path);
+    }
+
+    Err("The installed Fennara CLI could not be found. Run Fennara setup first.".to_string())
+}
+
+fn find_on_path(binary: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    env::split_paths(&path)
+        .map(|dir| dir.join(binary))
+        .find(|path| path.is_file())
+}
+
+fn bounded_text(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes)
+        .trim()
+        .chars()
+        .take(MAX_REPORT_CHARS)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/mcp_setup/tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/mcp_setup/tests.rs
@@ -1,0 +1,28 @@
+use super::{target_flag, try_setup_guard};
+
+#[test]
+fn public_targets_map_to_cli_flags() {
+    assert_eq!(target_flag("claude"), Some("--claude"));
+    assert_eq!(target_flag("gemini"), Some("--gemini"));
+    assert_eq!(target_flag("codex"), Some("--codex"));
+    assert_eq!(target_flag("vscode"), Some("--vscode"));
+}
+
+#[test]
+fn internal_or_unknown_targets_are_rejected() {
+    assert_eq!(target_flag("claude-code"), None);
+    assert_eq!(target_flag("claude-desktop"), None);
+    assert_eq!(target_flag("antigravity"), None);
+    assert_eq!(target_flag("unknown"), None);
+}
+
+#[test]
+fn concurrent_setup_is_rejected_instead_of_queued() {
+    let guard = try_setup_guard().expect("first setup should acquire the lock");
+    assert_eq!(
+        try_setup_guard().unwrap_err(),
+        "Another Fennara MCP setup is already running. Try again shortly."
+    );
+    drop(guard);
+    assert!(try_setup_guard().is_ok());
+}

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs
@@ -23,6 +23,7 @@ mod exec_command;
 mod generation;
 mod ids;
 mod images;
+mod mcp_setup;
 mod models;
 mod prompt;
 mod providers;
@@ -66,6 +67,7 @@ struct ClientRequest {
     force: Option<bool>,
     refresh_local: Option<bool>,
     chat_surface: Option<String>,
+    mcp_target: Option<String>,
 }
 
 #[derive(Clone)]
@@ -288,6 +290,29 @@ where
                     .await
                 }
                 Err(error) => send_error(sender, request_id, "update_start_failed", &error).await,
+            }
+        }
+        "setup_mcp_app" => {
+            let Some(target) = request.mcp_target.as_deref() else {
+                return send_error(sender, request_id, "bad_request", "mcp_target is required.")
+                    .await
+                    .map_err(|_| ());
+            };
+            match mcp_setup::run(target).await {
+                Ok(result) => {
+                    send_json(
+                        sender,
+                        json!({
+                            "type": "mcp_setup_completed",
+                            "request_id": request_id,
+                            "target": result.target,
+                            "report": result.report,
+                            "warning": result.warning
+                        }),
+                    )
+                    .await
+                }
+                Err(error) => send_error(sender, request_id, "mcp_setup_failed", &error).await,
             }
         }
         "set_mcp_target" => {

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -184,6 +184,7 @@
   let providerPopovers = null;
   let projectFileLinks = null;
   let settingsPanel = null;
+  let mcpAppsSettings = null;
   let storedTranscript = null;
   let composerActions = null;
   let effortControls = null;
@@ -255,6 +256,7 @@
     onClose() {
       appShell?.setAttribute("data-connection", "offline");
       stopProjectStatusPolling();
+      mcpAppsSettings?.handleDisconnect();
     },
     onSendUnavailable() {
       appendSystem("Local daemon is not connected yet.");
@@ -268,6 +270,15 @@
   const ensureDaemonConnected = daemonClient.ensureConnected;
   const nextRequestId = daemonClient.nextRequestId;
   const send = daemonClient.send;
+
+  mcpAppsSettings = window.FennaraMcpAppsSettings.createMcpAppsSettings({
+    callbacks: {
+      ensureDaemonConnected,
+      nextRequestId,
+      send,
+    },
+    previewMode: new URLSearchParams(window.location.search).get("preview") === "mcp",
+  });
 
   projectFileLinks = window.FennaraProjectFileLinks.createProjectFileLinks({
     send,
@@ -1327,6 +1338,9 @@
   }
 
   function handleDaemonMessage(message) {
+    if (mcpAppsSettings?.handleMessage(message)) {
+      return;
+    }
     if (message.type === "settings" || message.type === "settings_saved") {
       const requestId = String(message.request_id || "");
       const isKeySave = requestId.startsWith("save-settings-key");

--- a/ui/chat/index.html
+++ b/ui/chat/index.html
@@ -457,63 +457,63 @@
               <article class="mcp-app-card" data-mcp-app="codex" data-mcp-search="codex">
                 <div class="mcp-app-copy">
                   <strong>Codex</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="claude" data-mcp-search="claude code desktop" data-mcp-restart="Claude Code and Claude Desktop">
                 <div class="mcp-app-copy">
                   <strong>Claude</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="gemini" data-mcp-search="gemini antigravity" data-mcp-restart="Gemini CLI and Antigravity">
                 <div class="mcp-app-copy">
                   <strong>Gemini &amp; Antigravity</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="cline" data-mcp-search="cline">
                 <div class="mcp-app-copy">
                   <strong>Cline</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="cursor" data-mcp-search="cursor">
                 <div class="mcp-app-copy">
                   <strong>Cursor</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="vscode" data-mcp-search="vs code vscode visual studio code">
                 <div class="mcp-app-copy">
                   <strong>VS Code</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="opencode" data-mcp-search="opencode open code">
                 <div class="mcp-app-copy">
                   <strong>OpenCode</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="windsurf" data-mcp-search="windsurf">
                 <div class="mcp-app-copy">
                   <strong>Windsurf</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>
               <article class="mcp-app-card" data-mcp-app="kiro" data-mcp-search="kiro">
                 <div class="mcp-app-copy">
                   <strong>Kiro</strong>
-                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                  <span class="mcp-app-status" data-mcp-app-status>Setup available</span>
                 </div>
                 <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
               </article>

--- a/ui/chat/index.html
+++ b/ui/chat/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Fennara Chat</title>
-    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./styles.css?v=mcp-apps-7" />
   </head>
   <body>
     <main class="app-shell" data-connection="offline">
@@ -393,49 +393,139 @@
             <h2>Chat Settings</h2>
             <button class="icon-button" type="submit" aria-label="Close settings">x</button>
           </header>
-          <fieldset class="settings-group">
-            <legend>Providers</legend>
-            <p class="settings-note">
-              Choose a provider and configure the connection details it requires.
-            </p>
-            <button class="secondary-button settings-provider-button" type="button" data-open-settings-providers>
-              Open providers
-            </button>
-          </fieldset>
-          <fieldset class="settings-group">
-            <legend>Tool approvals</legend>
-            <label class="settings-radio">
-              <input type="radio" name="approval_mode" value="ask" data-approval-mode checked />
-              <span>
-                <strong>Ask for approval</strong>
-                <small>Read-only tools run. Project changes and runtime actions wait for you.</small>
-              </span>
+          <nav class="settings-tabs" aria-label="Settings sections">
+            <button class="settings-tab is-active" type="button" aria-selected="true" data-settings-tab="chat">Chat</button>
+            <button class="settings-tab" type="button" aria-selected="false" data-settings-tab="mcp">MCP Apps</button>
+          </nav>
+          <section class="settings-page" data-settings-page="chat">
+            <fieldset class="settings-group">
+              <legend>Providers</legend>
+              <p class="settings-note">
+                Choose a provider and configure the connection details it requires.
+              </p>
+              <button class="secondary-button settings-provider-button" type="button" data-open-settings-providers>
+                Open providers
+              </button>
+            </fieldset>
+            <fieldset class="settings-group">
+              <legend>Tool approvals</legend>
+              <label class="settings-radio">
+                <input type="radio" name="approval_mode" value="ask" data-approval-mode checked />
+                <span>
+                  <strong>Ask for approval</strong>
+                  <small>Read-only tools run. Project changes and runtime actions wait for you.</small>
+                </span>
+              </label>
+              <label class="settings-radio">
+                <input type="radio" name="approval_mode" value="full_access" data-approval-mode />
+                <span>
+                  <strong>Full access</strong>
+                  <small>Project changes and runtime actions run without prompting. Hard safety blocks still apply.</small>
+                </span>
+              </label>
+            </fieldset>
+            <fieldset class="settings-group">
+              <legend>Chat display</legend>
+              <label class="settings-check">
+                <input type="checkbox" data-chat-surface-browser />
+                <span>Open chat in my system browser next time</span>
+              </label>
+              <p class="settings-note">
+                This keeps the Godot dock lightweight and can reduce editor GPU and memory usage.
+              </p>
+              <p class="settings-status settings-restart" data-chat-surface-restart hidden>
+                Restart Godot for this change to take effect.
+              </p>
+            </fieldset>
+          </section>
+          <section class="settings-page mcp-apps-page" data-settings-page="mcp" hidden>
+            <div class="mcp-apps-intro">
+              <div>
+                <h3>Use Fennara from your AI apps</h3>
+                <p>Connect an app once, then choose this Godot project from the MCP target button.</p>
+              </div>
+              <span class="mcp-ready-badge"><span></span> Fennara ready</span>
+            </div>
+            <label class="mcp-app-search">
+              <svg class="svg-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <circle cx="11" cy="11" r="7"></circle>
+                <path d="M20 20l-3.5-3.5"></path>
+              </svg>
+              <input type="search" placeholder="Search supported apps..." aria-label="Search supported MCP apps" data-mcp-app-search />
             </label>
-            <label class="settings-radio">
-              <input type="radio" name="approval_mode" value="full_access" data-approval-mode />
-              <span>
-                <strong>Full access</strong>
-                <small>Project changes and runtime actions run without prompting. Hard safety blocks still apply.</small>
-              </span>
-            </label>
-          </fieldset>
-          <fieldset class="settings-group">
-            <legend>Chat display</legend>
-            <label class="settings-check">
-              <input type="checkbox" data-chat-surface-browser />
-              <span>Open chat in my system browser next time</span>
-            </label>
-            <p class="settings-note">
-              This keeps the Godot dock lightweight and can reduce editor GPU and memory usage.
-            </p>
-            <p class="settings-status settings-restart" data-chat-surface-restart hidden>
-              Restart Godot for this change to take effect.
-            </p>
-          </fieldset>
+            <div class="mcp-app-list" aria-label="MCP applications">
+              <article class="mcp-app-card" data-mcp-app="codex" data-mcp-search="codex">
+                <div class="mcp-app-copy">
+                  <strong>Codex</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="claude" data-mcp-search="claude code desktop" data-mcp-restart="Claude Code and Claude Desktop">
+                <div class="mcp-app-copy">
+                  <strong>Claude</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="gemini" data-mcp-search="gemini antigravity" data-mcp-restart="Gemini CLI and Antigravity">
+                <div class="mcp-app-copy">
+                  <strong>Gemini &amp; Antigravity</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="cline" data-mcp-search="cline">
+                <div class="mcp-app-copy">
+                  <strong>Cline</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="cursor" data-mcp-search="cursor">
+                <div class="mcp-app-copy">
+                  <strong>Cursor</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="vscode" data-mcp-search="vs code vscode visual studio code">
+                <div class="mcp-app-copy">
+                  <strong>VS Code</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="opencode" data-mcp-search="opencode open code">
+                <div class="mcp-app-copy">
+                  <strong>OpenCode</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="windsurf" data-mcp-search="windsurf">
+                <div class="mcp-app-copy">
+                  <strong>Windsurf</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+              <article class="mcp-app-card" data-mcp-app="kiro" data-mcp-search="kiro">
+                <div class="mcp-app-copy">
+                  <strong>Kiro</strong>
+                  <span class="mcp-app-status" data-mcp-app-status>Not configured</span>
+                </div>
+                <button class="primary-button mcp-app-action" type="button" data-mcp-app-action>Set Up</button>
+              </article>
+            </div>
+            <p class="mcp-app-empty" data-mcp-app-empty hidden>No supported apps match your search.</p>
+            <div class="mcp-app-result" role="status" aria-live="polite" data-mcp-app-result hidden></div>
+            <p class="mcp-apps-footnote">Fennara creates a backup before changing an app's MCP configuration.</p>
+          </section>
           <p class="settings-toast" role="status" aria-live="polite" data-settings-saved-toast hidden>
             Settings saved
           </p>
-          <menu>
+          <menu data-settings-actions>
             <button class="secondary-button" value="cancel">Cancel</button>
             <button class="primary-button" value="default" data-save-settings disabled>Save</button>
           </menu>
@@ -457,11 +547,12 @@
     <script src="./project-file-links.js"></script>
     <script src="./provider-popovers.js"></script>
     <script src="./settings-panel.js"></script>
+    <script src="./mcp-apps-settings.js?v=mcp-apps-8"></script>
     <script src="./chat-navigation.js"></script>
     <script src="./composer-actions.js"></script>
     <script src="./effort-controls.js"></script>
     <script src="./overlay-manager.js"></script>
     <script src="./shell-bindings.js"></script>
-    <script src="./app.js"></script>
+    <script src="./app.js?v=mcp-apps-8"></script>
   </body>
 </html>

--- a/ui/chat/mcp-apps-settings.js
+++ b/ui/chat/mcp-apps-settings.js
@@ -1,0 +1,208 @@
+(function () {
+  const REQUEST_TIMEOUT_MS = 65_000;
+
+  function createMcpAppsSettings(options = {}) {
+    const callbacks = options.callbacks || {};
+    const dialog = document.querySelector("[data-settings]");
+    const tabs = Array.from(document.querySelectorAll("[data-settings-tab]"));
+    const pages = Array.from(document.querySelectorAll("[data-settings-page]"));
+    const result = document.querySelector("[data-mcp-app-result]");
+    const appSearch = document.querySelector("[data-mcp-app-search]");
+    const appCards = Array.from(document.querySelectorAll("[data-mcp-app]"));
+    const emptySearch = document.querySelector("[data-mcp-app-empty]");
+    const settingsActions = document.querySelector("[data-settings-actions]");
+    const previewMode = Boolean(options.previewMode);
+    const pendingRequests = new Map();
+
+    function selectPage(pageName) {
+      tabs.forEach((tab) => {
+        const selected = tab.dataset.settingsTab === pageName;
+        tab.classList.toggle("is-active", selected);
+        tab.setAttribute("aria-selected", String(selected));
+      });
+      pages.forEach((page) => {
+        page.hidden = page.dataset.settingsPage !== pageName;
+      });
+      if (settingsActions) {
+        settingsActions.hidden = pageName === "mcp";
+      }
+    }
+
+    function renderResult(title, detail, failed = false) {
+      if (!result) {
+        return;
+      }
+      const heading = document.createElement("strong");
+      const message = document.createElement("span");
+      heading.textContent = title;
+      message.textContent = detail;
+      result.replaceChildren(heading, message);
+      result.classList.toggle("is-error", failed);
+      result.hidden = false;
+    }
+
+    function lockSetupActions(activeButton) {
+      appCards.forEach((card) => {
+        const button = card.querySelector("[data-mcp-app-action]");
+        if (button) {
+          button.disabled = true;
+          button.setAttribute("aria-busy", String(button === activeButton));
+        }
+      });
+    }
+
+    function restoreSetupActions() {
+      appCards.forEach((card) => {
+        const button = card.querySelector("[data-mcp-app-action]");
+        const status = card.querySelector("[data-mcp-app-status]");
+        if (!button) {
+          return;
+        }
+        const completed = status?.classList.contains("is-configured");
+        const retryable = status?.classList.contains("is-warning") || status?.classList.contains("is-error");
+        button.disabled = Boolean(completed && !retryable);
+        button.removeAttribute("aria-busy");
+      });
+    }
+
+    function setRunning(card, button) {
+      const status = card.querySelector("[data-mcp-app-status]");
+      lockSetupActions(button);
+      button.textContent = "Setting up...";
+      status.textContent = "Running Fennara CLI";
+      status.classList.remove("is-configured", "is-error", "is-warning");
+      result.hidden = true;
+    }
+
+    function setCompleted(card, warning = "") {
+      const appName = card.querySelector("strong")?.textContent || "App";
+      const restartName = card.dataset.mcpRestart || appName;
+      const status = card.querySelector("[data-mcp-app-status]");
+      const button = card.querySelector("[data-mcp-app-action]");
+      status.textContent = warning ? "Configured with warning" : "Configured, restart required";
+      status.classList.add("is-configured");
+      status.classList.toggle("is-warning", Boolean(warning));
+      status.classList.remove("is-error");
+      button.textContent = warning ? "Retry" : "Configured";
+      button.disabled = !warning;
+      card.classList.add("is-configured");
+      if (warning) {
+        renderResult(`${appName} setup needs attention.`, warning, true);
+      } else {
+        renderResult(`${appName} is connected.`, `Restart ${restartName} so it can load Fennara.`);
+      }
+      restoreSetupActions();
+    }
+
+    function setFailed(card, error) {
+      const appName = card.querySelector("strong")?.textContent || "App";
+      const status = card.querySelector("[data-mcp-app-status]");
+      const button = card.querySelector("[data-mcp-app-action]");
+      status.textContent = "Setup failed";
+      status.classList.add("is-error");
+      status.classList.remove("is-configured", "is-warning");
+      button.textContent = "Retry";
+      renderResult(`${appName} could not be configured.`, error || "Try again or run Fennara MCP setup from the CLI.", true);
+      restoreSetupActions();
+    }
+
+    function completeRequest(requestId, message) {
+      const pending = pendingRequests.get(requestId);
+      if (!pending) {
+        return false;
+      }
+      window.clearTimeout(pending.timeoutId);
+      pendingRequests.delete(requestId);
+      if (message.type === "mcp_setup_completed") {
+        setCompleted(pending.card, message.warning || "");
+      } else {
+        setFailed(pending.card, message.message);
+      }
+      return true;
+    }
+
+    tabs.forEach((tab) => {
+      tab.addEventListener("click", () => selectPage(tab.dataset.settingsTab));
+    });
+
+    appSearch?.addEventListener("input", () => {
+      const query = appSearch.value.trim().toLowerCase();
+      let visibleCount = 0;
+      appCards.forEach((card) => {
+        const searchText = `${card.dataset.mcpSearch || ""} ${card.textContent || ""}`.toLowerCase();
+        const visible = !query || searchText.includes(query);
+        card.hidden = !visible;
+        if (visible) {
+          visibleCount += 1;
+        }
+      });
+      if (emptySearch) {
+        emptySearch.hidden = visibleCount > 0;
+      }
+    });
+
+    document.querySelectorAll("[data-mcp-app-action]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const card = button.closest("[data-mcp-app]");
+        if (!card) {
+          return;
+        }
+        setRunning(card, button);
+
+        if (previewMode) {
+          window.setTimeout(() => setCompleted(card), 850);
+          return;
+        }
+        if (!callbacks.ensureDaemonConnected?.()) {
+          setFailed(card, "The local Fennara daemon is not connected yet.");
+          return;
+        }
+
+        const requestId = callbacks.nextRequestId?.("mcp-setup");
+        if (!requestId || !callbacks.send?.({
+          type: "setup_mcp_app",
+          request_id: requestId,
+          mcp_target: card.dataset.mcpApp,
+        })) {
+          setFailed(card, "The setup request could not be sent to the local daemon.");
+          return;
+        }
+        const timeoutId = window.setTimeout(() => {
+          if (pendingRequests.delete(requestId)) {
+            setFailed(card, "Fennara MCP setup timed out. Try again.");
+          }
+        }, REQUEST_TIMEOUT_MS);
+        pendingRequests.set(requestId, { card, timeoutId });
+      });
+    });
+
+    if (previewMode) {
+      selectPage("mcp");
+      window.setTimeout(() => dialog?.showModal(), 0);
+    }
+
+    return {
+      handleDisconnect() {
+        pendingRequests.forEach((pending) => {
+          window.clearTimeout(pending.timeoutId);
+          setFailed(pending.card, "The local Fennara daemon disconnected during setup.");
+        });
+        pendingRequests.clear();
+      },
+      handleMessage(message) {
+        const requestId = String(message?.request_id || "");
+        if (!pendingRequests.has(requestId)) {
+          return false;
+        }
+        if (message.type !== "mcp_setup_completed" && message.type !== "error") {
+          return false;
+        }
+        return completeRequest(requestId, message);
+      },
+    };
+  }
+
+  window.FennaraMcpAppsSettings = {
+    createMcpAppsSettings,
+  };
+})();

--- a/ui/chat/styles.css
+++ b/ui/chat/styles.css
@@ -4,5 +4,5 @@
 @import "./styles/drawer.css";
 @import "./styles/chat.css";
 @import "./styles/model-picker.css";
-@import "./styles/settings.css";
+@import "./styles/settings.css?v=mcp-apps-7";
 @import "./styles/responsive.css";

--- a/ui/chat/styles/settings.css
+++ b/ui/chat/styles/settings.css
@@ -1,11 +1,13 @@
 .settings-dialog {
-  width: min(420px, calc(100vw - 24px));
+  width: min(520px, calc(100vw - 24px));
+  height: min(520px, calc(100vh - 24px));
   padding: 0;
   border: 1px solid var(--line-strong);
   border-radius: 8px;
   background: var(--surface);
   color: var(--text);
   box-shadow: 0 16px 48px var(--shadow);
+  overflow: hidden;
 }
 
 .settings-dialog::backdrop {
@@ -15,8 +17,245 @@
 .settings-panel {
   position: relative;
   display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   gap: 10px;
+  height: 100%;
   padding: 10px;
+  overflow: hidden;
+}
+
+.settings-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 3px;
+  border-radius: 7px;
+  background: var(--surface-raised);
+}
+
+.settings-tab {
+  flex: 1;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--faint);
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+}
+
+.settings-tab.is-active {
+  background: var(--surface);
+  color: var(--text);
+  box-shadow: 0 1px 4px var(--shadow);
+}
+
+.settings-page {
+  display: grid;
+  gap: 10px;
+  min-height: 0;
+  overflow: auto;
+}
+
+.settings-page[hidden] {
+  display: none;
+}
+
+.mcp-apps-page {
+  grid-template-rows: auto auto minmax(0, 1fr) auto auto;
+  gap: 12px;
+  overflow: hidden;
+}
+
+.settings-panel .mcp-app-search {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 0 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--field);
+}
+
+.settings-panel .mcp-app-search:focus-within {
+  border-color: #4f93d2;
+}
+
+.settings-panel .mcp-app-search .svg-icon {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  color: var(--faint);
+}
+
+.settings-panel .mcp-app-search input {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+}
+
+.settings-panel .mcp-app-search input::placeholder {
+  color: var(--faint);
+}
+
+.mcp-apps-intro {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 5px 2px 2px;
+}
+
+.mcp-apps-intro h3 {
+  margin: 0 0 4px;
+  font-size: 14px;
+}
+
+.mcp-apps-intro p {
+  max-width: 330px;
+  margin: 0;
+  color: var(--faint);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.mcp-ready-badge {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 7px;
+  border: 1px solid rgba(79, 147, 210, 0.42);
+  border-radius: 999px;
+  color: #68a8ff;
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.mcp-ready-badge span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #68a8ff;
+}
+
+.mcp-app-list {
+  display: grid;
+  align-content: start;
+  gap: 7px;
+  min-height: 0;
+  padding-right: 3px;
+  overflow-y: auto;
+}
+
+.mcp-app-card[hidden] {
+  display: none;
+}
+
+.mcp-app-empty {
+  align-self: center;
+  margin: 0;
+  color: var(--faint);
+  text-align: center;
+}
+
+.mcp-app-empty[hidden] {
+  display: none;
+}
+
+.mcp-app-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 9px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--surface-raised);
+}
+
+.mcp-app-card.is-configured {
+  border-color: rgba(79, 147, 210, 0.48);
+}
+
+.mcp-app-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.mcp-app-copy strong {
+  font-size: 12.5px;
+}
+
+.mcp-app-status {
+  overflow: hidden;
+  color: var(--faint);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mcp-app-status.is-configured {
+  color: #68a8ff;
+}
+
+.mcp-app-status.is-error {
+  color: #d98686;
+}
+
+.mcp-app-status.is-warning {
+  color: var(--warning);
+}
+
+.mcp-app-action {
+  width: 88px;
+  min-width: 88px;
+  max-width: 88px;
+  justify-self: end;
+  padding: 6px 9px;
+  font-size: 11.5px;
+}
+
+.mcp-app-result {
+  display: grid;
+  gap: 2px;
+  padding: 9px 10px;
+  border: 1px solid rgba(79, 147, 210, 0.46);
+  border-radius: 7px;
+  background: rgba(71, 142, 201, 0.12);
+  color: #68a8ff;
+  font-size: 11.5px;
+}
+
+.mcp-app-result[hidden] {
+  display: none;
+}
+
+.mcp-app-result span {
+  color: var(--muted);
+}
+
+.mcp-app-result.is-error {
+  border-color: rgba(217, 134, 134, 0.46);
+  background: rgba(152, 66, 66, 0.12);
+  color: #e39a9a;
+}
+
+.mcp-apps-footnote {
+  margin: 0;
+  color: var(--faint);
+  font-size: 10.5px;
+  line-height: 1.4;
 }
 
 .settings-panel header {
@@ -118,6 +357,10 @@
   justify-content: flex-end;
   margin: 0;
   padding: 0;
+}
+
+.settings-panel menu[hidden] {
+  display: none;
 }
 
 .settings-panel .primary-button:disabled,


### PR DESCRIPTION
## Summary

- document the addon-first setup and update workflow, including a dedicated CLI reference
- add a searchable MCP Apps section to the Godot chat settings without changing the dock size
- route MCP app setup through the local daemon to the installed `fennara mcp-setup` command
- preserve CLI ownership of app-specific configuration, backups, and platform paths

## Motivation

Users can install and update Fennara from the Godot addon without beginning in a terminal, but connecting external MCP apps still required manually running CLI commands. This adds a discoverable in-editor entry point while keeping the existing CLI workflow available and avoiding a second configuration implementation in the chat UI.

The daemon accepts only supported MCP targets, rejects concurrent setup requests, bounds CLI execution to 60 seconds, limits retained command output, and reports partial Claude setup warnings without claiming every Claude app was configured.

## Validation

```text
cargo check --manifest-path local/Cargo.toml -p fennara-daemon
cargo test --manifest-path local/Cargo.toml -p fennara-daemon runtime_daemon::chat::mcp_setup::tests
node --check ui/chat/mcp-apps-settings.js
node --check ui/chat/app.js
node scripts/sync-chat-ui.mjs
git diff --check
```

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **MCP Apps** tab in chat settings to search supported apps and mark setup status.
  * Added in-chat MCP app setup with a single-click action, request progress, and clear completion/error reporting (including preview mode).
  * Enabled triggering MCP app setup from chat requests and improved setup concurrency handling.

* **Documentation**
  * Shortened README Quick Start/updates/troubleshooting and added clearer setup flow references.
  * Added comprehensive **CLI reference** documentation and expanded links for setup and CLI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->