### PR TITLE
docs(guides): simplify setup and navigation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,7 +58,9 @@ The display mode for built-in chat. Embedded mode uses the native Godot dock web
 
 **Chat Provider**
 
-A backend that can generate built-in chat responses, such as OpenRouter, Ollama Cloud, DeepSeek, Z.AI, Moonshot AI, Kimi For Coding, MiniMax, local Ollama, or LM Studio.
+A backend that can generate built-in chat responses, such as OpenAI, Anthropic,
+OpenRouter, Ollama Cloud, DeepSeek, Z.AI, Moonshot AI, Kimi For Coding, MiniMax,
+local Ollama, or LM Studio.
 
 **Model Ref**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,9 @@ Open an issue or discussion before starting:
 Use Conventional Commit style:
 
 ```text
-fix: handle missing daemon status
-docs: clarify setup steps
-ci: add public pull request checks
+fix(daemon): handle missing daemon status
+docs(setup): clarify setup steps
+ci(actions): add public pull request checks
 ```
 
 Common types:

--- a/README.md
+++ b/README.md
@@ -44,75 +44,88 @@ External MCP apps and the built-in chat use separate model settings. See [MCP Ap
 
 For the full install walkthrough, see [Setup](docs/setup.md).
 
-## What Fennara Installs
+## What Setup Adds
 
-- a small `fennara` CLI
+- the Fennara addon kept in `res://addons/fennara/`
+- a small `fennara` CLI installed in Fennara app data
 - a local MCP server used by AI coding apps
 - a local daemon that bridges MCP/chat requests to the open Godot editor
-- a Godot addon copied into `res://addons/fennara/`
 - generated project guidance for AI agents
 
 The built-in chat dock uses the platform webview: Microsoft Edge WebView2 on Windows, WKWebView/WebKit on macOS, and a Fennara-managed shared CEF runtime on Linux. MCP tools still work if the optional chat dock cannot start.
 
-## Quick Start
+## Install
 
-Get the addon using either option:
+Choose either the addon or CLI install.
+
+### Add The Addon To Your Project
 
 - Install **Fennara** from the Godot Asset Library.
-- Open the [Latest Release](https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest), download `fennara-addon-latest.zip`, and extract its `addons/fennara/` folder into your Godot project.
+- Or open the [Latest Release](https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest), download `fennara-addon-latest.zip`, and extract its `addons/fennara/` folder into your project.
 
-Open the project, select the Fennara dock, and use the native setup panel:
+Open the project, select the Fennara dock, and press **Set Up Fennara**.
 
-```text
-Fennara needs to finish setup.
+### Alternative: Install With The CLI
 
-[Set Up Fennara]
+You do not need this if you used the addon option above. Use the CLI only if
+you prefer installing Fennara from the terminal.
+
+Install the CLI on Windows:
+
+```powershell
+irm https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.ps1 | iex
 ```
 
-The addon verifies and installs the matching CLI, then the CLI installs the
-local components required by that addon. The active project addon is left
-unchanged during first-run setup.
-
-After setup, use the built-in chat, connect an external MCP app, or use both.
-The full user walkthrough is in [Setup](docs/setup.md).
-
-### Prefer The Terminal?
-
-The terminal uses the same installer and maintenance logic as the Godot setup
-panel. Follow [Fennara CLI](docs/cli.md#install-the-cli) to install it, then run:
+Or on macOS and Linux:
 
 ```bash
-fennara install --project path/to/your-godot-project
+curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh
 ```
 
-Configure an external MCP app only if you want one. The supported app commands
-and manual configuration path are in [MCP Setup](docs/mcp-setup.md).
-
-With Godot open, verify the connection from your MCP app:
-
-```text
-Use Fennara MCP to run fennara_status and tell me which Godot project is connected.
-```
-
-For every CLI command, update behavior, recovery, diagnostics, app-data paths,
-and automation guidance, see [Fennara CLI](docs/cli.md).
-
-## Updates
-
-When an update is available, the Fennara dock shows an **Update** button. It
-verifies and stages the release while Godot remains open, then asks before
-closing the editor. The detached updater replaces the addon, reopens the same
-project, validates the new addon and daemon, and retains the previous working
-version until validation succeeds.
-
-Terminal users can close Godot and run:
+Then run Fennara from your Godot project:
 
 ```bash
-fennara update --project path/to/your-godot-project
+cd path/to/your-godot-project
+fennara install
 ```
 
-See [Setup](docs/setup.md#update-fennara) for the user-facing flow and
-[Fennara CLI](docs/cli.md#update-a-project) for terminal and recovery commands.
+See [Setup](docs/setup.md) for troubleshooting and [Fennara CLI](docs/cli.md)
+for the complete command reference.
+
+## Set Up A Provider Or Connect An MCP App
+
+### Built-In Chat
+
+Open **Chat Settings > Chat**, select **Open providers**, and connect a provider.
+Fennara uses your own key for cloud providers (BYOK). You can also use a local
+Ollama or LM Studio server. See the [supported provider list](docs/providers.md).
+
+### MCP Apps
+
+Open **Chat Settings > MCP Apps**, find your app, and press **Set Up**.
+
+You can also connect an app from the terminal:
+
+```bash
+fennara mcp-setup --codex
+fennara mcp-setup --help
+```
+
+If your MCP app is not listed in Chat Settings, see [MCP Setup](docs/mcp-setup.md)
+for the complete app list and manual configuration instructions.
+
+## Update
+
+When the Fennara dock shows **Update**, press it and follow the prompts.
+
+To update from the terminal, close Godot and run:
+
+```bash
+cd path/to/your-godot-project
+fennara update
+```
+
+See [Update Fennara](docs/setup.md#update-fennara) for recovery and diagnostics.
 
 ## Tools
 
@@ -127,18 +140,6 @@ Fennara exposes a small set of Godot-aware tools:
 - run small runtime scripts against a live scene
 
 The goal is not to replace an agent's normal file tools. Fennara gives the missing Godot feedback loop.
-
-## Built-In Chat
-
-The Fennara dock includes a native web chat surface inside Godot. It talks to the local daemon, not a hosted Fennara backend.
-
-- bring your own model provider key, or use local Ollama / LM Studio
-- use `/provider` and `/model` to switch models from inside Godot
-- attach selected script ranges and supported image context
-- keep chat history, provider keys, and local URLs on your machine
-- open the chat embedded in Godot or in your system browser
-
-More detail: [Built-In Chat Providers](docs/providers.md), [Built-In Chat Slash Commands](docs/slash-commands.md).
 
 ## Demos
 
@@ -163,22 +164,16 @@ See [Demos](docs/demos.md) for more videos from the Fennara channel.
  </picture>
 </a>
 
-## Repository
+## Documentation
 
-Useful starting points:
-
-- [Setup](docs/setup.md)
-- [Fennara CLI](docs/cli.md)
-- [MCP setup](docs/mcp-setup.md)
-- [Repo map](docs/repo-map.md)
-- [Architecture](docs/architecture.md)
-- [Tools](docs/tools.md)
-- [FAQ](docs/faq.md)
-- [Demos](docs/demos.md)
-- [Manual install notes](docs/manual-install.md)
-- [Release process](docs/release.md)
-- [Contributing](CONTRIBUTING.md)
-- [Security](SECURITY.md)
+| Start with... | When you need... |
+| --- | --- |
+| [Documentation home](docs/README.md) | Every guide and reference page |
+| [Setup](docs/setup.md) | Installation, updates, and troubleshooting |
+| [Chat providers](docs/providers.md) | Built-in chat models and keys |
+| [MCP setup](docs/mcp-setup.md) | Codex, Claude, Cursor, and other MCP apps |
+| [Tools](docs/tools.md) | The Godot feedback available to agents |
+| [Contributing](CONTRIBUTING.md) | Development and pull request guidance |
 
 ## Community
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,51 @@
+# Fennara Documentation
+
+Start with the task you want to complete. Each page begins with the normal path
+and keeps advanced details lower on the page.
+
+## Start Here
+
+| I want to... | Read... |
+| --- | --- |
+| Install Fennara | [Setup](setup.md) |
+| Connect the built-in chat | [Chat providers](providers.md) |
+| Connect Codex, Claude, Cursor, or another MCP app | [MCP setup](mcp-setup.md) |
+| Update or recover Fennara | [Update Fennara](setup.md#update-fennara) |
+| Fix a setup problem | [Troubleshooting](setup.md#troubleshooting) |
+
+## Use Fennara
+
+| Guide | What it covers |
+| --- | --- |
+| [MCP apps and built-in chat](chat-vs-mcp.md) | Which model account each path uses |
+| [Tools](tools.md) | Godot-aware tools and when to use them |
+| [Examples](examples.md) | Prompts for common Godot workflows |
+| [Slash commands](slash-commands.md) | `/provider` and `/model` in the chat dock |
+| [FAQ](faq.md) | Short answers to common questions |
+| [Demos](demos.md) | Videos and project walkthroughs |
+
+## Reference And Recovery
+
+| Reference | Use it when... |
+| --- | --- |
+| [Fennara CLI](cli.md) | You want terminal commands, diagnostics, or automation |
+| [Manual install](manual-install.md) | The normal installer cannot be used |
+| [MCP setup reference](mcp-setup.md) | You need app-specific or manual configuration |
+| [Provider reference](providers.md) | You need keys, model IDs, or local server details |
+
+## For Contributors
+
+| Document | Purpose |
+| --- | --- |
+| [Contributing](../CONTRIBUTING.md) | Contribution and pull request expectations |
+| [Architecture](architecture.md) | System boundaries and runtime flows |
+| [Repository map](repo-map.md) | Where code and generated files live |
+| [Release process](release.md) | Packaging, manifests, validation, and publishing |
+| [Project vocabulary](../CONTEXT.md) | Shared names used across code and documentation |
+| [Security](../SECURITY.md) | Reporting vulnerabilities |
+
+## Learn From Examples
+
+- [Fennara vs traditional Godot MCP](fennara-vs-traditional-godot-mcp.md)
+- [Open RPG demo breakdown](open-rpg-demo.md)
+- [Prompt examples](examples.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,19 +1,29 @@
 # Architecture
 
-Fennara is a local bridge between an MCP client and a Godot editor project.
+Fennara is a local bridge between AI clients and an open Godot editor project.
+This page explains ownership, process boundaries, install layout, and update
+handoff behavior.
 
-There is no cloud service in the normal OSS path. The MCP client starts a local
-process, that process talks to a local daemon, and the daemon talks to the
-Godot addon running inside the open editor.
+| If You Need To... | Start Here |
+| --- | --- |
+| Find the source for a component | [Repo Map](repo-map.md) |
+| Install or update Fennara | [Setup](setup.md) |
+| Understand release artifacts | [Release Process](release.md) |
+| Inspect the available model tools | [Tools](tools.md) |
 
-```text
-MCP client
-  -> fennara-mcp launcher
-  -> versioned fennara-mcp-runtime
-  -> fennara-daemon launcher
-  -> versioned fennara-daemon-runtime
-  -> Godot editor addon
-  -> open Godot project
+There is no Fennara cloud service in the normal OSS path. An external MCP app
+starts the local MCP process, which talks to the daemon. The built-in chat talks
+to that daemon directly. The daemon reaches the Fennara addon in the open Godot
+editor.
+
+```mermaid
+flowchart LR
+    A["External MCP app"] --> B["fennara-mcp launcher"]
+    B --> C["Versioned MCP runtime"]
+    C --> D["Local daemon"]
+    E["Built-in Fennara chat"] --> D
+    D --> F["Godot editor addon"]
+    F --> G["Open Godot project"]
 ```
 
 ## Main Pieces
@@ -24,11 +34,12 @@ MCP client
 | MCP launcher | `local/crates/fennara-mcp/` | Stable executable that MCP apps call. It finds the active version and starts the runtime. |
 | MCP runtime | `local/crates/fennara-mcp/` | Speaks MCP over stdio and forwards tool calls to the local bridge. |
 | Daemon launcher | `local/crates/fennara-daemon/` | Stable executable used to start the active daemon runtime. |
-| Daemon runtime | `local/crates/fennara-daemon/` | Keeps local state, coordinates with Godot, and serves the MCP runtime. |
+| Daemon runtime | `local/crates/fennara-daemon/` | Keeps local state, coordinates with Godot, serves the MCP runtime, and hosts built-in chat routes. |
+| Chat UI source | `ui/chat/` | HTML, CSS, and JavaScript for the built-in chat, settings, provider setup, MCP app setup, and update UI. It is synced into the packaged addon under `godot_demo/addons/fennara/dist/`. |
 | Godot addon | `godot_demo/addons/fennara/` | The addon payload copied into user projects. |
 | Runtime helper source | `runtime/` | Godot-side runtime helper scripts synced into the addon payload for runtime sessions and runtime scripts. |
 | GDExtension | `fennara-cpp/` | Godot-facing tools, dock UI, diagnostics, validation, runtime capture, and editor integration. |
-| Tool schemas | `local/schemas/tools/` | MCP tool descriptions exposed to clients. |
+| Tool schemas | `local/schemas/tools/` | Shared model-facing tool contracts. The MCP runtime and built-in chat each select the schemas they expose. |
 
 ## Native Update Handoff
 

--- a/docs/chat-vs-mcp.md
+++ b/docs/chat-vs-mcp.md
@@ -1,75 +1,55 @@
-# MCP Apps And Built-In Chat
+# MCP Apps Or Built-In Chat?
 
-Fennara has two related but separate ways to use AI with Godot.
+Fennara supports both. Choose where you want the conversation to happen.
 
-| Path | Where You Chat | Who Provides The Model | What Fennara Provides |
-| --- | --- | --- | --- |
-| External MCP app | Claude Code, Claude Desktop, Codex, Cursor, Gemini, Antigravity, or another MCP client | That app's own model account, subscription, or API setup | Godot-aware MCP tools |
-| Built-in Fennara chat | The Fennara dock inside Godot | The provider configured in Fennara chat settings | A local in-editor chat UI plus the same Godot-aware tools |
+| | External MCP app | Built-in Fennara chat |
+| --- | --- | --- |
+| Where you chat | Codex, Claude, Cursor, Gemini, or another MCP app | The Fennara dock or your system browser |
+| Model account | The external app's account or subscription | A provider connected in Fennara Chat Settings |
+| What Fennara adds | Godot-aware MCP tools | Chat UI, the same core Godot tools, and chat-only file and shell tools |
+| Setup | **Chat Settings > MCP Apps** | **Chat Settings > Chat > Open providers** |
 
-The built-in chat can be displayed inside the Godot dock or opened in your system browser, depending on the Chat Settings display option. Both display modes are still the same Fennara chat path and use the provider configured in Fennara settings.
+> [!TIP]
+> You can use both paths. Their model settings remain separate.
 
-## What `mcp-setup` Does
+## External MCP Apps
 
-`fennara mcp-setup --claude` edits Claude's MCP configuration so Claude can start the local Fennara MCP server and call Fennara tools.
+Connecting an MCP app lets that app start the local Fennara MCP server and call
+Godot tools. It does not share the app's subscription or login with the
+built-in chat.
 
-It does not make the built-in Fennara chat use Claude. It also does not share your Claude subscription, Claude Code login, or Claude Desktop account with the Fennara dock.
-
-The same applies to:
+Set up an app from **Chat Settings > MCP Apps**, or use the CLI:
 
 ```bash
 fennara mcp-setup --codex
-fennara mcp-setup --cursor
-fennara mcp-setup --gemini
+fennara mcp-setup --help
 ```
 
-Those commands connect external apps to Fennara's Godot tools. They do not configure the in-editor chat model.
+No Fennara chat provider key is required. Restart the external app after setup.
+See [MCP Setup](mcp-setup.md) for every target and manual configuration.
 
-## Do I Need An API Key?
+## Built-In Chat
 
-You do not need a Fennara chat provider key to use Fennara through an external MCP app. If you use Claude Code with `fennara mcp-setup --claude`, Claude uses its own model setup and Fennara supplies Godot tools.
+The built-in chat needs a provider connected in Fennara Chat Settings. Use your
+own key for a cloud provider, or connect a local Ollama or LM Studio server.
 
-You only need a chat provider in Fennara settings if you want to use the built-in chat dock inside Godot.
+The same chat can appear inside the Godot dock or in your system browser. This
+display choice does not change its provider, model, history, or project.
 
-Built-in chat can use:
+To attach code, select it in Godot's script editor, open the context menu, and
+choose **Add to Chat**. See [Built-In Chat Providers](providers.md) for provider
+and model setup.
 
-- cloud providers with your own API key, such as OpenAI, Anthropic, OpenRouter, Ollama Cloud, DeepSeek, Z.AI, Moonshot AI, Kimi For Coding, or MiniMax
-- local providers, such as Ollama or LM Studio
+## Project Routing
 
-Provider keys and local provider URLs are stored locally by the daemon outside the Godot project.
+Both paths use the local Fennara daemon for Godot feedback.
 
-## Common Examples
+- External MCP calls go to the project selected by the dock's **MCP target**
+  control.
+- Built-in chat stays bound to the Godot editor that opened the chat.
 
-If you ask Claude Code to edit your Godot project, run:
-
-```bash
-fennara mcp-setup --claude
-```
-
-Then ask Claude:
+To verify an external MCP connection, ask:
 
 ```text
 Use Fennara MCP to run fennara_status and tell me which Godot project is connected.
 ```
-
-No Fennara chat API key is required for that flow.
-
-If you want to chat inside Godot's Fennara dock, open the dock settings and choose a chat provider. Use an API key for a cloud provider, or run a local server and select a local model such as:
-
-```text
-ollama/llama3.1:8b
-lmstudio/openai/gpt-oss-20b
-```
-
-The built-in dock can also receive selected code from Godot's script editor.
-Select script text, open the script editor context menu, choose **Add to Chat**,
-then send your next chat message. The selected `res://` path, line range, and
-code are attached only to that built-in chat request.
-
-For provider setup details, see [Built-In Chat Providers](providers.md). For dock shortcuts, see [Built-In Chat Slash Commands](slash-commands.md).
-
-## Shared Godot Target
-
-External MCP apps and the built-in chat both talk to the local Fennara daemon, so they can use the same Godot feedback loop. The model account is the part that differs.
-
-When multiple Godot editors are open, use the Fennara dock's MCP target control to choose which project receives external MCP tool calls. Built-in chat sessions stay bound to the Godot editor that opened that chat.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,12 +1,23 @@
 # Fennara CLI
 
-The Fennara CLI is the shared installer and maintenance layer behind both the
-Godot setup panel and terminal workflows. The addon bootstrap downloads the
-matching CLI, verifies it, and asks it to finish setup. Users who prefer a
-terminal can run the same operations directly.
+Use the CLI when you prefer the terminal, need diagnostics or recovery, or want
+an automated install with an exact version.
 
-Use [Setup](setup.md) for the normal Godot user journey. This page is the CLI
-reference.
+> [!TIP]
+> You do not need to install the CLI manually if **Set Up Fennara** already
+> completed in the Godot dock.
+
+## Common Flow
+
+```bash
+cd path/to/your-godot-project
+fennara install
+```
+
+Use `fennara doctor` when you need to inspect or repair the local installation.
+
+Use [Setup](setup.md) for the normal Godot journey. Keep this page as the
+terminal command reference.
 
 ## Install The CLI
 
@@ -42,17 +53,18 @@ Linux: ~/.local/share/fennara
 
 ## Command Summary
 
-```text
-fennara doctor [--repair]
-fennara diagnostics [--operation <operation-id>] [--json]
-fennara install [--project <path>] [--version <version>]
-fennara mcp-setup <target flags>
-fennara update [--project <path>] [--version <version>] [--no-self-update] [--prepare]
-fennara recover --project <path> [--operation <operation-id>]
-fennara self-update [--version <version>]
-```
+| Command | Purpose |
+| --- | --- |
+| `fennara install` | Install or adopt a project addon and its matching local components |
+| `fennara update` | Update a project and its local components |
+| `fennara doctor` | Inspect or repair the local installation |
+| `fennara diagnostics` | Show a sanitized operation report |
+| `fennara mcp-setup` | Connect an external MCP app |
+| `fennara recover` | Restore an interrupted native update |
+| `fennara self-update` | Update only the installed CLI |
 
-Run `fennara <command> --help` for the options supported by the installed CLI.
+Run `fennara --help` for the installed command summary. Use
+`fennara mcp-setup --help` for the supported MCP app targets.
 
 ## Install A Project
 
@@ -72,7 +84,7 @@ Without `--version`, the CLI selects the current release manifest. Use an exact
 release when reproducibility matters:
 
 ```bash
-fennara install --project path/to/project --version 0.3.8
+fennara install --project path/to/project --version <version>
 ```
 
 Installation has two safe paths:
@@ -84,9 +96,6 @@ Installation has two safe paths:
   the current platform library, and installs that exact version's CLI-managed
   components. It keeps the project addon unchanged. An explicit `--version`
   must match the existing addon.
-
-This second path is what the Godot **Set Up Fennara** panel uses after it has
-bootstrapped the CLI.
 
 ## Update A Project
 
@@ -149,6 +158,9 @@ launchers, runtimes, daemon state, and webview prerequisite:
 ```bash
 fennara doctor
 ```
+
+If it reports a running daemon or MCP runtime older than `current.json`, restart
+Godot or the affected MCP app so it launches the selected runtime.
 
 Use `--repair` to recreate missing base app-data directories. On Linux it also
 cleans stale CEF process profiles and repairs the current-runtime marker when a

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,16 @@
 # Examples
 
+Copy a prompt, replace its project details, and send it from an MCP app or the
+built-in Fennara chat.
+
+| Goal | Example |
+| --- | --- |
+| Confirm the connected editor | [Check Connection](#check-connection) |
+| Understand an existing project | [Inspect Before Editing](#inspect-a-project-before-editing) |
+| Make a focused change | [Architecture-Aware Change](#make-a-small-architecture-aware-change) |
+| Diagnose a running project | [Runtime Error](#debug-a-runtime-error) |
+| Inspect rendered output | [Visual Feedback](#visual-feedback) |
+
 ## Check Connection
 
 ```text

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,15 @@
 # FAQ
 
+Start with [Setup](setup.md) for installation and updates. Use this page for
+short answers and links to the detailed reference.
+
+| Question | Short answer |
+| --- | --- |
+| Do I need a provider key? | Only for a cloud provider in the built-in chat |
+| Can I use an external MCP app instead? | Yes, it uses its own model account |
+| Does Fennara upload my project to a Fennara server? | No |
+| Can multiple Godot editors be open? | Yes, choose the external MCP target in the dock |
+
 ## Is Fennara only a code generator?
 
 No. Fennara is a Godot-aware agent workflow. It can work with project files, scenes, diagnostics, runtime errors, screenshots, and Godot editor context.
@@ -14,22 +24,15 @@ No. Fennara is not trying to make Godot optional. It is designed to make AI agen
 
 ## How should I install Fennara?
 
-Use [Setup](setup.md) for the normal install path:
-
-```bash
-fennara install
-fennara mcp-setup --help
-```
-
-The setup flow installs the Godot addon, downloads the local MCP runtime package, writes generated project guidance, and configures supported MCP apps.
+Add the addon, open the Fennara dock, and press **Set Up Fennara**. You can also
+install from the terminal. See [Setup](setup.md) for both paths.
 
 ## Do I need a chat provider API key?
 
 Only if you want to use a cloud provider in the built-in Fennara chat dock. External MCP clients use their own model/app configuration and can use Fennara MCP tools without putting any provider key into Fennara chat.
 
-The built-in chat can also use local providers such as Ollama or LM Studio, which do not require a cloud API key.
-
-Supported built-in chat providers are OpenAI, Anthropic, OpenRouter, Ollama Cloud, DeepSeek, Z.AI, Moonshot AI, Kimi For Coding, MiniMax, local Ollama, and LM Studio. See [Built-In Chat Providers](providers.md).
+The built-in chat can also use local Ollama or LM Studio without a cloud API
+key. See [Built-In Chat Providers](providers.md).
 
 ## Why does the dock ask for a provider if I already ran `mcp-setup --claude`?
 

--- a/docs/fennara-vs-traditional-godot-mcp.md
+++ b/docs/fennara-vs-traditional-godot-mcp.md
@@ -1,5 +1,11 @@
 # Fennara vs Traditional Godot MCP
 
+| Traditional command bridge | Fennara feedback loop |
+| --- | --- |
+| Exposes editor actions | Exposes Godot-aware inspection, actions, and checks |
+| A successful command can be the end of the flow | Diagnostics, validation, runtime logs, and screenshots inform the next step |
+| Best for direct, known edits | Best when an agent must inspect, change, verify, and recover |
+
 Most Godot MCP servers expose editor commands to AI clients.
 
 Examples:

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -1,14 +1,14 @@
 # Manual Install
 
-Use this page if you do not want to run the install script.
+Use this page only when you need to assemble Fennara without the Godot setup
+flow or `fennara install`.
 
-For most users, the normal setup guide is easier:
+> [!TIP]
+> Most users should add `addons/fennara` to the project, open the Fennara dock,
+> and press **Set Up Fennara**. See [Setup](setup.md).
 
-```bash
-fennara install
-```
-
-See [Setup](setup.md).
+Manual installation has four parts: the CLI, the project addon, the shared local
+runtime package, and optional MCP app configuration.
 
 ## 1. Download Release Files
 
@@ -16,42 +16,19 @@ Open the latest GitHub release:
 
 https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest
 
-Download the release manifest, the CLI and local runtime files for your
-platform, plus the shared addon zip.
+Download the release manifest, your platform files, and the shared addon zip.
 
-Release manifest:
-
-```text
-fennara-release-manifest-v<version>.json
-```
-
-Windows:
-
-```text
-fennara-cli-windows-x86_64-v<version>.zip
-fennara-release-local-windows-x86_64-v<version>.zip
-```
-
-Linux:
-
-```text
-fennara-cli-linux-x86_64-v<version>.zip
-fennara-release-local-linux-x86_64-v<version>.zip
-fennara-webview-cef-linux-x64-<cef-version>.zip
-```
-
-macOS:
-
-```text
-fennara-cli-macos-arm64-v<version>.zip
-fennara-release-local-macos-arm64-v<version>.zip
-```
-
-Shared addon:
-
-```text
-fennara-release-addon-v<version>.zip
-```
+| Purpose | Asset |
+| --- | --- |
+| Release plan and SHA-256 values | `fennara-release-manifest-v<version>.json` |
+| Windows x86_64 CLI | `fennara-cli-windows-x86_64-v<version>.zip` |
+| Windows x86_64 local runtime | `fennara-release-local-windows-x86_64-v<version>.zip` |
+| Linux x86_64 CLI | `fennara-cli-linux-x86_64-v<version>.zip` |
+| Linux x86_64 local runtime | `fennara-release-local-linux-x86_64-v<version>.zip` |
+| Linux x86_64 embedded webview | `fennara-webview-cef-linux-x64-<cef-version>.zip` |
+| macOS arm64 CLI | `fennara-cli-macos-arm64-v<version>.zip` |
+| macOS arm64 local runtime | `fennara-release-local-macos-arm64-v<version>.zip` |
+| Versioned all-platform addon | `fennara-release-addon-v<version>.zip` |
 
 For Godot Asset Library links, use the stable latest asset:
 
@@ -251,10 +228,6 @@ Even if you install the CLI manually, you can let it install the addon and local
 cd path/to/your-godot-project
 fennara install
 ```
-
-For C# projects, use the same `fennara install` command and ensure the required
-.NET SDK is available through `dotnet`. Fennara uses project builds for C#
-diagnostics and runtime preflight checks.
 
 The CLI also writes project guidance for AI coding agents:
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,48 +1,44 @@
 # MCP Setup
 
-Use this guide when connecting Fennara to an external MCP app such as Claude
-Code, Claude Desktop, Codex, Cursor, Cline, VS Code, Gemini, Antigravity,
-OpenCode, Windsurf, Kiro, or another MCP client.
+Connect an external AI app to Fennara's Godot tools. The app keeps using its own
+model account, subscription, or API setup.
 
-External MCP apps use their own model account, subscription, or API setup.
-Fennara supplies the local Godot-aware tools. The built-in Fennara chat dock is
-configured separately inside Godot.
+> [!NOTE]
+> This does not configure the built-in Fennara chat. See
+> [MCP Apps And Built-In Chat](chat-vs-mcp.md) if you are unsure which path you
+> need.
 
-## Preferred Setup
+## Quick Setup
 
-Finish **Set Up Fennara** in the Godot dock first. Then open **Chat Settings >
-MCP Apps**, find the external app, and press **Set Up**. The dock asks the local
-daemon to run the matching `fennara mcp-setup` command. The CLI remains the only
-component that edits MCP app configuration and creates backups.
+1. Finish **Set Up Fennara** in the Godot dock.
+2. Open **Chat Settings > MCP Apps**.
+3. Find your app and press **Set Up**.
+4. Restart the app.
 
-Restart the selected MCP app after setup so it reloads Fennara. The combined
-**Claude** option configures Claude Code and Claude Desktop. **Gemini &
-Antigravity** configures the shared Gemini and Antigravity targets.
+Fennara creates a backup before changing an app's MCP configuration. The
+combined **Claude** option configures Claude Code and Claude Desktop. **Gemini
+& Antigravity** configures both shared targets.
 
-The terminal workflow remains available. Run `fennara install` inside the Godot
-project first, then configure the external app directly:
+### Terminal Alternative
 
-Then configure your MCP app:
+Run `fennara install` inside the Godot project first, then choose a target:
 
-```bash
-fennara mcp-setup --claude
-fennara mcp-setup --codex
-fennara mcp-setup --cursor
-fennara mcp-setup --gemini
-```
+| App | Command |
+| --- | --- |
+| Claude Code and Claude Desktop | `fennara mcp-setup --claude` |
+| Claude Code only | `fennara mcp-setup --claude-code` |
+| Claude Desktop only | `fennara mcp-setup --claude-desktop` |
+| Codex | `fennara mcp-setup --codex` |
+| Cursor | `fennara mcp-setup --cursor` |
+| Gemini and Antigravity | `fennara mcp-setup --gemini` or `fennara mcp-setup --antigravity` |
+| Cline | `fennara mcp-setup --cline` |
+| VS Code | `fennara mcp-setup --vscode` |
+| OpenCode | `fennara mcp-setup --opencode` |
+| Windsurf | `fennara mcp-setup --windsurf` |
+| Kiro | `fennara mcp-setup --kiro` |
 
-Other supported targets:
-
-```bash
-fennara mcp-setup --claude-code
-fennara mcp-setup --claude-desktop
-fennara mcp-setup --cline
-fennara mcp-setup --vscode
-fennara mcp-setup --opencode
-fennara mcp-setup --windsurf
-fennara mcp-setup --kiro
-fennara mcp-setup --help
-```
+Run `fennara mcp-setup --help` for the target list supported by your installed
+CLI.
 
 ## Manual Setup
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,16 +1,29 @@
 # Built-In Chat Providers
 
-This page is for the Fennara chat dock inside Godot.
+Connect a model provider to the Fennara chat dock inside Godot.
 
-External MCP apps are different. Claude Code, Claude Desktop, Codex, Cursor, Gemini, and Antigravity use their own model setup when they call Fennara MCP tools. See [MCP Apps And Built-In Chat](chat-vs-mcp.md) for that distinction.
+> [!NOTE]
+> External MCP apps use their own model setup. You do not need to connect a
+> provider here to use Fennara from Codex, Claude, Cursor, or another MCP app.
+> See [MCP Apps And Built-In Chat](chat-vs-mcp.md).
 
-## Supported Providers
+## Quick Setup
+
+1. Open **Chat Settings > Chat** in the Fennara dock.
+2. Select **Open providers**.
+3. Choose a cloud provider and enter your own key, or choose Ollama or LM
+   Studio for a local model.
+4. Select a model.
+
+You can also type `/provider` and `/model` in the composer.
+
+## Provider Reference
 
 | Provider | How To Connect | Model Id Shape | Notes |
 | --- | --- | --- | --- |
 | OpenAI | Create a key in [OpenAI API keys](https://platform.openai.com/api-keys). Fennara key/env: `OPENAI_API_KEY`. | `openai/<model>` | Uses OpenAI's official API. |
 | Anthropic | Create a key in [Claude Console API keys](https://console.anthropic.com/settings/keys). Fennara key/env: `ANTHROPIC_API_KEY`. | `anthropic/<model>` | Uses Anthropic's official Messages API. |
-| OpenRouter | Create a key in [OpenRouter Keys](https://openrouter.ai/settings/keys). Fennara key/env: `OPENROUTER_API_KEY`. | `openrouter/<provider>/<model>` | Use this when you want OpenRouter to route the request. See [OpenRouter Model Ids](#openrouter-model-ids). |
+| OpenRouter | Create a key in [OpenRouter Keys](https://openrouter.ai/settings/keys). Fennara key/env: `OPENROUTER_API_KEY`. | `openrouter/<provider>/<model>` | Uses OpenRouter's API. |
 | Ollama Cloud | Create a key in [Ollama API keys](https://ollama.com/settings/keys). Fennara key/env: `OLLAMA_API_KEY`. | `ollama-cloud/<model>` | Uses Ollama's hosted API, not the local Ollama server. |
 | DeepSeek | Create a key in [DeepSeek API keys](https://platform.deepseek.com/api_keys). Fennara key/env: `DEEPSEEK_API_KEY`. | `deepseek/<model>` | Uses DeepSeek's OpenAI-compatible API. |
 | Z.AI | Create a key in [Z.AI API keys](https://z.ai/manage-apikey/apikey-list). Fennara key/env: `ZHIPU_API_KEY`. | `zai/<model>` | Uses Z.AI's OpenAI-compatible API. |
@@ -24,21 +37,10 @@ External MCP apps are different. Claude Code, Claude Desktop, Codex, Cursor, Gem
 | Ollama | Run a local Ollama server. No cloud API key is required. | `ollama/<local-model>` | Defaults to `http://127.0.0.1:11434`. |
 | LM Studio | Start LM Studio's local server. No key is required by default. | `lmstudio/<local-model>` | Defaults to `http://127.0.0.1:1234/v1`. If your LM Studio server requires auth, set `LMSTUDIO_API_KEY` in the daemon environment. |
 
-Cloud providers need your own API key or subscription key. Local providers need the local server running with a model available.
+Cloud providers need your own API key or subscription key. Local providers need
+the local server running with a model available.
 
 Fennara can store keys from the provider picker in the dock. Chat Settings includes an **Open providers** button for discovering the same picker. The key/env names above are the same names Fennara understands if you prefer environment variables. Stored keys live in the daemon's local app data, outside the Godot project.
-
-## OpenRouter Model Ids
-
-OpenRouter model ids often already contain a provider slug. In Fennara, prefer the explicit OpenRouter prefix:
-
-```text
-openrouter/google/gemini-...
-openrouter/anthropic/claude-...
-openrouter/openai/gpt-...
-```
-
-If you paste a raw OpenRouter slug such as `google/gemini-...`, Fennara still sends it to OpenRouter for compatibility. Native Fennara prefixes win, though: `openai/gpt-...` uses the official OpenAI provider, and `anthropic/claude-...` uses the official Anthropic provider. To use those vendors through OpenRouter, choose `openrouter/openai/...` or `openrouter/anthropic/...`.
 
 ## Where Settings Live
 
@@ -61,15 +63,10 @@ When this is off, Fennara tries to render the built-in chat inside the Godot doc
 
 Changing this setting takes effect the next time Godot starts. It only changes where the built-in chat UI is displayed; it does not change the selected provider, model, API keys, chat history, MCP app setup, or which model Claude/Codex/Cursor use externally.
 
-## Choosing A Provider And Model
+## Picker Shortcuts
 
-Inside the Fennara dock:
-
-1. Open **Chat Settings** and click **Open providers**, or use `/provider` directly.
-2. Choose a provider and add the connection details it requires, such as an API key for a cloud provider or a base URL for a local provider.
-3. Use the model picker to choose a model from the connected provider.
-
-Chat Settings, the dock controls, and `/provider` all open the same registry-backed provider picker. Use `/model` or the dock model control to open the model picker.
+Chat Settings, the dock controls, and `/provider` open the same provider picker.
+Use `/model` or the dock model control to open the model picker.
 
 See [Built-In Chat Slash Commands](slash-commands.md) for command palette behavior.
 
@@ -87,6 +84,9 @@ Then choose:
 ```text
 ollama/llama3.1:8b
 ```
+
+Older `local/<model>` selections are still accepted as Ollama compatibility
+aliases. Prefer the explicit `ollama/<model>` form for new settings.
 
 For LM Studio, start the local server from LM Studio and choose a model id shaped like:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,6 +2,20 @@
 
 Releases are manual. Do not publish from pull request workflows.
 
+> [!IMPORTANT]
+> Run releases from `main`, keep `VERSION` and the workflow input identical, and
+> explicitly decide whether the release needs a higher minimum CLI version.
+
+## Release At A Glance
+
+| Step | Result |
+| --- | --- |
+| Prepare and merge the version change | Repository version sources agree |
+| Run Package Preview | Release-shaped artifacts are built without publishing |
+| Inspect the preview | Archives, manifest, hashes, and Linux CEF layout are verified |
+| Run Release from `main` | Tag and GitHub Release are published |
+| Smoke test install and update | The public user flow is verified |
+
 ## Versioning
 
 `VERSION` is the source of truth.
@@ -9,7 +23,7 @@ Releases are manual. Do not publish from pull request workflows.
 To bump the repo version:
 
 ```bash
-node scripts/set-version.mjs 0.3.1
+node scripts/set-version.mjs X.Y.Z
 ```
 
 The script updates:
@@ -89,7 +103,7 @@ Actions > Release > Run workflow
 Inputs:
 
 ```text
-version: 0.3.1
+version: X.Y.Z
 promote_latest: true
 ```
 
@@ -119,54 +133,26 @@ Preview is not the user-facing release channel.
 
 Each release should contain per-platform CLI/local runtime packages and one shared all-platform addon package.
 
-Windows:
-
-```text
-fennara-cli-windows-x86_64-v<version>.zip
-fennara-release-local-windows-x86_64-v<version>.zip
-```
-
-Linux:
-
-```text
-fennara-cli-linux-x86_64-v<version>.zip
-fennara-release-local-linux-x86_64-v<version>.zip
-```
-
-macOS:
-
-```text
-fennara-cli-macos-arm64-v<version>.zip
-fennara-release-local-macos-arm64-v<version>.zip
-```
-
-Shared addon:
-
-```text
-fennara-release-addon-v<version>.zip
-fennara-addon-latest.zip
-```
-
-Linux webview runtime:
-
-```text
-fennara-webview-cef-linux-x64-<cef-version>.zip
-```
-
-Release manifest:
-
-```text
-fennara-release-manifest-v<version>.json
-```
+| Target | Assets |
+| --- | --- |
+| Windows x86_64 | `fennara-cli-windows-x86_64-v<version>.zip`<br>`fennara-release-local-windows-x86_64-v<version>.zip` |
+| Linux x86_64 | `fennara-cli-linux-x86_64-v<version>.zip`<br>`fennara-release-local-linux-x86_64-v<version>.zip`<br>`fennara-webview-cef-linux-x64-<cef-version>.zip` |
+| macOS arm64 | `fennara-cli-macos-arm64-v<version>.zip`<br>`fennara-release-local-macos-arm64-v<version>.zip` |
+| All platforms | `fennara-release-addon-v<version>.zip`<br>`fennara-addon-latest.zip`<br>`fennara-release-manifest-v<version>.json` |
 
 Package roles:
 
-- `fennara-cli-*`: install script payload; contains only the `fennara` CLI for one platform.
-- `fennara-release-local-*`: local MCP and daemon launchers plus versioned runtime binaries for one platform. Release uses the `fennara-release-local-*` prefix so older CLIs cannot silently bypass the manifest.
-- `fennara-release-addon-v*`: versioned all-platform Godot addon payload copied into projects by the CLI through the release manifest.
-- `fennara-addon-latest.zip`: stable all-platform addon URL for the Godot Asset Library and docs links.
-- `fennara-webview-cef-linux-x64-*`: Linux-only shared CEF runtime installed once into Fennara app data by the CLI.
-- `fennara-release-manifest-v*`: schema-versioned install/update plan used by the CLI to resolve assets, verify SHA-256 hashes, and install shared runtimes.
+| Pattern | Role |
+| --- | --- |
+| `fennara-cli-*` | Install script payload containing only the `fennara` CLI for one platform |
+| `fennara-release-local-*` | MCP and daemon launchers plus versioned runtime binaries for one platform |
+| `fennara-release-addon-v*` | Versioned all-platform addon resolved through the release manifest |
+| `fennara-addon-latest.zip` | Stable all-platform addon URL for the Godot Asset Library and documentation |
+| `fennara-webview-cef-linux-x64-*` | Linux-only shared CEF runtime installed once in Fennara app data |
+| `fennara-release-manifest-v*` | Install and update plan containing asset names, SHA-256 values, install primitives, and shared runtimes |
+
+The `fennara-release-local-*` prefix prevents older CLIs from silently bypassing
+the manifest-managed package path.
 
 ## Release Manifest
 
@@ -181,12 +167,11 @@ manifest whenever the release publishes one. The manifest records:
 - the shared addon asset with SHA-256
 - platform-specific shared runtime assets, currently Linux CEF
 
-The 0.3.3 manifest uses `minimum_cli_version: 0.3.3` by default because this
-release includes CLI update/install behavior that should travel with the
-packages. Future normal package layout or asset name changes should be handled
-by manifest data, not by changing the outer CLI. Raise `minimum_cli_version`
-only when a release needs a new manifest schema or install primitive that older
-CLIs truly cannot perform.
+The current manifest generator and release workflows use
+`minimum_cli_version: 0.3.3` by default. Normal package layout or asset name
+changes should be handled by manifest data, not by changing the outer CLI.
+Raise `minimum_cli_version` only when a release needs a new manifest schema or
+install primitive that older CLIs truly cannot perform.
 
 When the CLI is too old, `fennara update` should use the manifest's
 per-platform `assets.cli` entry to update the installed CLI first, then resume

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -2,6 +2,19 @@
 
 This is the quick map for contributors and coding agents working in this repository.
 
+## Find The Right Area
+
+| Change | Primary Location |
+| --- | --- |
+| User setup or CLI behavior | `local/crates/fennara-cli/` |
+| External MCP protocol or schemas | `local/crates/fennara-mcp/`, `local/schemas/tools/` |
+| Built-in chat or daemon behavior | `local/crates/fennara-daemon/` |
+| Godot editor integration | `fennara-cpp/` |
+| Chat UI | `ui/chat/` |
+| Runtime helper scripts | `runtime/` |
+| Packaging or releases | `scripts/`, `.github/workflows/` |
+| User documentation | `README.md`, `docs/` |
+
 ## Top Level
 
 | Path | Owns |
@@ -20,6 +33,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `install.ps1` / `install.sh` | Bootstrap scripts that install the Fennara CLI from GitHub releases. |
 | `VERSION` | Version source of truth. |
 | `README.md` | Short human-facing overview and quick start. |
+| `docs/README.md` | Task-oriented documentation index. |
 | `docs/setup.md` | User-facing addon-first setup, chat prerequisites, MCP connection, update flow, and troubleshooting. |
 | `docs/cli.md` | Terminal command reference, CLI-owned install/update behavior, recovery, diagnostics, app-data layout, and automation guidance. |
 | `CONTRIBUTING.md` | Contribution rules. |
@@ -46,7 +60,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `local/crates/fennara-daemon/src/runtime_daemon/chat/prompt.rs` | Built-in chat PromptBuilder and generated runtime environment context. |
 | `local/crates/fennara-daemon/src/runtime_daemon/chat/trace.rs` | Local-only built-in chat trace recorder, SQLite event rows, retention, and debug query helpers. |
 | `local/crates/fennara-daemon/src/runtime_daemon/chat/providers/` | Built-in chat provider runtime primitives, catalog/resolution, context preflight hooks, normalized stream/error types, and OpenAI-compatible or Anthropic-compatible adapters for OpenAI, Anthropic, OpenRouter, Ollama Cloud, DeepSeek, Z.AI, Moonshot AI, Kimi For Coding, MiniMax, Ollama/local, and LM Studio. |
-| `local/schemas/tools/` | MCP tool JSON schemas embedded into the local MCP server. |
+| `local/schemas/tools/` | Shared tool JSON schemas. The external MCP server and built-in chat embed their own allowed subsets. |
 | `local/webview-runtimes/linux-cef.json` | Linux CEF runtime placeholder/generated manifest used for release manifest generation, doctor output, and legacy fallback. It records the shared app-data layout and archive metadata without placing CEF inside the addon zip. |
 | `local/Cargo.toml` | Rust workspace config. |
 | `local/Cargo.lock` | Locked Rust dependency graph. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,164 +1,124 @@
 # Setup
 
-This guide walks through a normal Fennara setup from a clean machine to a Godot project connected through an external MCP app, the built-in chat dock, or both.
+Install Fennara, choose where you want to chat, and connect your Godot project.
 
-## Requirements
+> [!TIP]
+> Most users only need to add the addon, open the Fennara dock, and press
+> **Set Up Fennara**.
 
-- Godot 4.5+ project
-- An MCP client that can run local stdio MCP servers, only if you want external AI app integration
-- Windows, macOS, or Linux
-- For C# projects: .NET SDK installed and available as `dotnet`
-- Optional for built-in chat: a configured chat provider, such as a cloud API key or a local Ollama/LM Studio server
-- Optional for embedded Windows chat: Microsoft Edge WebView2 Runtime
-- Windows troubleshooting only: Microsoft Visual C++ Redistributable 2015-2022 x64 if the Fennara CLI/runtime fails to start with missing `VCRUNTIME` / `MSVCP` DLLs or exit code `-1073741515`
+## Before You Start
 
-## Default: Set Up From Godot
+| Requirement | When you need it |
+| --- | --- |
+| Godot 4.5 or newer | Always |
+| Windows x86_64, Linux x86_64, or macOS arm64 | Always |
+| An MCP-capable AI app | Only for external MCP use |
+| A cloud API key, Ollama, or LM Studio | Only for the built-in chat |
+| The .NET SDK available as `dotnet` | Only for C# diagnostics and runtime preflight |
 
-Add Fennara to the project using one of the download options in the
-[README Quick Start](../README.md#quick-start). Open the project and select the
-Fennara dock. If the matching local components are missing, Fennara shows a
-native setup panel that does not depend on chat, the daemon, or a webview.
+## Install From Godot
 
-Select **Set Up Fennara**. The addon reads its own `VERSION`, downloads the
-release manifest and matching CLI archive, verifies the archive SHA-256, and
-installs the CLI under Fennara app data. It then runs the same
-`fennara install --project <path> --version <addon-version>` flow used by the
-terminal installer.
+1. Install **Fennara** from the Godot Asset Library, or download
+   `fennara-addon-latest.zip` from the
+   [latest release](https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest)
+   and copy `addons/fennara/` into your project.
+2. Open the project and select the Fennara dock.
+3. Press **Set Up Fennara**.
 
-The panel follows the CLI's durable operation state and shows installation
-progress. A failure includes a stable error code, operation ID when one was
-created, **Retry**, **Copy Report**, and **Open Logs** actions. Copied reports
-use the sanitized operation state and do not include API keys, chat content, or
+Fennara installs the matching local components and connects the open project.
+If setup fails, the dock provides **Retry**, **Copy Report**, and **Open Logs**.
+Copied reports are sanitized and do not include API keys, chat content, or
 project files.
 
-The bootstrap only installs the exact verified CLI and then delegates the rest
-of setup to that CLI. It does not place the daemon, MCP server, browser runtime,
-or updater inside the project addon.
+> [!NOTE]
+> The addon stays in your project. The CLI, daemon, MCP server, logs, and shared
+> browser runtime live in Fennara app data outside the project.
 
-## Terminal Setup Alternative
+## Alternative: Install From The Terminal
 
-Use this flow for non-interactive setup or when the native setup panel cannot
-download or launch the CLI. It uses the same CLI that the Godot panel
-bootstraps.
+You do not need this if setup from the Godot dock succeeded.
 
-Install the CLI using the platform command in
-[Fennara CLI](cli.md#install-the-cli), then install the Godot project:
+Install the CLI on Windows:
 
-```bash
-fennara install --project path/to/your-godot-project
+```powershell
+irm https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.ps1 | iex
 ```
 
-Running inside the project works too:
+Or on macOS and Linux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh
+```
+
+Then run Fennara inside the project:
 
 ```bash
 cd path/to/your-godot-project
 fennara install
 ```
 
-For a C# Godot project, use the same `fennara install` command. Ensure the .NET
-SDK required by the project is available through `dotnet`; Fennara uses project
-builds for C# diagnostics and runtime preflight.
+If the project already contains a complete Fennara addon, the CLI keeps it and
+installs the matching local components. Otherwise, it installs the current
+release addon too. See the [CLI install reference](cli.md#install-a-project) for
+version pinning and automation.
 
-If the project already has a complete Asset Library or release addon, the CLI
-keeps it and installs its exact matching local components. Otherwise it installs
-the selected release addon. See [Fennara CLI](cli.md#install-a-project) for
-version selection, repeat-install behavior, and automation options.
+## Choose How You Use Fennara
 
-## Built-In Chat Webview Prerequisites
+| Path | Model account | Setup |
+| --- | --- | --- |
+| Built-in chat | A provider connected in Fennara Chat Settings | [Connect a provider](#connect-the-built-in-chat) |
+| External MCP app | The app's own model account or subscription | [Connect an MCP app](#connect-an-mcp-app) |
+| Both | Each path keeps its own model settings | Complete both sections |
 
-Fennara MCP tools work without the built-in Godot chat dock. The chat dock needs
-the platform webview:
+### Connect The Built-In Chat
 
-```text
-Windows: Microsoft Edge WebView2 Runtime
-macOS: WKWebView from the system WebKit.framework
-Linux: Fennara-managed shared CEF runtime
-```
+1. Open **Chat Settings > Chat**.
+2. Select **Open providers**.
+3. Connect a cloud provider with your own key, or connect a local Ollama or
+   LM Studio server.
+4. Choose a model.
 
-`fennara install`, `fennara update`, and `fennara doctor` check the current
-platform. On Windows, missing WebView2 prints the official Microsoft WebView2
-Runtime link. On macOS, WebKit is normally part of the OS, so Fennara only
-reports if the framework cannot be found. On Linux, the CEF runtime is selected
-from the release manifest and installed under Fennara app data.
+See [Built-In Chat Providers](providers.md) for supported providers, keys, local
+server URLs, and model IDs. Use `/provider` and `/model` for the same actions
+from the composer.
 
-On Linux, Fennara also uses a shared browser runtime location for the embedded
-chat CEF runtime:
+The embedded chat uses the platform webview:
 
-```text
-~/.local/share/fennara/webview/cef/linux-x64/<cef-version>
-```
+| Platform | Webview |
+| --- | --- |
+| Windows | Microsoft Edge WebView2 Runtime |
+| macOS | System WKWebView/WebKit |
+| Linux | Fennara-managed shared CEF runtime |
 
-The CEF browser payload is installed once per user and shared across Godot
-projects/editors. It is not copied into `addons/fennara`. The Linux chat dock
-renders through that shared runtime when it is present. Release manifests point
-at the matching CEF runtime asset; `fennara install`, `fennara update`, and
-`fennara doctor --repair` validate or repair the shared runtime layout.
+`fennara install`, `fennara update`, and `fennara doctor` check these
+prerequisites. MCP tools continue to work if the optional embedded chat cannot
+start.
 
-The shared CEF runtime directory is read-only during normal browser use. Each
-open Godot editor gets its own writable CEF profile/cache/log directories under
-the Fennara app-data `cache/webview/profiles/cef/` and `logs/webview/cef/`
-roots, so multiple editors can keep embedded chat open at the same time.
+To use the system browser instead, enable **Open chat in my system browser next
+time** in Chat Settings and restart Godot. This changes only where the built-in
+chat appears. It keeps the same provider, history, and project connection.
 
-The built-in chat has its own provider settings. It can use OpenAI, Anthropic,
-OpenRouter, Ollama Cloud, DeepSeek, Z.AI, Moonshot AI, Kimi For Coding, MiniMax,
-local Ollama, or LM Studio. These settings are separate
-from Claude Code, Codex, Cursor, Gemini, or any other external MCP app.
-Provider keys and local base URLs are stored locally outside the Godot project.
+To attach code to the next built-in chat message, select code in Godot's script
+editor, open the context menu, and choose **Add to Chat**.
 
-Chat Settings also has **Open chat in my system browser next time**. Leave it
-off to use the embedded Godot dock webview. Turn it on to have the dock show an
-**Open chat** button that launches the same built-in chat in your system browser
-through the local daemon. Restart Godot after changing this display setting.
+### Connect An MCP App
 
-Inside the dock, use `/provider` to connect or switch providers and `/model` to
-choose a model. See [Built-In Chat Providers](providers.md) and [Built-In Chat Slash Commands](slash-commands.md).
+Open **Chat Settings > MCP Apps**, find your app, and press **Set Up**. Restart
+the app so it can load Fennara.
 
-To add focused code context to a built-in chat request, select code in Godot's
-script editor, open the script editor context menu, and choose **Add to Chat**.
-The selected script range is attached to the next chat message as removable code
-context.
-
-## Configure Your MCP App
-
-Claude Code and Claude Desktop:
-
-```bash
-fennara mcp-setup --claude
-```
-
-Codex:
+You can also connect an app from the terminal:
 
 ```bash
 fennara mcp-setup --codex
-```
-
-Cursor:
-
-```bash
-fennara mcp-setup --cursor
-```
-
-Gemini and Antigravity:
-
-```bash
-fennara mcp-setup --gemini
-```
-
-Other supported targets:
-
-```bash
 fennara mcp-setup --help
 ```
 
-Restart the MCP app after running `mcp-setup`.
+If your app is not listed, see [MCP Setup](mcp-setup.md) for every supported
+target and manual configuration formats.
 
-If your app is not listed, or if `mcp-setup` cannot find that app's config file,
-see [MCP Setup](mcp-setup.md) for manual JSON/TOML config examples.
-
-`mcp-setup` only connects that external app to Fennara's MCP tools. For example,
-`fennara mcp-setup --claude` lets Claude call Fennara tools, but it does not make
-the built-in Fennara dock use Claude or your Claude subscription. The dock uses
-the provider configured in Fennara chat settings. See [MCP Apps And Built-In Chat](chat-vs-mcp.md).
+External MCP apps use their own model accounts. The built-in chat uses the
+provider selected in Fennara Chat Settings. See
+[MCP Apps And Built-In Chat](chat-vs-mcp.md) for the distinction.
 
 ## Verify The Connection
 
@@ -168,64 +128,55 @@ Open the Godot project, then ask your MCP app:
 Use Fennara MCP to run fennara_status and tell me which Godot project is connected.
 ```
 
-The result should show the project path you expect.
-
-If the wrong project is shown, use the Fennara dock in Godot to set the current project as the MCP target.
+If it reports the wrong project, select the correct MCP target from the Fennara
+dock.
 
 ## Update Fennara
 
-When the dock shows **Update**, select it to download and verify the release
-while Godot stays open. The dock shows progress, then asks whether to close
-Godot and install. Choosing **Not Now** leaves the current installation running.
+When the dock shows **Update**, press it and follow the prompts. Fennara
+downloads and verifies the update before asking to close Godot. It reopens the
+same project after installation and keeps the previous working version until
+the update validates.
 
-After confirmation, Fennara closes the editor normally, installs the staged
-release, and reopens the same project. It keeps the previous working version
-until the new addon and daemon validate. If validation fails, the dock offers
-**Restore Previous Version**, **Open Logs**, and **Copy Report**.
-
-Terminal users can close Godot and run:
+To update from the terminal, close Godot and run:
 
 ```bash
-fennara update --project path/to/your-godot-project
+cd path/to/your-godot-project
+fennara update
 ```
 
-See [Fennara CLI](cli.md#update-a-project) for exact-version updates, the
-prepare primitive, interrupted-update recovery, and diagnostics.
+If validation fails, use **Restore Previous Version**, **Open Logs**, or
+**Copy Report** in the dock. See the [CLI update reference](cli.md#update-a-project)
+for exact versions, preparation, and interrupted-update recovery.
 
 ## Troubleshooting
 
 ### An Install Or Update Failed
 
-`fennara install`, `fennara update`, and CLI self-update operations print an
-operation ID and durable event-log path. Show the latest sanitized report with:
+Copy the sanitized report from the dock, or show the latest report in a
+terminal:
 
 ```bash
 fennara diagnostics
 ```
 
-The report is safe to copy into a support request. See
-[CLI diagnostics](cli.md#inspect-health-and-failures) for operation selection,
+See [CLI diagnostics](cli.md#inspect-health-and-failures) for operation IDs,
 JSON output, recorded fields, and redaction guarantees.
 
 ### `fennara` Is Not Found
 
-Open a new terminal and try again:
+Open a new terminal and run:
 
 ```bash
 fennara doctor
 ```
 
-`doctor` also reports when a running Fennara daemon or MCP runtime appears to be
-older than the version selected by `current.json`; restart Godot or the MCP app
-when it prints that warning.
+If the command is still unavailable, add the Fennara `bin` directory to PATH.
+The [CLI installation page](cli.md#install-the-cli) lists the platform paths.
 
-If it still fails, add the Fennara `bin` directory to PATH manually.
-The platform paths are listed in [Fennara CLI](cli.md#install-the-cli).
+### Windows Binaries Fail Before Starting
 
-### Windows CLI Fails Before It Starts
-
-If `fennara`, `fennara-mcp`, or `fennara-daemon` fails before printing normal
-output with a missing `VCRUNTIME` / `MSVCP` DLL error, exit code
+If a Fennara binary reports a missing `VCRUNTIME` or `MSVCP` DLL, exit code
 `-1073741515`, or `0xc0000135`, install the Microsoft Visual C++ Redistributable
 2015-2022 x64:
 
@@ -233,43 +184,34 @@ output with a missing `VCRUNTIME` / `MSVCP` DLL error, exit code
 https://aka.ms/vs/17/release/vc_redist.x64.exe
 ```
 
-This is not a hard requirement for every Windows user. It only means that
-machine is missing the Microsoft runtime DLLs used by the current Fennara
-Windows binaries. The installer and self-update path already print clearer
-messages for the known `-1073741515` case, but the docs call it out here for
-manual troubleshooting.
+This is required only on Windows machines missing those Microsoft runtime DLLs.
 
-Long term, Fennara should either ship Windows binaries in a way that avoids
-this footgun or detect the missing runtime earlier and point directly at the
-fix.
+### A Release Requires A Newer CLI
 
-### Release Requires A Newer CLI
-
-If `fennara install` or `fennara update` says the release requires a newer
-Fennara CLI and self-update could not run, rerun the install script from
-[Install the CLI](cli.md#install-the-cli), then run the command again. This
-should be rare; normal package, runtime, and CLI changes are handled by the
-release manifest.
+If CLI self-update cannot install the required version, rerun the install script
+from [Install The CLI](cli.md#install-the-cli), then retry the command.
 
 ### The Addon Is Not Visible In Godot
 
-Check that the project contains:
+Confirm this file exists, then reopen the project:
 
 ```text
 addons/fennara/fennara.gdextension
 ```
 
-Then reopen the project or refresh the plugin list in Godot.
-
 ### `fennara_status` Shows The Wrong Project
 
-Open the intended Godot project and use the Fennara dock to set it as the MCP target.
+Open the intended project and select it with the MCP target control in the
+Fennara dock.
 
 ### C# Diagnostics Are Missing
 
-Make sure the project contains an unambiguous `.csproj`, `.sln`, or `.slnx` and
-that `dotnet` works from your terminal:
+Confirm the project contains one clear `.csproj`, `.sln`, or `.slnx`, then run:
 
 ```bash
 dotnet --version
 ```
+
+For browser runtime layouts, manual recovery, and implementation details, see
+[Architecture](architecture.md), [Manual Install](manual-install.md), and the
+[FAQ](faq.md).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,8 @@
 # Tools
 
-Fennara tools are built around Godot feedback.
+Fennara tools provide Godot-aware inspection, editing, validation, and runtime
+feedback. The exact tool set depends on whether you use an external MCP app or
+the built-in Fennara chat.
 
 The MCP client should still use its normal repository search, read, and diff
 tools for broad code navigation. Fennara is for the parts that need Godot
@@ -12,12 +14,22 @@ generated Fennara block in `AGENTS.md`. Agents should read that project guidance
 before doing Godot-specific work. The live MCP tool schemas remain the exact
 source of truth for arguments, limits, and result fields.
 
+## Tool Surfaces
+
+| Surface | Tools |
+| --- | --- |
+| External MCP apps | `fennara_status` and the 12 Godot tools in the table below |
+| Built-in Fennara chat | The same 12 Godot tools, plus `read_file` and `exec_command` |
+
+> [!NOTE]
+> `fennara_status` belongs to the external MCP server. The built-in chat already
+> receives connection and project status from the local daemon.
+
 ## External MCP Tools
 
 | Tool | Use It For |
 | --- | --- |
-| `fennara_status` | Check the active Godot project, daemon bridge, app-data paths, local runtime state, chat/webview support, and available MCP tools. |
-| `read_file` | Read project-scoped text files and selected images through Godot path normalization and project boundaries. |
+| `fennara_status` | Check daemon and Godot connectivity, the active project, connected editors, versions, rendering context, and advertised Godot tools. |
 | `get_scene_tree` | Inspect real scene node structure, node types, scripts, and instanced subscenes before using node paths. |
 | `get_node_properties` | Read properties changed from defaults for up to 5 scene nodes, including recursive SubResource summaries. |
 | `get_class_info` | Look up real Godot class methods, properties, signals, enums, constants, inheritance, and docs before writing Godot API code. |
@@ -31,13 +43,19 @@ source of truth for arguments, limits, and result fields.
 | `runtime_script` | Run a small GDScript probe or input-driver inside an active managed runtime session. |
 | `scrape_editor` | Read a narrow Godot editor debugger snapshot when the user manually ran a scene in the editor. |
 
-These are the tools exposed to external MCP clients through the local
-`fennara-mcp` process.
+These are the tools exposed through the local `fennara-mcp` process. External
+MCP apps should use their own file readers and repository search tools for normal
+source navigation.
 
 ## Built-In Chat Tool Use
 
-The in-editor Fennara chat uses the same local daemon and can call the same
-Godot-side tools, including `read_file`.
+The in-editor Fennara chat uses the same local daemon and can call the 12
+Godot-side tools listed above. It also provides two chat-only tools:
+
+| Tool | Use It For |
+| --- | --- |
+| `read_file` | Read project-scoped text files and selected images through Godot path normalization and project boundaries. |
+| `exec_command` | Run one non-interactive shell command inside the active project root. |
 
 It does not use the external MCP app's model account. Claude Code, Codex,
 Cursor, Gemini, and other MCP clients use their own model setup when they call
@@ -74,11 +92,10 @@ also writes a daemon-side raw log and result envelope under Fennara app data so
 older compacted chat history can point to exact stdout/stderr without replaying
 large command output into model context.
 
-The difference is presentation, not tool identity. External MCP clients receive
-compact markdown tool results over MCP. The built-in chat may add UI-specific
-handling around the same raw results, such as showing image previews from
-`read_file`, collapsing large output, or attaching screenshots/image context to
-the model request.
+For shared Godot tools, the difference is presentation. External MCP clients
+receive compact Markdown results over MCP. The built-in chat may add UI-specific
+handling, such as collapsing large output or attaching screenshots and image
+context to the model request.
 
 ### Selected Script Context
 
@@ -108,7 +125,7 @@ repository reading/search when Godot feedback is not needed.
 
 ## Normal Workflow
 
-For most tasks, use tools in this order:
+For most external MCP tasks, use tools in this order:
 
 ```text
 fennara_status
@@ -118,13 +135,22 @@ run diagnostics or validation
 use runtime tools or screenshots when behavior/visuals matter
 ```
 
+The built-in chat already receives project connection context, so it begins at
+the inspection step instead of calling `fennara_status`.
+
 ## Connection
 
 ### `fennara_status`
 
 Use this first when the MCP client is not sure which Godot project is connected.
-It reports the active project, Godot/addon bridge reachability, app-data paths,
-daemon/runtime state, local chat/webview support, and available Fennara tools.
+It reports daemon and Godot bridge reachability, the active project, connected
+editors, Godot and addon versions, rendering context, and the tools advertised
+by each connected editor.
+
+The editor advertisement describes the Godot bridge and currently includes
+`read_file`, which the built-in chat can use. For an external MCP app, the
+**External MCP Tools** table above and the live MCP `tools/list` response are
+the callable surface.
 
 Example prompt:
 
@@ -134,7 +160,7 @@ Use Fennara MCP to run fennara_status and tell me which Godot project is connect
 
 ## Inspection
 
-### `read_file`
+### `read_file` (Built-In Chat)
 
 Use this when Godot-side path normalization or image handling matters. It is
 project-scoped and accepts Godot-style paths such as `res://scripts/player.gd`.

--- a/llms.txt
+++ b/llms.txt
@@ -20,17 +20,22 @@ Core positioning:
 
 Start here:
 - README.md
+- docs/README.md
 - AGENTS.md
 - CONTEXT.md
+
+User guides:
 - docs/setup.md
 - docs/cli.md
-- docs/repo-map.md
-- docs/architecture.md
 - docs/mcp-setup.md
 - docs/chat-vs-mcp.md
 - docs/providers.md
 - docs/slash-commands.md
 - docs/manual-install.md
+
+Contributor reference:
+- docs/repo-map.md
+- docs/architecture.md
 - docs/release.md
 - CONTRIBUTING.md
 

--- a/local/README.md
+++ b/local/README.md
@@ -25,11 +25,12 @@ local/target/debug/fennara-daemon.exe
 
 ## MCP Server
 
-`crates/fennara-mcp` is the first local MCP server. It speaks JSON-RPC over stdio so MCP clients can launch it as a local process.
+`crates/fennara-mcp` is the local MCP server. It speaks JSON-RPC over stdio so MCP clients can launch it as a local process.
 
-`fennara-mcp` embeds the MCP-facing tool schemas from `local/schemas/tools/`
-at build time and forwards tool calls to the local daemon. It does not need an
-external schema service at runtime.
+`fennara-mcp` embeds its selected MCP-facing schemas from `local/schemas/tools/`
+at build time and forwards those tool calls to the local daemon. It does not
+need an external schema service at runtime. The built-in chat selects a related
+but different tool set from the same schema directory.
 
 `fennara install` also writes generated project guidance from `local/templates/`
 into the Godot project:


### PR DESCRIPTION
## Summary

- reorganize the README and setup guides around install, provider or MCP connection, and update tasks
- add a documentation landing page with clear paths for users, troubleshooting, reference material, and contributors
- reduce repeated onboarding text while preserving detailed CLI, architecture, manual install, tool, and release guidance
- align documented tools, MCP targets, provider behavior, UI labels, platform support, package names, and release requirements with the current implementation

## Why

The setup information was repeated across several long pages, which made the normal addon-first flow harder to find. Some reference material also mixed user instructions with implementation details. This gives new users a short path while keeping advanced and recovery information in focused reference pages.

## Validation

- `git diff --check origin/main...HEAD`
- Manually verify every relative Markdown link and heading anchor in the root documentation and `docs/` pages.
- Compare the documented CLI commands, MCP setup targets, provider identifiers, and external versus built-in tool lists with their current source definitions.

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized setup, installation, updates, troubleshooting, and manual installation guidance.
  * Added clearer instructions for built-in chat providers, local providers, and external MCP app connections.
  * Added a documentation landing page, examples index, and improved navigation across guides.
  * Clarified built-in chat and external MCP workflows, project routing, available tools, and connection behavior.
  * Updated CLI, architecture, repository, contributor, and release reference documentation.
  * Added OpenAI and Anthropic to the documented chat provider examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->