### PR TITLE
feat(release): complete staging install and update pipeline

### DIFF
--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -169,6 +169,9 @@ jobs:
           SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
         run: |
           scons platform=windows target=editor fennara_setup_tests=yes
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
 
           $testTimeoutSeconds = 120
           $godot = Start-Process `

--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -162,16 +162,31 @@ jobs:
 
       - name: Test native first-run setup states
         if: steps.source.outputs.available == 'true' && matrix.platform == 'windows'
+        timeout-minutes: 20
         shell: pwsh
         working-directory: fennara-cpp
         env:
           SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
         run: |
           scons platform=windows target=editor fennara_setup_tests=yes
-          & "${{ steps.godot.outputs.console }}" `
-            --headless `
-            --path "${{ github.workspace }}\godot_demo" `
-            --script "res://tests/first_run_setup_test.gd"
-          if ($LASTEXITCODE -ne 0) {
-            exit $LASTEXITCODE
+
+          $testTimeoutSeconds = 120
+          $godot = Start-Process `
+            -FilePath "${{ steps.godot.outputs.console }}" `
+            -ArgumentList @(
+              "--headless",
+              "--path",
+              '"${{ github.workspace }}\godot_demo"',
+              "--script",
+              "res://tests/first_run_setup_test.gd"
+            ) `
+            -NoNewWindow `
+            -PassThru
+          if (-not $godot.WaitForExit($testTimeoutSeconds * 1000)) {
+            Write-Host "::error::Native first-run setup test exceeded ${testTimeoutSeconds} seconds."
+            & taskkill.exe /PID $godot.Id /T /F
+            exit 124
+          }
+          if ($godot.ExitCode -ne 0) {
+            exit $godot.ExitCode
           }

--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -439,7 +439,7 @@ jobs:
           node scripts/write-release-manifest.mjs \
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
-            --minimum-cli-version 0.3.3 \
+            --minimum-cli-version 0.3.8 \
             --out "release-assets/fennara-release-manifest-v${version}.json"
 
       - name: Upload release-shaped preview assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,23 @@ jobs:
             --minimum-cli-version 0.3.8 \
             --out "release-assets/fennara-release-manifest-v${{ inputs.version }}.json"
 
+      - name: Require immutable GitHub releases
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::RELEASE_ADMIN_TOKEN must provide repository Administration read access for the immutable-release preflight."
+            exit 1
+          fi
+          if ! gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/immutable-releases" >/dev/null 2>&1; then
+            echo "::error::Repository release immutability must be enabled before publishing a release."
+            exit 1
+          fi
+
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -379,13 +396,6 @@ jobs:
           set -euo pipefail
 
           tag="v${VERSION}"
-          if ! gh api \
-            -H "X-GitHub-Api-Version: 2026-03-10" \
-            "repos/${GITHUB_REPOSITORY}/immutable-releases" >/dev/null 2>&1; then
-            echo "::error::Repository release immutability must be enabled before publishing a release."
-            exit 1
-          fi
-
           mapfile -t assets < <(find release-assets -type f \( -name '*.zip' -o -name 'fennara-release-manifest-v*.json' \) | sort)
           if [[ "${#assets[@]}" -eq 0 ]]; then
             echo "::error::No release assets found."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,7 @@ jobs:
           node scripts/write-release-manifest.mjs \
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
-            --minimum-cli-version 0.3.3 \
+            --minimum-cli-version 0.3.8 \
             --out "release-assets/fennara-release-manifest-v${{ inputs.version }}.json"
 
       - name: Publish release
@@ -379,8 +379,10 @@ jobs:
           set -euo pipefail
 
           tag="v${VERSION}"
-          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::error::Release ${tag} already exists."
+          if ! gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/immutable-releases" >/dev/null 2>&1; then
+            echo "::error::Repository release immutability must be enabled before publishing a release."
             exit 1
           fi
 
@@ -389,22 +391,76 @@ jobs:
             echo "::error::No release assets found."
             exit 1
           fi
+          mapfile -t desired_assets < <(printf '%s\n' "${assets[@]##*/}" | sort)
+
+          if [[ "${PROMOTE_LATEST}" == "true" ]]; then
+            if ! gh release view latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "::error::The legacy mutable latest release is missing and cannot be recreated after enabling release immutability."
+              exit 1
+            fi
+            latest_immutable="$(
+              gh release view latest \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json isImmutable \
+                --jq '.isImmutable'
+            )"
+            if [[ "${latest_immutable}" != "false" ]]; then
+              echo "::error::The moving latest release must remain the pre-policy mutable release."
+              exit 1
+            fi
+          fi
 
           notes="Fennara Godot AI ${tag}
 
           Built from ${GITHUB_SHA}."
+          promotion_assets=("${assets[@]}")
 
-          gh release create "${tag}" "${assets[@]}" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --target "${GITHUB_SHA}" \
-            --title "Fennara Godot AI ${tag}" \
-            --notes "${notes}"
+          if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            read -r exact_immutable exact_draft exact_prerelease < <(
+              gh release view "${tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json isImmutable,isDraft,isPrerelease \
+                --jq '[.isImmutable, .isDraft, .isPrerelease] | @tsv'
+            )
+            exact_tag_sha="$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')"
+            mapfile -t published_exact_assets < <(
+              gh release view "${tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json assets \
+                --jq '.assets[].name' | sort
+            )
+            if [[ "${exact_immutable}" != "true" || "${exact_draft}" != "false" || "${exact_prerelease}" != "false" || "${exact_tag_sha}" != "${GITHUB_SHA}" ]] ||
+              ! diff -u <(printf '%s\n' "${desired_assets[@]}") <(printf '%s\n' "${published_exact_assets[@]}"); then
+              echo "::error::Existing ${tag} release does not match this immutable release request."
+              exit 1
+            fi
+            exact_assets_dir="${RUNNER_TEMP}/exact-release-${VERSION}"
+            rm -rf "${exact_assets_dir}"
+            mkdir -p "${exact_assets_dir}"
+            gh release download "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --dir "${exact_assets_dir}"
+            node scripts/verify-published-assets.mjs \
+              --expected-dir release-assets \
+              --actual-dir "${exact_assets_dir}"
+            mapfile -t promotion_assets < <(find "${exact_assets_dir}" -maxdepth 1 -type f | sort)
+            echo "Resuming promotion from matching immutable release ${tag}."
+          else
+            gh release create "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${GITHUB_SHA}" \
+              --title "Fennara Godot AI ${tag}" \
+              --notes "${notes}" \
+              --draft
+            gh release upload "${tag}" "${assets[@]}" \
+              --repo "${GITHUB_REPOSITORY}"
+            gh release edit "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --draft=false
+          fi
+          gh release verify "${tag}" --repo "${GITHUB_REPOSITORY}"
 
           if [[ "${PROMOTE_LATEST}" == "true" ]]; then
-            if gh release view latest --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-              gh release delete latest --repo "${GITHUB_REPOSITORY}" --yes --cleanup-tag
-            fi
-
             git tag --force latest "${GITHUB_SHA}"
             git push --force origin refs/tags/latest
 
@@ -412,9 +468,27 @@ jobs:
 
             Currently points to ${tag}, built from ${GITHUB_SHA}."
 
-            gh release create latest "${assets[@]}" \
+            gh release upload latest "${promotion_assets[@]}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber
+            mapfile -t desired_latest_assets < <(printf '%s\n' "${promotion_assets[@]##*/}" | sort)
+            mapfile -t published_latest_assets < <(
+              gh release view latest \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json assets \
+                --jq '.assets[].name' | sort
+            )
+            for published_asset in "${published_latest_assets[@]}"; do
+              if ! printf '%s\n' "${desired_latest_assets[@]}" | grep -Fxq "${published_asset}"; then
+                gh release delete-asset latest "${published_asset}" \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --yes
+              fi
+            done
+            gh release edit latest \
               --repo "${GITHUB_REPOSITORY}" \
               --target "${GITHUB_SHA}" \
               --title "Fennara Godot AI latest" \
-              --notes "${latest_notes}"
+              --notes "${latest_notes}" \
+              --latest
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,6 +414,7 @@ jobs:
 
           Built from ${GITHUB_SHA}."
           promotion_assets=("${assets[@]}")
+          reconcile_draft=false
 
           if gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
             read -r exact_immutable exact_draft exact_prerelease < <(
@@ -423,17 +424,63 @@ jobs:
                 --jq '[.isImmutable, .isDraft, .isPrerelease] | @tsv'
             )
             exact_tag_sha="$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}')"
+            exact_target="$(
+              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" \
+                --jq '.target_commitish'
+            )"
             mapfile -t published_exact_assets < <(
               gh release view "${tag}" \
                 --repo "${GITHUB_REPOSITORY}" \
                 --json assets \
                 --jq '.assets[].name' | sort
             )
-            if [[ "${exact_immutable}" != "true" || "${exact_draft}" != "false" || "${exact_prerelease}" != "false" || "${exact_tag_sha}" != "${GITHUB_SHA}" ]] ||
+            if [[ "${exact_immutable}" == "false" && "${exact_draft}" == "true" && "${exact_prerelease}" == "false" && "${exact_target}" == "${GITHUB_SHA}" ]]; then
+              reconcile_draft=true
+              echo "Resuming matching draft release ${tag}."
+            elif [[ "${exact_immutable}" != "true" || "${exact_draft}" != "false" || "${exact_prerelease}" != "false" || "${exact_tag_sha}" != "${GITHUB_SHA}" ]] ||
               ! diff -u <(printf '%s\n' "${desired_assets[@]}") <(printf '%s\n' "${published_exact_assets[@]}"); then
               echo "::error::Existing ${tag} release does not match this immutable release request."
               exit 1
+            else
+              exact_assets_dir="${RUNNER_TEMP}/exact-release-${VERSION}"
+              rm -rf "${exact_assets_dir}"
+              mkdir -p "${exact_assets_dir}"
+              gh release download "${tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --dir "${exact_assets_dir}"
+              node scripts/verify-published-assets.mjs \
+                --expected-dir release-assets \
+                --actual-dir "${exact_assets_dir}"
+              mapfile -t promotion_assets < <(find "${exact_assets_dir}" -maxdepth 1 -type f | sort)
+              echo "Resuming promotion from matching immutable release ${tag}."
             fi
+          else
+            gh release create "${tag}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${GITHUB_SHA}" \
+              --title "Fennara Godot AI ${tag}" \
+              --notes "${notes}" \
+              --draft
+            reconcile_draft=true
+          fi
+
+          if [[ "${reconcile_draft}" == "true" ]]; then
+            gh release upload "${tag}" "${assets[@]}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber
+            mapfile -t draft_assets < <(
+              gh release view "${tag}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json assets \
+                --jq '.assets[].name' | sort
+            )
+            for draft_asset in "${draft_assets[@]}"; do
+              if ! printf '%s\n' "${desired_assets[@]}" | grep -Fxq "${draft_asset}"; then
+                gh release delete-asset "${tag}" "${draft_asset}" \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --yes
+              fi
+            done
             exact_assets_dir="${RUNNER_TEMP}/exact-release-${VERSION}"
             rm -rf "${exact_assets_dir}"
             mkdir -p "${exact_assets_dir}"
@@ -443,27 +490,14 @@ jobs:
             node scripts/verify-published-assets.mjs \
               --expected-dir release-assets \
               --actual-dir "${exact_assets_dir}"
-            mapfile -t promotion_assets < <(find "${exact_assets_dir}" -maxdepth 1 -type f | sort)
-            echo "Resuming promotion from matching immutable release ${tag}."
-          else
-            gh release create "${tag}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --target "${GITHUB_SHA}" \
-              --title "Fennara Godot AI ${tag}" \
-              --notes "${notes}" \
-              --draft
-            gh release upload "${tag}" "${assets[@]}" \
-              --repo "${GITHUB_REPOSITORY}"
             gh release edit "${tag}" \
               --repo "${GITHUB_REPOSITORY}" \
               --draft=false
+            mapfile -t promotion_assets < <(find "${exact_assets_dir}" -maxdepth 1 -type f | sort)
           fi
           gh release verify "${tag}" --repo "${GITHUB_REPOSITORY}"
 
           if [[ "${PROMOTE_LATEST}" == "true" ]]; then
-            git tag --force latest "${GITHUB_SHA}"
-            git push --force origin refs/tags/latest
-
             latest_notes="Latest Fennara Godot AI release.
 
             Currently points to ${tag}, built from ${GITHUB_SHA}."
@@ -482,13 +516,24 @@ jobs:
               if ! printf '%s\n' "${desired_latest_assets[@]}" | grep -Fxq "${published_asset}"; then
                 gh release delete-asset latest "${published_asset}" \
                   --repo "${GITHUB_REPOSITORY}" \
-                  --yes
+                --yes
               fi
             done
+            latest_assets_dir="${RUNNER_TEMP}/latest-release-${VERSION}"
+            rm -rf "${latest_assets_dir}"
+            mkdir -p "${latest_assets_dir}"
+            gh release download latest \
+              --repo "${GITHUB_REPOSITORY}" \
+              --dir "${latest_assets_dir}"
+            node scripts/verify-published-assets.mjs \
+              --expected-dir "$(dirname "${promotion_assets[0]}")" \
+              --actual-dir "${latest_assets_dir}"
             gh release edit latest \
               --repo "${GITHUB_REPOSITORY}" \
               --target "${GITHUB_SHA}" \
               --title "Fennara Godot AI latest" \
               --notes "${latest_notes}" \
               --latest
+            git tag --force latest "${GITHUB_SHA}"
+            git push --force origin refs/tags/latest
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,12 +362,14 @@ jobs:
           node scripts/check-linux-cef-runtime-release.mjs --assets-dir release-assets
 
       - name: Write release manifest
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           node scripts/write-release-manifest.mjs \
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
             --minimum-cli-version 0.3.8 \
-            --out "release-assets/fennara-release-manifest-v${{ inputs.version }}.json"
+            --out "release-assets/fennara-release-manifest-v${VERSION}.json"
 
       - name: Require immutable GitHub releases
         env:

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -1,0 +1,712 @@
+name: Staging Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Open pull request number to build."
+        required: true
+        type: string
+      base_version:
+        description: "Planned stable version, for example 0.3.9."
+        required: true
+        type: string
+      candidate:
+        description: "Positive candidate number for this pull request."
+        required: true
+        type: string
+      source_commit:
+        description: "Optional full PR head SHA used as an optimistic lock."
+        required: false
+        default: ""
+        type: string
+      publish:
+        description: "Publish the validated candidate and advance its PR channel. Leave off for a dry run."
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: staging-release-pr-${{ inputs.pull_request }}
+  cancel-in-progress: true
+
+jobs:
+  resolve:
+    name: resolve trusted candidate identity
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.candidate.outputs.version }}
+      channel: ${{ steps.candidate.outputs.channel }}
+      pull_request: ${{ steps.candidate.outputs.pull_request }}
+      source_commit: ${{ steps.candidate.outputs.source_commit }}
+      source_repository: ${{ steps.candidate.outputs.source_repository }}
+      release_tag: ${{ steps.candidate.outputs.release_tag }}
+
+    steps:
+      - name: Require the trusted main workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Staging releases must be dispatched from main."
+            exit 1
+          fi
+
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Resolve the frozen PR head
+        id: source
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+          REQUESTED_SOURCE_COMMIT: ${{ inputs.source_commit }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::pull_request must be a positive integer."
+            exit 1
+          fi
+
+          read -r state head_sha head_repository <<< "$(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+              --jq '[.state, .head.sha, .head.repo.full_name] | @tsv'
+          )"
+          if [[ "${state}" != "open" || ! "${head_sha}" =~ ^[0-9a-f]{40}$ || -z "${head_repository}" ]]; then
+            echo "::error::Pull request ${PR_NUMBER} is not an open buildable pull request."
+            exit 1
+          fi
+          if [[ -n "${REQUESTED_SOURCE_COMMIT}" && "${REQUESTED_SOURCE_COMMIT}" != "${head_sha}" ]]; then
+            echo "::error::Requested source commit does not match the current PR head ${head_sha}."
+            exit 1
+          fi
+
+          echo "source_commit=${head_sha}" >> "${GITHUB_OUTPUT}"
+          echo "source_repository=${head_repository}" >> "${GITHUB_OUTPUT}"
+
+      - name: Write staging candidate identity
+        id: candidate
+        env:
+          BASE_VERSION: ${{ inputs.base_version }}
+          PR_NUMBER: ${{ inputs.pull_request }}
+          CANDIDATE_NUMBER: ${{ inputs.candidate }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.source_commit }}
+          SOURCE_REPOSITORY: ${{ steps.source.outputs.source_repository }}
+        run: |
+          node scripts/write-staging-candidate.mjs \
+            --base-version "${BASE_VERSION}" \
+            --pull-request "${PR_NUMBER}" \
+            --candidate "${CANDIDATE_NUMBER}" \
+            --source-commit "${SOURCE_COMMIT}" \
+            --source-repository "${SOURCE_REPOSITORY}" \
+            --out staging-metadata/candidate.json \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Upload trusted candidate identity
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-staging-candidate-metadata
+          path: staging-metadata/candidate.json
+          if-no-files-found: error
+
+  linux-cef-runtime:
+    name: prepare Linux CEF runtime
+    runs-on: ubuntu-latest
+    needs: resolve
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout exact candidate source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.resolve.outputs.source_repository }}
+          ref: ${{ needs.resolve.outputs.source_commit }}
+          persist-credentials: false
+
+      - name: Verify exact source commit
+        shell: bash
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ needs.resolve.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SOURCE_COMMIT}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Linux CEF packaging dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential bzip2 binutils
+
+      - name: Prepare Linux CEF SDK
+        id: linux_cef_sdk
+        run: |
+          node scripts/prepare-linux-cef-sdk.mjs \
+            --out-dir "${RUNNER_TEMP}/fennara-cef-sdk" \
+            --download-dir "${RUNNER_TEMP}/fennara-cef-download"
+
+      - name: Build Linux CEF runtime asset
+        run: |
+          node scripts/prepare-linux-cef-runtime.mjs \
+            --cef-root "${{ steps.linux_cef_sdk.outputs.cef_root }}" \
+            --version "139.0.28+g55ab8a8+chromium-139.0.7258.139" \
+            --out-dir dist/linux-cef-runtime-release \
+            --write-manifest dist/generated-linux-cef-manifest/linux-cef.json
+
+      - name: Validate Linux CEF runtime asset
+        run: |
+          cp dist/generated-linux-cef-manifest/linux-cef.json local/webview-runtimes/linux-cef.json
+          node scripts/check-linux-cef-runtime-release.mjs --assets-dir dist/linux-cef-runtime-release
+
+      - name: Upload generated Linux CEF manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-generated-linux-cef-manifest
+          path: dist/generated-linux-cef-manifest/linux-cef.json
+          if-no-files-found: error
+
+      - name: Upload Linux CEF runtime asset
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-release-linux-cef-runtime
+          path: dist/linux-cef-runtime-release/*.zip
+          if-no-files-found: error
+
+  package:
+    name: package ${{ matrix.platform }} ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    needs: [resolve, linux-cef-runtime]
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            arch: x86_64
+            os: windows-latest
+          - platform: linux
+            arch: x86_64
+            os: ubuntu-latest
+          - platform: macos
+            arch: arm64
+            os: macos-latest
+
+    steps:
+      - name: Checkout exact candidate source
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ needs.resolve.outputs.source_repository }}
+          ref: ${{ needs.resolve.outputs.source_commit }}
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Verify exact source commit
+        shell: bash
+        env:
+          EXPECTED_SOURCE_COMMIT: ${{ needs.resolve.outputs.source_commit }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${EXPECTED_SOURCE_COMMIT}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Stamp candidate version in the runner workspace
+        run: |
+          node scripts/set-version.mjs "${{ needs.resolve.outputs.version }}" \
+            --track staging \
+            --channel "${{ needs.resolve.outputs.channel }}" \
+            --source-commit "${{ needs.resolve.outputs.source_commit }}"
+
+      - name: Check candidate version sync
+        run: node scripts/check-version.mjs
+
+      - name: Download generated Linux CEF manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: fennara-generated-linux-cef-manifest
+          path: generated-linux-cef-manifest
+
+      - name: Use generated Linux CEF manifest
+        shell: bash
+        run: cp generated-linux-cef-manifest/linux-cef.json local/webview-runtimes/linux-cef.json
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install SCons
+        run: pip install scons
+
+      - name: Install Linux build dependencies
+        if: matrix.platform == 'linux'
+        run: sudo apt-get update && sudo apt-get install -y build-essential bzip2 pkg-config ripgrep
+
+      - name: Install Windows ripgrep
+        if: matrix.platform == 'windows'
+        shell: pwsh
+        run: choco install ripgrep -y --no-progress
+
+      - name: Install macOS ripgrep
+        if: matrix.platform == 'macos'
+        run: brew install ripgrep
+
+      - name: Prepare Linux CEF SDK
+        if: matrix.platform == 'linux'
+        id: linux_cef_sdk
+        run: |
+          node scripts/prepare-linux-cef-sdk.mjs \
+            --out-dir "${RUNNER_TEMP}/fennara-cef-sdk" \
+            --download-dir "${RUNNER_TEMP}/fennara-cef-download"
+
+      - name: Build GDExtension
+        working-directory: fennara-cpp
+        env:
+          FENNARA_CEF_ROOT: ${{ steps.linux_cef_sdk.outputs.cef_root }}
+        run: scons platform=${{ matrix.platform }} target=editor
+
+      - name: Build local tools
+        working-directory: local
+        run: cargo build --release --locked
+
+      - name: Assemble candidate archives
+        run: node scripts/package-preview.mjs --platform ${{ matrix.platform }} --arch ${{ matrix.arch }}
+
+      - name: Upload candidate archives
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-release-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/*.zip
+          if-no-files-found: error
+
+      - name: Upload addon part
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-addon-part-${{ matrix.platform }}-${{ matrix.arch }}
+          path: dist/addon-part-${{ matrix.platform }}-${{ matrix.arch }}/
+          if-no-files-found: error
+
+  addon:
+    name: package all-platform addon
+    runs-on: ubuntu-latest
+    needs: [resolve, package]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout trusted packaging tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download addon parts without merging them
+        uses: actions/download-artifact@v4
+        with:
+          path: addon-parts
+          pattern: fennara-addon-part-*
+
+      - name: Assemble all-platform addon archive
+        run: |
+          node scripts/package-addon-all.mjs \
+            --parts-dir addon-parts \
+            --version "${{ needs.resolve.outputs.version }}"
+
+      - name: Upload all-platform addon archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-release-addon
+          path: dist/fennara-addon-v${{ needs.resolve.outputs.version }}.zip
+          if-no-files-found: error
+
+  assemble:
+    name: validate candidate release assets
+    runs-on: ubuntu-latest
+    needs: [resolve, linux-cef-runtime, package, addon]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout trusted validation tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download candidate identity
+        uses: actions/download-artifact@v4
+        with:
+          name: fennara-staging-candidate-metadata
+          path: staging-metadata
+
+      - name: Download candidate release archives
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+          pattern: fennara-release-*
+          merge-multiple: true
+
+      - name: Download addon parts for cross-platform validation
+        uses: actions/download-artifact@v4
+        with:
+          path: addon-parts
+          pattern: fennara-addon-part-*
+
+      - name: Download generated Linux CEF manifest
+        uses: actions/download-artifact@v4
+        with:
+          name: fennara-generated-linux-cef-manifest
+          path: generated-linux-cef-manifest
+
+      - name: Rename manifest-managed packages
+        shell: bash
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          local_assets=(release-assets/fennara-local-*-v"${VERSION}".zip)
+          if [[ "${#local_assets[@]}" -ne 3 ]]; then
+            echo "::error::Expected three local archives for ${VERSION}."
+            exit 1
+          fi
+          for asset in "${local_assets[@]}"; do
+            renamed="${asset/release-assets\/fennara-local-/release-assets\/fennara-release-local-}"
+            mv "${asset}" "${renamed}"
+          done
+
+          mv "release-assets/fennara-addon-v${VERSION}.zip" \
+            "release-assets/fennara-release-addon-v${VERSION}.zip"
+
+      - name: Validate Linux CEF runtime asset
+        run: |
+          cp generated-linux-cef-manifest/linux-cef.json local/webview-runtimes/linux-cef.json
+          node scripts/check-linux-cef-runtime-release.mjs --assets-dir release-assets
+
+      - name: Write exact release manifest
+        run: |
+          node scripts/write-release-manifest.mjs \
+            --version "${{ needs.resolve.outputs.version }}" \
+            --assets-dir release-assets \
+            --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
+            --release-identity staging-metadata/candidate.json \
+            --minimum-cli-version 0.3.8 \
+            --out "release-assets/fennara-release-manifest-v${{ needs.resolve.outputs.version }}.json"
+
+      - name: Validate complete candidate asset set
+        run: |
+          node scripts/validate-staging-build.mjs \
+            --candidate staging-metadata/candidate.json \
+            --assets-dir release-assets \
+            --addon-parts-dir addon-parts \
+            --release-manifest "release-assets/fennara-release-manifest-v${{ needs.resolve.outputs.version }}.json" \
+            --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json
+
+      - name: Write channel pointer
+        run: |
+          node scripts/write-staging-pointer.mjs \
+            --candidate staging-metadata/candidate.json \
+            --manifest "release-assets/fennara-release-manifest-v${{ needs.resolve.outputs.version }}.json" \
+            --out "staging-metadata/fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json"
+
+      - name: Assemble publication bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p staging-bundle/release-assets staging-bundle/metadata
+          cp release-assets/* staging-bundle/release-assets/
+          cp staging-metadata/candidate.json staging-bundle/metadata/candidate.json
+          cp staging-metadata/fennara-staging-channel-*.json staging-bundle/metadata/channel-pointer.json
+          cp generated-linux-cef-manifest/linux-cef.json staging-bundle/metadata/linux-cef.json
+
+      - name: Upload validated staging candidate
+        uses: actions/upload-artifact@v4
+        with:
+          name: fennara-staging-candidate-${{ needs.resolve.outputs.version }}
+          path: staging-bundle/
+          if-no-files-found: error
+
+  publish:
+    name: publish immutable candidate and advance channel
+    runs-on: ubuntu-latest
+    needs: [resolve, assemble]
+    if: inputs.publish
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - name: Checkout trusted publication tools
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download validated publication bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: fennara-staging-candidate-${{ needs.resolve.outputs.version }}
+          path: staging-bundle
+
+      - name: Revalidate untrusted candidate artifacts as data
+        run: node scripts/validate-staging-publish-bundle.mjs --bundle staging-bundle
+
+      - name: Require immutable GitHub releases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh api \
+            -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/immutable-releases" >/dev/null 2>&1; then
+            echo "::error::Repository release immutability must be enabled before publishing staging candidates."
+            exit 1
+          fi
+
+      - name: Publish or verify immutable candidate release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
+          PULL_REQUEST: ${{ needs.resolve.outputs.pull_request }}
+          SOURCE_COMMIT: ${{ needs.resolve.outputs.source_commit }}
+          SOURCE_REPOSITORY: ${{ needs.resolve.outputs.source_repository }}
+        run: |
+          set -euo pipefail
+          expected_dir="staging-bundle/release-assets"
+          remote_dir="${RUNNER_TEMP}/published-${VERSION}"
+
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            read -r is_draft is_prerelease is_immutable target_commitish <<< "$(
+              gh release view "${RELEASE_TAG}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --json isDraft,isPrerelease,isImmutable,targetCommitish \
+                --jq '[.isDraft, .isPrerelease, .isImmutable, .targetCommitish] | @tsv'
+            )"
+            if [[ "${target_commitish}" != "${SOURCE_COMMIT}" || "${is_prerelease}" != "true" ]]; then
+              echo "::error::Existing ${RELEASE_TAG} has conflicting release metadata."
+              exit 1
+            fi
+            if [[ "${is_draft}" == "true" ]]; then
+              gh release delete "${RELEASE_TAG}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --yes \
+                --cleanup-tag
+            elif [[ "${is_immutable}" != "true" ]]; then
+              echo "::error::Existing ${RELEASE_TAG} is published but not immutable."
+              exit 1
+            fi
+          fi
+
+          if ! gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            mapfile -t assets < <(find "${expected_dir}" -maxdepth 1 -type f | sort)
+            notes="Testing-only Fennara staging candidate ${VERSION}.
+
+          Channel: ${CHANNEL}
+          Pull request: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PULL_REQUEST}
+          Source: ${SOURCE_REPOSITORY}@${SOURCE_COMMIT}
+          Supported packages: Windows x86_64, Linux x86_64, macOS arm64
+          Workflow: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            gh release create "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${SOURCE_COMMIT}" \
+              --title "Fennara staging ${VERSION}" \
+              --notes "${notes}" \
+              --draft \
+              --prerelease
+            gh release upload "${RELEASE_TAG}" "${assets[@]}" \
+              --repo "${GITHUB_REPOSITORY}"
+            gh release edit "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --draft=false \
+              --prerelease
+          fi
+
+          gh release verify "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}"
+
+          rm -rf "${remote_dir}"
+          mkdir -p "${remote_dir}"
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --dir "${remote_dir}"
+          node scripts/verify-published-assets.mjs \
+            --expected-dir "${expected_dir}" \
+            --actual-dir "${remote_dir}"
+
+      - name: Smoke test public release downloads
+        env:
+          RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+        run: |
+          node scripts/smoke-public-release.mjs \
+            --repository "${GITHUB_REPOSITORY}" \
+            --release-tag "${RELEASE_TAG}" \
+            --expected-dir staging-bundle/release-assets \
+            --download-dir "${RUNNER_TEMP}/public-${{ needs.resolve.outputs.version }}"
+
+      - name: Read current channel pointer
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL_REF: fennara-staging/${{ needs.resolve.outputs.channel }}
+          POINTER_NAME: fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json
+        run: |
+          set -euo pipefail
+          mkdir -p current-channel
+          if gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/contents/${POINTER_NAME}" \
+            -f ref="${CHANNEL_REF}" \
+            -H "Accept: application/vnd.github.raw+json" \
+            > "current-channel/${POINTER_NAME}" 2>/dev/null; then
+            echo "Loaded ${CHANNEL_REF}."
+          else
+            rm -f "current-channel/${POINTER_NAME}"
+          fi
+
+      - name: Check monotonic channel advancement
+        id: channel
+        run: |
+          node scripts/check-staging-channel-advance.mjs \
+            --current "current-channel/fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json" \
+            --next staging-bundle/metadata/channel-pointer.json \
+            --github-output "${GITHUB_OUTPUT}"
+
+      - name: Advance the per-PR staging pointer last
+        if: steps.channel.outputs.action != 'noop'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL_REF: fennara-staging/${{ needs.resolve.outputs.channel }}
+          VERSION: ${{ needs.resolve.outputs.version }}
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
+          SOURCE_COMMIT: ${{ needs.resolve.outputs.source_commit }}
+          POINTER_NAME: fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json
+        run: |
+          set -euo pipefail
+          pointer="staging-bundle/metadata/channel-pointer.json"
+          cp "${pointer}" "${RUNNER_TEMP}/${POINTER_NAME}"
+
+          rm -rf channel-recheck
+          mkdir -p channel-recheck
+          if gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/contents/${POINTER_NAME}" \
+            -f ref="${CHANNEL_REF}" \
+            -H "Accept: application/vnd.github.raw+json" \
+            > "channel-recheck/${POINTER_NAME}" 2>/dev/null; then
+            echo "Rechecked ${CHANNEL_REF}."
+          else
+            rm -f "channel-recheck/${POINTER_NAME}"
+          fi
+          action="$(
+            node scripts/check-staging-channel-advance.mjs \
+              --current "channel-recheck/${POINTER_NAME}" \
+              --next "${pointer}"
+          )"
+          if [[ "${action}" == "noop" ]]; then
+            exit 0
+          fi
+
+          if ! gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/git/ref/heads/${CHANNEL_REF}" >/dev/null 2>&1; then
+            gh api --method POST \
+              "repos/${GITHUB_REPOSITORY}/git/refs" \
+              --raw-field ref="refs/heads/${CHANNEL_REF}" \
+              --raw-field sha="${GITHUB_SHA}" >/dev/null
+          fi
+
+          current_blob_sha="$(
+            gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/contents/${POINTER_NAME}" \
+              -f ref="${CHANNEL_REF}" \
+              --jq '.sha' 2>/dev/null || true
+          )"
+          content="$(base64 -w 0 < "${RUNNER_TEMP}/${POINTER_NAME}")"
+          update_args=(
+            --method PUT
+            "repos/${GITHUB_REPOSITORY}/contents/${POINTER_NAME}"
+            --raw-field message="chore(release): advance ${CHANNEL} to ${VERSION}"
+            --raw-field content="${content}"
+            --raw-field branch="${CHANNEL_REF}"
+          )
+          if [[ -n "${current_blob_sha}" ]]; then
+            update_args+=(--raw-field sha="${current_blob_sha}")
+          fi
+          gh api "${update_args[@]}" >/dev/null
+
+      - name: Verify active channel pointer
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHANNEL_REF: fennara-staging/${{ needs.resolve.outputs.channel }}
+          POINTER_NAME: fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json
+        run: |
+          set -euo pipefail
+          rm -rf verified-channel
+          mkdir -p verified-channel
+          gh api --method GET \
+            "repos/${GITHUB_REPOSITORY}/contents/${POINTER_NAME}" \
+            -f ref="${CHANNEL_REF}" \
+            -H "Accept: application/vnd.github.raw+json" \
+            > "verified-channel/${POINTER_NAME}"
+          cmp staging-bundle/metadata/channel-pointer.json "verified-channel/${POINTER_NAME}"

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -239,11 +239,15 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Stamp candidate version in the runner workspace
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
+          SOURCE_COMMIT: ${{ needs.resolve.outputs.source_commit }}
         run: |
-          node scripts/set-version.mjs "${{ needs.resolve.outputs.version }}" \
+          node scripts/set-version.mjs "${VERSION}" \
             --track staging \
-            --channel "${{ needs.resolve.outputs.channel }}" \
-            --source-commit "${{ needs.resolve.outputs.source_commit }}"
+            --channel "${CHANNEL}" \
+            --source-commit "${SOURCE_COMMIT}"
 
       - name: Check candidate version sync
         run: node scripts/check-version.mjs
@@ -345,10 +349,12 @@ jobs:
           pattern: fennara-addon-part-*
 
       - name: Assemble all-platform addon archive
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           node scripts/package-addon-all.mjs \
             --parts-dir addon-parts \
-            --version "${{ needs.resolve.outputs.version }}"
+            --version "${VERSION}"
 
       - name: Upload all-platform addon archive
         uses: actions/upload-artifact@v4
@@ -433,30 +439,37 @@ jobs:
           node scripts/check-linux-cef-runtime-release.mjs --assets-dir release-assets
 
       - name: Write exact release manifest
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           node scripts/write-release-manifest.mjs \
-            --version "${{ needs.resolve.outputs.version }}" \
+            --version "${VERSION}" \
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
             --release-identity staging-metadata/candidate.json \
             --minimum-cli-version 0.3.8 \
-            --out "release-assets/fennara-release-manifest-v${{ needs.resolve.outputs.version }}.json"
+            --out "release-assets/fennara-release-manifest-v${VERSION}.json"
 
       - name: Validate complete candidate asset set
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           node scripts/validate-staging-build.mjs \
             --candidate staging-metadata/candidate.json \
             --assets-dir release-assets \
             --addon-parts-dir addon-parts \
-            --release-manifest "release-assets/fennara-release-manifest-v${{ needs.resolve.outputs.version }}.json" \
+            --release-manifest "release-assets/fennara-release-manifest-v${VERSION}.json" \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json
 
       - name: Write channel pointer
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
         run: |
           node scripts/write-staging-pointer.mjs \
             --candidate staging-metadata/candidate.json \
-            --manifest "release-assets/fennara-release-manifest-v${{ needs.resolve.outputs.version }}.json" \
-            --out "staging-metadata/fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json"
+            --manifest "release-assets/fennara-release-manifest-v${VERSION}.json" \
+            --out "staging-metadata/fennara-staging-channel-${CHANNEL}.json"
 
       - name: Assemble publication bundle
         shell: bash

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -32,7 +32,7 @@ permissions:
 
 concurrency:
   group: staging-release-pr-${{ inputs.pull_request }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   resolve:
@@ -526,9 +526,13 @@ jobs:
       - name: Require immutable GitHub releases
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
         run: |
           set -euo pipefail
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::RELEASE_ADMIN_TOKEN must provide repository Administration read access for the immutable-release preflight."
+            exit 1
+          fi
           if ! gh api \
             -H "X-GitHub-Api-Version: 2026-03-10" \
             "repos/${GITHUB_REPOSITORY}/immutable-releases" >/dev/null 2>&1; then

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -598,12 +598,13 @@ jobs:
       - name: Smoke test public release downloads
         env:
           RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
+          VERSION: ${{ needs.resolve.outputs.version }}
         run: |
           node scripts/smoke-public-release.mjs \
             --repository "${GITHUB_REPOSITORY}" \
             --release-tag "${RELEASE_TAG}" \
             --expected-dir staging-bundle/release-assets \
-            --download-dir "${RUNNER_TEMP}/public-${{ needs.resolve.outputs.version }}"
+            --download-dir "${RUNNER_TEMP}/public-${VERSION}"
 
       - name: Read current channel pointer
         shell: bash
@@ -626,9 +627,11 @@ jobs:
 
       - name: Check monotonic channel advancement
         id: channel
+        env:
+          CHANNEL: ${{ needs.resolve.outputs.channel }}
         run: |
           node scripts/check-staging-channel-advance.mjs \
-            --current "current-channel/fennara-staging-channel-${{ needs.resolve.outputs.channel }}.json" \
+            --current "current-channel/fennara-staging-channel-${CHANNEL}.json" \
             --next staging-bundle/metadata/channel-pointer.json \
             --github-output "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -166,9 +166,11 @@ jobs:
             --download-dir "${RUNNER_TEMP}/fennara-cef-download"
 
       - name: Build Linux CEF runtime asset
+        env:
+          CEF_ROOT: ${{ steps.linux_cef_sdk.outputs.cef_root }}
         run: |
           node scripts/prepare-linux-cef-runtime.mjs \
-            --cef-root "${{ steps.linux_cef_sdk.outputs.cef_root }}" \
+            --cef-root "${CEF_ROOT}" \
             --version "139.0.28+g55ab8a8+chromium-139.0.7258.139" \
             --out-dir dist/linux-cef-runtime-release \
             --write-manifest dist/generated-linux-cef-manifest/linux-cef.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,9 +308,9 @@ still apply in both modes.
 `fennara update` is the normal project update command. It reads the installed
 addon release identity, resolves stable latest or that addon's isolated staging
 channel, and freezes the result to one exact immutable version. It first checks
-that release manifest's per-platform CLI asset and, when newer, stages that CLI,
-lets the old process exit, replaces the installed CLI, and resumes with the same
-exact target. It then uses the same manifest-driven resolver and installer as
+the version of that release manifest's per-platform CLI asset and, when newer,
+stages that CLI, lets the old process exit, replaces the installed CLI, and
+resumes with the same target. It then uses the same manifest-driven resolver and installer as
 `fennara install`.
 
 Native staging discovery caches validated channel pointers for five minutes in

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,11 +305,18 @@ still apply in both modes.
 
 ## Updates
 
-`fennara update` is the normal project update command. It first checks the
-release manifest's per-platform CLI asset and, when newer, stages that CLI,
-lets the old process exit, replaces the installed CLI, and resumes the update
-with the new binary. It then uses the same manifest-driven resolver and
-installer as `fennara install`.
+`fennara update` is the normal project update command. It reads the installed
+addon release identity, resolves stable latest or that addon's isolated staging
+channel, and freezes the result to one exact immutable version. It first checks
+that release manifest's per-platform CLI asset and, when newer, stages that CLI,
+lets the old process exit, replaces the installed CLI, and resumes with the same
+exact target. It then uses the same manifest-driven resolver and installer as
+`fennara install`.
+
+Native staging discovery caches validated channel pointers for five minutes in
+shared Fennara app data and revalidates them with GitHub ETags. A missing
+channel is treated as no staging update, while malformed or cross-channel data
+fails closed and never replaces a valid cache entry.
 
 It can update:
 
@@ -327,6 +334,12 @@ If an MCP app is currently running a launcher, the update may keep that launcher
 and continue. The versioned runtime package is still updated, and future starts
 use the version from `current.json`. Use `fennara update --no-self-update` only
 when intentionally skipping the outer CLI check.
+
+Shared activation supports one active Fennara version at a time. The daemon
+rejects update shutdown while any other Godot project is still connected, which
+prevents a version switch underneath another editor. Exact version packages,
+the previous `current.json`, launcher snapshots, and the previous project addon
+are retained until the reopened editor validates the new GDExtension.
 
 The daemon currently allows one managed `runtime_session` scene globally across
 all connected Godot editors. A start request runs in the selected or

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,10 +105,13 @@ For a normal terminal update, close Godot for that project and run:
 fennara update --project path/to/project
 ```
 
-The CLI resolves the selected release, self-updates when the release requires a
-newer CLI, verifies the release assets, refreshes the addon and versioned local
-components, updates project guidance, and checks the platform webview
-prerequisite. Use `--version <version>` to select an exact release.
+Without `--version`, the CLI reads the installed addon identity. Stable addons
+resolve stable latest, while staging addons resolve only their `pr-<number>`
+channel. The moving selector is immediately frozen to one exact immutable
+version, including across CLI self-replacement. The CLI then verifies the
+release assets, refreshes the addon and versioned local components, updates
+project guidance, and checks the platform webview prerequisite. Use
+`--version <version>` to select an exact release explicitly.
 
 `--no-self-update` is intended for controlled automation or continuation after
 the CLI has already been replaced. Do not use it to bypass a release's minimum
@@ -126,6 +129,13 @@ Preparation downloads, verifies, and durably stages the addon. It does not
 close Godot, replace the live addon, switch the active runtime manifest, or
 restart the daemon. The Godot dock observes the operation receipt and asks the
 user before starting the detached close, replace, reopen, and validation step.
+The dock passes the exact version it already discovered, so pointer movement
+cannot change an in-progress update.
+
+Fennara supports one active shared runtime version at a time. Activation is
+blocked if another Fennara-enabled Godot editor remains connected to the shared
+daemon. Close the other editor, then retry. The previous local version and
+runtime pointer remain available for recovery without network access.
 
 `--prepare` is a low-level primitive for the Godot integration. Terminal users
 normally use `fennara update` with Godot already closed.
@@ -210,6 +220,13 @@ installed CLI:
 fennara self-update
 fennara self-update --version <version>
 ```
+
+Without `--version`, self-update preserves the active installation track:
+stable uses stable latest, and staging uses only its recorded PR channel.
+
+Staging never crosses into stable automatically. To leave staging deliberately,
+close Godot and run `fennara update --version <stable-version> --project <path>`.
+That exact stable release is validated before the shared active version changes.
 
 Use this when support requests it or when a project update reports that the
 installed CLI is too old to continue safely.

--- a/docs/release.md
+++ b/docs/release.md
@@ -20,6 +20,11 @@ Releases are manual. Do not publish from pull request workflows.
 
 `VERSION` is the source of truth.
 
+Release tooling accepts SemVer values. Stable releases use `X.Y.Z`. Staging
+candidates use an isolated pull-request prerelease such as
+`0.3.9-pr.101.2`, where `pr-101` is the staging channel and `2` is that
+channel's candidate number.
+
 To bump the repo version:
 
 ```bash
@@ -33,6 +38,21 @@ The script updates:
 - plugin version constants
 - Rust workspace package version under `local/`
 - `local/Cargo.lock`
+
+The addon also carries `addons/fennara/release.json`. Stable identity is
+written automatically by the normal command above. A staging build workspace
+uses the explicit identity inputs:
+
+```bash
+node scripts/set-version.mjs 0.3.9-pr.101.2 \
+  --track staging \
+  --channel pr-101 \
+  --source-commit <full-commit-sha>
+```
+
+The staging version, channel, source commit, and immutable release tag must
+agree. A prerelease addon without this identity is rejected. Existing stable
+addons from before `release.json` continue to default to the stable track.
 
 Check version sync:
 
@@ -178,6 +198,34 @@ per-platform `assets.cli` entry to update the installed CLI first, then resume
 the package update with `--no-self-update`. If self-update is not available for
 that release or install location, it should fail before installing packages and
 print a clear instruction to rerun `install.sh` or `install.ps1`.
+
+The optional release identity added to manifest schema 1 does not require a
+minimum CLI increase. Older schema-1 clients ignore unknown fields, while
+staging-aware clients validate the identity when it is present. A future
+release that depends on channel-aware activation or updater handoff must
+revisit the minimum CLI before publication.
+
+## Staging Identity And Discovery Contract
+
+Staging channels are isolated per pull request:
+
+| Value | PR 101 example |
+| --- | --- |
+| Channel | `pr-101` |
+| Candidate version | `0.3.9-pr.101.2` |
+| Immutable release | `v0.3.9-pr.101.2` |
+| Channel release | `staging-pr-101` |
+| Pointer asset | `fennara-staging-channel-pr-101.json` |
+
+The channel release contains only a small pointer to an immutable exact
+release. Release binaries never live under the moving channel name. The CLI
+can resolve this pointer with the internal version request
+`channel:pr-101`, then continues using only the exact immutable version.
+
+PR 101 and PR 125 therefore use different release tags and pointer assets.
+Updating one channel cannot redirect testers on the other channel. Publishing
+these releases and safely advancing their pointers belongs to the later
+staging workflow work, not this identity foundation.
 
 The shared addon zip contains every built GDExtension binary referenced by `godot_demo/addons/fennara/fennara.gdextension`. Godot loads the matching library for the user's OS and ignores the others.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -263,7 +263,7 @@ When publication is enabled, the trusted final job:
 7. Downloads the active pointer and verifies its exact contents.
 
 Runs for one pull request are serialized. Different pull requests use separate
-concurrency groups, release tags, and pointer refs. Retrying the same exact
+concurrency groups, release tags, and pointer refs. Retrying the same
 candidate verifies the existing immutable release instead of mixing files into
 it. The workflow never creates, uploads to, or promotes stable `latest`.
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -188,7 +188,7 @@ manifest whenever the release publishes one. The manifest records:
 - platform-specific shared runtime assets, currently Linux CEF
 
 The current manifest generator and release workflows use
-`minimum_cli_version: 0.3.3` by default. Normal package layout or asset name
+`minimum_cli_version: 0.3.8` by default. Normal package layout or asset name
 changes should be handled by manifest data, not by changing the outer CLI.
 Raise `minimum_cli_version` only when a release needs a new manifest schema or
 install primitive that older CLIs truly cannot perform.
@@ -274,6 +274,11 @@ The stable Release workflow updates that release in place and fails if it is
 missing or immutable. Exact stable and staging releases are created as drafts,
 receive all assets before publication, and must pass `gh release verify` after
 publication.
+
+The stable and staging publication jobs use the `RELEASE_ADMIN_TOKEN` repository
+secret only for the immutable-release preflight. Configure it as a fine-grained
+token with repository Administration read access. Asset publication continues
+to use the job-scoped `GITHUB_TOKEN` with contents write access.
 
 Staging-capable and stable release workflows use `minimum_cli_version: 0.3.8`.
 Channel handoff, exact-target preservation across CLI replacement, and safe

--- a/docs/release.md
+++ b/docs/release.md
@@ -214,18 +214,70 @@ Staging channels are isolated per pull request:
 | Channel | `pr-101` |
 | Candidate version | `0.3.9-pr.101.2` |
 | Immutable release | `v0.3.9-pr.101.2` |
-| Channel release | `staging-pr-101` |
-| Pointer asset | `fennara-staging-channel-pr-101.json` |
+| Channel ref | `fennara-staging/pr-101` |
+| Pointer file | `fennara-staging-channel-pr-101.json` |
 
-The channel release contains only a small pointer to an immutable exact
-release. Release binaries never live under the moving channel name. The CLI
-can resolve this pointer with the internal version request
+The per-channel Git ref contains only a small pointer file to an immutable
+exact release. Release binaries never live under the moving channel ref. The
+CLI can resolve this pointer with the internal version request
 `channel:pr-101`, then continues using only the exact immutable version.
 
 PR 101 and PR 125 therefore use different release tags and pointer assets.
 Updating one channel cannot redirect testers on the other channel. Publishing
-these releases and safely advancing their pointers belongs to the later
-staging workflow work, not this identity foundation.
+one channel never changes stable `latest` or another pull request's channel.
+
+## Staging Candidate Workflow
+
+The manual **Staging Release** workflow builds a candidate from the current
+head of an open pull request. Run it from `main` and provide:
+
+| Input | Meaning |
+| --- | --- |
+| `pull_request` | Open pull request to build |
+| `base_version` | Planned stable version, such as `0.3.9` |
+| `candidate` | Increasing candidate number for this pull request |
+| `source_commit` | Optional full SHA that must still be the pull request head |
+| `publish` | Off for artifact-only validation, on to publish the candidate |
+
+The workflow freezes the pull request head SHA before any platform build. The
+Windows, Linux, and macOS jobs check out that exact commit with read-only
+permissions, no persisted Git credentials, no release credentials, and no
+shared dependency caches. Candidate code can produce build artifacts, but it
+cannot publish a GitHub Release.
+
+Trusted repository scripts then validate the candidate identity, exact archive
+inventory, addon contents, platform package layout, release manifest, and every
+SHA-256 value. Publication remains disabled unless `publish` is explicitly
+selected.
+
+When publication is enabled, the trusted final job:
+
+1. Requires GitHub release immutability to be enabled for the repository.
+2. Revalidates the candidate artifacts as data.
+3. Creates a draft, uploads every asset, publishes it as the immutable
+   `v<exact-version>` prerelease, and verifies its release attestation.
+4. Downloads the published assets and compares their names and hashes.
+5. Rejects a backward or conflicting channel change.
+6. Updates the small `fennara-staging/pr-<number>` pointer ref last through a
+   conditional GitHub Contents API write.
+7. Downloads the active pointer and verifies its exact contents.
+
+Runs for one pull request are serialized. Different pull requests use separate
+concurrency groups, release tags, and pointer refs. Retrying the same exact
+candidate verifies the existing immutable release instead of mixing files into
+it. The workflow never creates, uploads to, or promotes stable `latest`.
+
+GitHub release immutability applies only to releases created after the setting
+is enabled. Fennara intentionally preserves the existing pre-policy `latest`
+release as the one mutable compatibility endpoint used by current installers.
+The stable Release workflow updates that release in place and fails if it is
+missing or immutable. Exact stable and staging releases are created as drafts,
+receive all assets before publication, and must pass `gh release verify` after
+publication.
+
+Staging-capable and stable release workflows use `minimum_cli_version: 0.3.8`.
+Channel handoff, exact-target preservation across CLI replacement, and safe
+shared-runtime activation depend on the updater behavior introduced in that CLI.
 
 The shared addon zip contains every built GDExtension binary referenced by `godot_demo/addons/fennara/fennara.gdextension`. Godot loads the matching library for the user's OS and ignores the others.
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -126,7 +126,11 @@ This is the quick map for contributors and coding agents working in this reposit
 | `scripts/check-version.mjs` | Checks version sync. |
 | `scripts/release-identity.mjs` | Shared Node validation and generation for SemVer release identity and per-PR staging pointers. |
 | `scripts/staging-candidate.mjs` | Trusted staging candidate identity generation and monotonic per-PR pointer decisions. |
-| `scripts/staging-*-validation.mjs` | Focused staging addon, archive, manifest, and publication-bundle validation. |
+| `scripts/staging-*-validation.mjs` / `scripts/staging-validation-files.mjs` | Focused staging addon, archive, manifest, shared filesystem, and publication-bundle validation. |
+| `scripts/validate-staging-build.mjs` / `scripts/validate-staging-publish-bundle.mjs` | Strict validation entrypoints for untrusted build outputs and the trusted publication bundle. |
+| `scripts/check-staging-channel-advance.mjs` | Applies monotonic and provenance checks before a staging channel pointer advances. |
+| `scripts/verify-published-assets.mjs` / `scripts/smoke-public-release.mjs` | Verify published asset bytes and public download behavior before pointer promotion. |
+| `scripts/release-targets.mjs` | Defines supported platform release targets and their packaged asset names. |
 | `scripts/write-staging-candidate.mjs` / `scripts/write-staging-pointer.mjs` | Write the frozen candidate identity and its small channel pointer. |
 | `scripts/sync-chat-ui.mjs` | Copies the buildless chat UI source into the addon payload. |
 | `scripts/sync-runtime.mjs` | Copies repo-root runtime helper source into the addon payload. |

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -50,6 +50,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `local/crates/fennara-cli/src/project_addon.rs` | Existing project-addon version and current-platform GDExtension library validation. |
 | `local/crates/fennara-cli/src/release_identity.rs` | Stable/staging addon identity, exact release selectors, pull-request channel validation, and legacy stable compatibility. |
 | `local/crates/fennara-cli/src/release_channel.rs` | Per-channel staging pointer validation and resolution to an immutable exact release. |
+| `local/crates/fennara-cli/src/release_manifest.rs` | Release manifest parsing, asset hash validation, identity binding, and platform package selection. |
 | `local/crates/fennara-cli/src/release_version.rs` | Shared CLI SemVer parsing and precedence used by manifests and release selection. |
 | `local/crates/fennara-cli/src/existing_addon_install.rs` | Exact-version adoption of an existing Asset Library or release addon without replacing project addon files. |
 | `local/crates/fennara-cli/src/daemon_setup.rs` | Shared daemon health check, exact-version readiness, and startup used by install and doctor. |

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -48,6 +48,9 @@ This is the quick map for contributors and coding agents working in this reposit
 | `local/crates/fennara-cli/src/operation.rs` | Public install/update operation coordinator, phases, and CLI handoff entry points. |
 | `local/crates/fennara-cli/src/operation/` | Focused operation journal, durable storage, diagnostic redaction, and test modules. |
 | `local/crates/fennara-cli/src/project_addon.rs` | Existing project-addon version and current-platform GDExtension library validation. |
+| `local/crates/fennara-cli/src/release_identity.rs` | Stable/staging addon identity, exact release selectors, pull-request channel validation, and legacy stable compatibility. |
+| `local/crates/fennara-cli/src/release_channel.rs` | Per-channel staging pointer validation and resolution to an immutable exact release. |
+| `local/crates/fennara-cli/src/release_version.rs` | Shared CLI SemVer parsing and precedence used by manifests and release selection. |
 | `local/crates/fennara-cli/src/existing_addon_install.rs` | Exact-version adoption of an existing Asset Library or release addon without replacing project addon files. |
 | `local/crates/fennara-cli/src/daemon_setup.rs` | Shared daemon health check, exact-version readiness, and startup used by install and doctor. |
 | `local/crates/fennara-cli/tests/operation_failures.rs` | Process-level failure, durable diagnostics, redaction, and fail-closed operation-log tests. |
@@ -73,6 +76,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `fennara-cpp/include/` | Public C++ headers. |
 | `fennara-cpp/src/` | C++ implementation. |
 | `fennara-cpp/src/setup/` | Native first-run setup state, release-manifest CLI bootstrap, hash verification, CLI launch, and durable operation progress reader. |
+| `fennara-cpp/src/release/version.cpp` | Native SemVer validation and precedence used by release/update discovery. |
 | `fennara-cpp/src/ui/setup_panel.cpp` | Webview-independent first-run setup panel with progress, retry, logs, and sanitized report actions. |
 | `fennara-cpp/vendor/cef/` | Official CEF 139 header snapshot used by the Linux OSR bridge. Runtime binaries stay outside the addon. |
 | `fennara-cpp/src/ui/webview_host*` | Native in-editor chat webview host and platform backends. |
@@ -91,6 +95,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | --- | --- |
 | `godot_demo/addons/fennara/fennara.gdextension` | Godot GDExtension registration file. |
 | `godot_demo/addons/fennara/VERSION` | Addon package version. |
+| `godot_demo/addons/fennara/release.json` | Packaged stable or staging identity, including exact version, release tag, channel, and staging source commit. |
 | `godot_demo/addons/fennara/bin/` | Built platform libraries. |
 | `godot_demo/addons/fennara/dist/` | Packaged web UI assets used by the in-editor chat webview. |
 | `godot_demo/addons/fennara/runtime/` | Synced packaged copy of `runtime/` shipped inside the addon. |
@@ -115,6 +120,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | --- | --- |
 | `scripts/set-version.mjs` | Updates versioned files across the repo. |
 | `scripts/check-version.mjs` | Checks version sync. |
+| `scripts/release-identity.mjs` | Shared Node validation and generation for SemVer release identity and per-PR staging pointers. |
 | `scripts/sync-chat-ui.mjs` | Copies the buildless chat UI source into the addon payload. |
 | `scripts/sync-runtime.mjs` | Copies repo-root runtime helper source into the addon payload. |
 | `scripts/package-preview.mjs` | Assembles addon, CLI, and local runtime preview/release zips after platform builds. |

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -77,6 +77,9 @@ This is the quick map for contributors and coding agents working in this reposit
 | `fennara-cpp/src/` | C++ implementation. |
 | `fennara-cpp/src/setup/` | Native first-run setup state, release-manifest CLI bootstrap, hash verification, CLI launch, and durable operation progress reader. |
 | `fennara-cpp/src/release/version.cpp` | Native SemVer validation and precedence used by release/update discovery. |
+| `fennara-cpp/src/release/identity.cpp` | Packaged stable/staging identity validation and legacy stable compatibility. |
+| `fennara-cpp/src/release/discovery.cpp` | Stable-latest and isolated staging-channel update discovery. |
+| `fennara-cpp/src/update/` | Exact-target update coordination, durable receipt discovery, close/install handoff, and recovery UI state. |
 | `fennara-cpp/src/ui/setup_panel.cpp` | Webview-independent first-run setup panel with progress, retry, logs, and sanitized report actions. |
 | `fennara-cpp/vendor/cef/` | Official CEF 139 header snapshot used by the Linux OSR bridge. Runtime binaries stay outside the addon. |
 | `fennara-cpp/src/ui/webview_host*` | Native in-editor chat webview host and platform backends. |
@@ -121,6 +124,9 @@ This is the quick map for contributors and coding agents working in this reposit
 | `scripts/set-version.mjs` | Updates versioned files across the repo. |
 | `scripts/check-version.mjs` | Checks version sync. |
 | `scripts/release-identity.mjs` | Shared Node validation and generation for SemVer release identity and per-PR staging pointers. |
+| `scripts/staging-candidate.mjs` | Trusted staging candidate identity generation and monotonic per-PR pointer decisions. |
+| `scripts/staging-*-validation.mjs` | Focused staging addon, archive, manifest, and publication-bundle validation. |
+| `scripts/write-staging-candidate.mjs` / `scripts/write-staging-pointer.mjs` | Write the frozen candidate identity and its small channel pointer. |
 | `scripts/sync-chat-ui.mjs` | Copies the buildless chat UI source into the addon payload. |
 | `scripts/sync-runtime.mjs` | Copies repo-root runtime helper source into the addon payload. |
 | `scripts/package-preview.mjs` | Assembles addon, CLI, and local runtime preview/release zips after platform builds. |
@@ -134,6 +140,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `.github/workflows/local-build.yml` | Rust local package build check. |
 | `.github/workflows/package-preview.yml` | Manual package preview artifacts, including a test-only Linux CEF runtime artifact for Linux chat smoke tests. |
 | `.github/workflows/release.yml` | Manual GitHub release publishing, including generated Linux CEF runtime packaging, release manifest generation, and final asset validation. |
+| `.github/workflows/staging-release.yml` | Manual exact-SHA staging build, validation-only dry run, immutable prerelease publication, and per-PR pointer advancement. |
 
 ## Where To Change Things
 

--- a/fennara-cpp/include/fennara/release/discovery.hpp
+++ b/fennara-cpp/include/fennara/release/discovery.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "fennara/release/identity.hpp"
+
+#include <godot_cpp/variant/string.hpp>
+
+namespace fennara::release_discovery {
+
+struct Result {
+    bool success = false;
+    bool update_available = false;
+    release_identity::Identity current;
+    godot::String target_version;
+    godot::String target_release_tag;
+    godot::String target_source_commit;
+    godot::String target_manifest_sha256;
+    godot::String detail;
+    godot::String error;
+};
+
+Result check(int timeout_ms);
+
+} // namespace fennara::release_discovery

--- a/fennara-cpp/include/fennara/release/discovery.hpp
+++ b/fennara-cpp/include/fennara/release/discovery.hpp
@@ -4,10 +4,13 @@
 
 #include <godot_cpp/variant/string.hpp>
 
+#include <atomic>
+
 namespace fennara::release_discovery {
 
 struct Result {
     bool success = false;
+    bool cancelled = false;
     bool update_available = false;
     release_identity::Identity current;
     godot::String target_version;
@@ -18,6 +21,6 @@ struct Result {
     godot::String error;
 };
 
-Result check(int timeout_ms);
+Result check(int timeout_ms, const std::atomic_bool *cancelled = nullptr);
 
 } // namespace fennara::release_discovery

--- a/fennara-cpp/include/fennara/release/identity.hpp
+++ b/fennara-cpp/include/fennara/release/identity.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+#include <optional>
+
+namespace fennara::release_identity {
+
+struct Identity {
+    godot::String track;
+    godot::String channel;
+    godot::String version;
+    godot::String release_tag;
+    godot::String source_commit;
+
+    bool is_staging() const;
+};
+
+std::optional<Identity> load_addon(const godot::String &expected_version,
+                                   godot::String &error);
+std::optional<Identity> parse(const godot::Dictionary &value,
+                              const godot::String &expected_version,
+                              godot::String &error);
+bool manifest_matches(const godot::Dictionary &manifest, const Identity &expected,
+                      godot::String &error);
+godot::String channel_pointer_ref(const Identity &identity);
+godot::String channel_pointer_name(const Identity &identity);
+
+} // namespace fennara::release_identity

--- a/fennara-cpp/include/fennara/release/version.hpp
+++ b/fennara-cpp/include/fennara/release/version.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <godot_cpp/variant/string.hpp>
+
+#include <optional>
+
+namespace fennara::release_version {
+
+godot::String normalize(godot::String version);
+bool is_valid(const godot::String &version);
+std::optional<int> compare(const godot::String &left, const godot::String &right);
+
+} // namespace fennara::release_version

--- a/fennara-cpp/include/fennara/setup/first_run_setup.hpp
+++ b/fennara-cpp/include/fennara/setup/first_run_setup.hpp
@@ -6,6 +6,8 @@
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/string.hpp>
 
+#include "fennara/release/identity.hpp"
+
 namespace godot {
 class HTTPRequest;
 }
@@ -56,6 +58,7 @@ class FirstRunSetup : public godot::Node {
     Step step = Step::Idle;
     godot::String project_path;
     godot::String addon_version;
+    release_identity::Identity addon_identity;
     godot::String cli_asset_name;
     godot::String expected_cli_sha256;
     godot::String download_dir;

--- a/fennara-cpp/include/fennara/ui/dock.hpp
+++ b/fennara-cpp/include/fennara/ui/dock.hpp
@@ -56,6 +56,7 @@ private:
     void _release_webview_keyboard_focus();
     bool _event_is_inside_webview_region(const godot::Ref<godot::InputEvent> &event);
     void _refresh_status();
+    void _refresh_staging_badge();
     void _on_mcp_target_state_changed(bool active);
     void _on_setup_succeeded();
     void _on_update_requested();

--- a/fennara-cpp/include/fennara/ui/dock.hpp
+++ b/fennara-cpp/include/fennara/ui/dock.hpp
@@ -29,6 +29,7 @@ private:
     godot::Control *webview_region = nullptr;
     godot::Control *internal_webview_surface = nullptr;
     godot::Label *fallback_label = nullptr;
+    godot::Label *staging_badge = nullptr;
     godot::Control *browser_fallback_panel = nullptr;
     FirstRunSetup *first_run_setup = nullptr;
     FirstRunSetupPanel *setup_panel = nullptr;

--- a/fennara-cpp/include/fennara/ui/fennara_plugin.hpp
+++ b/fennara-cpp/include/fennara/ui/fennara_plugin.hpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include "fennara/ui/dock.hpp"
+#include <thread>
 
 namespace fennara {
 
@@ -20,6 +21,7 @@ private:
     godot::Ref<FennaraScriptContextMenuPlugin> script_context_menu_plugin;
     bool csharp_preparation_pending = false;
     bool initial_filesystem_scan_completed = false;
+    std::thread update_check_thread;
     void _configure_editor_settings();
     void _ensure_export_presets_exclude_fennara();
     bool _is_export_preset_section(const godot::String &section) const;
@@ -30,7 +32,7 @@ private:
 
 public:
     FennaraPlugin();
-    ~FennaraPlugin() = default;
+    ~FennaraPlugin();
 
     void _enter_tree() override;
     void _exit_tree() override;

--- a/fennara-cpp/include/fennara/ui/fennara_plugin.hpp
+++ b/fennara-cpp/include/fennara/ui/fennara_plugin.hpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/editor_plugin.hpp>
 #include "fennara/ui/dock.hpp"
+#include <atomic>
 #include <thread>
 
 namespace fennara {
@@ -21,7 +22,9 @@ private:
     godot::Ref<FennaraScriptContextMenuPlugin> script_context_menu_plugin;
     bool csharp_preparation_pending = false;
     bool initial_filesystem_scan_completed = false;
+    std::atomic_bool update_check_cancelled{false};
     std::thread update_check_thread;
+    void _stop_update_check();
     void _configure_editor_settings();
     void _ensure_export_presets_exclude_fennara();
     bool _is_export_preset_section(const godot::String &section) const;

--- a/fennara-cpp/include/fennara/update/update_coordinator.hpp
+++ b/fennara-cpp/include/fennara/update/update_coordinator.hpp
@@ -44,6 +44,8 @@ public:
     godot::String get_error_code() const;
     godot::String get_operation_id() const;
     godot::String get_target_version() const;
+    godot::String get_release_track() const;
+    godot::String get_release_channel() const;
 
 protected:
     static void _bind_methods();
@@ -55,6 +57,10 @@ private:
     godot::String error_code;
     godot::String operation_id;
     godot::String target_version;
+    godot::String release_track;
+    godot::String release_channel;
+    godot::String release_tag;
+    godot::String source_commit;
     godot::String staging_root;
     int64_t child_pid = -1;
     double poll_timer = 0.0;

--- a/fennara-cpp/include/fennara/update_notice.hpp
+++ b/fennara-cpp/include/fennara/update_notice.hpp
@@ -3,9 +3,11 @@
 #include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/string.hpp>
 
+#include <atomic>
+
 namespace fennara::update_notice {
 
-void check_once();
+void check_once(const std::atomic_bool *cancelled = nullptr);
 bool is_update_available();
 godot::String current_version();
 godot::String latest_version();

--- a/fennara-cpp/include/fennara/update_notice.hpp
+++ b/fennara-cpp/include/fennara/update_notice.hpp
@@ -9,6 +9,10 @@ void check_once();
 bool is_update_available();
 godot::String current_version();
 godot::String latest_version();
+godot::String channel();
+godot::String track();
+godot::String target_release_tag();
+godot::String source_commit();
 godot::String warning_text();
 godot::Dictionary status();
 

--- a/fennara-cpp/src/release/discovery.cpp
+++ b/fennara-cpp/src/release/discovery.cpp
@@ -1,0 +1,335 @@
+#include "fennara/release/discovery.hpp"
+
+#include "fennara/app_paths.hpp"
+#include "fennara/local_bridge.hpp"
+#include "fennara/release/version.hpp"
+
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/http_client.hpp>
+#include <godot_cpp/classes/json.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/time.hpp>
+#include <godot_cpp/classes/tls_options.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+
+namespace fennara::release_discovery {
+namespace {
+
+constexpr const char *kLatestReleasePath =
+    "/repos/fennaraOfficial/fennara-godot-ai/releases/latest";
+constexpr uint64_t kChannelCacheSeconds = 300;
+
+struct HttpResponse {
+    int code = 0;
+    godot::String body;
+    godot::String etag;
+    godot::String error;
+};
+
+struct ChannelCache {
+    bool valid = false;
+    int code = 0;
+    uint64_t checked_at = 0;
+    godot::String etag;
+    godot::String body;
+};
+
+godot::String addon_version() {
+    const godot::String path = "res://addons/fennara/VERSION";
+    const godot::String value =
+        godot::FileAccess::file_exists(path)
+            ? godot::FileAccess::get_file_as_string(path).strip_edges()
+            : godot::String();
+    return value.is_empty() ? godot::String(FennaraLocalBridge::PLUGIN_VERSION) : value;
+}
+
+HttpResponse request_github(const godot::String &path, const godot::String &accept,
+                            int timeout_ms, const godot::String &etag = "") {
+    HttpResponse result;
+    godot::Ref<godot::HTTPClient> http;
+    http.instantiate();
+    if (http->connect_to_host("https://api.github.com", 443,
+                              godot::TLSOptions::client()) != godot::OK) {
+        result.error = "Failed to connect to GitHub.";
+        return result;
+    }
+    godot::PackedStringArray headers;
+    headers.append("Accept: " + accept);
+    headers.append("User-Agent: fennara-godot-ai");
+    if (!etag.is_empty()) {
+        headers.append("If-None-Match: " + etag);
+    }
+    const uint64_t deadline =
+        godot::Time::get_singleton()->get_ticks_msec() + static_cast<uint64_t>(timeout_ms);
+    bool sent = false;
+    while (godot::Time::get_singleton()->get_ticks_msec() < deadline) {
+        http->poll();
+        const godot::HTTPClient::Status status = http->get_status();
+        if (status == godot::HTTPClient::STATUS_CANT_CONNECT ||
+            status == godot::HTTPClient::STATUS_TLS_HANDSHAKE_ERROR ||
+            status == godot::HTTPClient::STATUS_CONNECTION_ERROR) {
+            result.error = "Failed to connect to GitHub.";
+            return result;
+        }
+        if (status == godot::HTTPClient::STATUS_CONNECTED && !sent) {
+            if (http->request(godot::HTTPClient::METHOD_GET, path, headers) != godot::OK) {
+                result.error = "Failed to send the GitHub release request.";
+                return result;
+            }
+            sent = true;
+        }
+        if (status == godot::HTTPClient::STATUS_BODY) {
+            const godot::PackedByteArray chunk = http->read_response_body_chunk();
+            if (!chunk.is_empty()) {
+                result.body += chunk.get_string_from_utf8();
+            }
+            if (http->get_response_body_length() >= 0 &&
+                result.body.to_utf8_buffer().size() >= http->get_response_body_length()) {
+                break;
+            }
+        }
+        godot::OS::get_singleton()->delay_usec(10000);
+    }
+    if (!http->has_response()) {
+        result.error = "Timed out waiting for GitHub.";
+        return result;
+    }
+    result.code = http->get_response_code();
+    const godot::PackedStringArray response_headers = http->get_response_headers();
+    for (int index = 0; index < response_headers.size(); index++) {
+        const godot::String header = response_headers[index];
+        if (header.to_lower().begins_with("etag:")) {
+            result.etag = header.substr(header.find(":") + 1).strip_edges();
+            break;
+        }
+    }
+    return result;
+}
+
+godot::String channel_cache_path(const godot::String &channel) {
+    const godot::String root = app_paths::app_dir();
+    return root.is_empty()
+               ? godot::String()
+               : root.path_join("cache")
+                     .path_join("update-channels")
+                     .path_join(channel + godot::String(".json"));
+}
+
+ChannelCache load_channel_cache(const godot::String &channel) {
+    ChannelCache result;
+    const godot::String path = channel_cache_path(channel);
+    if (path.is_empty() || !godot::FileAccess::file_exists(path)) {
+        return result;
+    }
+    const godot::Variant parsed =
+        godot::JSON::parse_string(godot::FileAccess::get_file_as_string(path));
+    if (parsed.get_type() != godot::Variant::DICTIONARY) {
+        return result;
+    }
+    const godot::Dictionary value = parsed;
+    if ((int64_t)value.get("schema_version", 0) != 1 ||
+        godot::String(value.get("channel", "")) != channel) {
+        return result;
+    }
+    result.code = value.get("response_code", 0);
+    result.checked_at = value.get("checked_at_unix", 0);
+    result.etag = value.get("etag", "");
+    result.body = value.get("body", "");
+    result.valid = (result.code == 200 && !result.body.is_empty()) || result.code == 404;
+    return result;
+}
+
+void save_channel_cache(const godot::String &channel, int code, const godot::String &etag,
+                        const godot::String &body) {
+    godot::Dictionary value;
+    value["schema_version"] = 1;
+    value["channel"] = channel;
+    value["response_code"] = code;
+    value["checked_at_unix"] = static_cast<int64_t>(
+        godot::Time::get_singleton()->get_unix_time_from_system());
+    value["etag"] = etag;
+    value["body"] = body;
+    app_paths::write_json(channel_cache_path(channel), value);
+}
+
+bool cache_is_fresh(const ChannelCache &cache) {
+    const uint64_t now = static_cast<uint64_t>(
+        godot::Time::get_singleton()->get_unix_time_from_system());
+    return cache.valid && now >= cache.checked_at &&
+           now - cache.checked_at < kChannelCacheSeconds;
+}
+
+godot::String extract_asset_version(const godot::String &name,
+                                    const godot::String &prefix,
+                                    const godot::String &suffix) {
+    if (!name.begins_with(prefix) || !name.ends_with(suffix)) {
+        return "";
+    }
+    const int count = name.length() - prefix.length() - suffix.length();
+    const godot::String version =
+        count > 0 ? release_version::normalize(name.substr(prefix.length(), count))
+                  : godot::String();
+    return release_version::is_valid(version) ? version : godot::String();
+}
+
+godot::String stable_version(const godot::Dictionary &release) {
+    const godot::String tag =
+        release_version::normalize(godot::String(release.get("tag_name", "")));
+    if (release_version::is_valid(tag)) {
+        return tag;
+    }
+    const godot::Variant assets_value = release.get("assets", godot::Array());
+    if (assets_value.get_type() != godot::Variant::ARRAY) {
+        return "";
+    }
+    const godot::String prefixes[] = {
+        "fennara-release-manifest-v", "fennara-release-addon-v",
+        "fennara-release-local-linux-x86_64-v",
+        "fennara-release-local-windows-x86_64-v",
+        "fennara-release-local-macos-arm64-v", "fennara-cli-linux-x86_64-v",
+        "fennara-cli-windows-x86_64-v", "fennara-cli-macos-arm64-v",
+    };
+    const godot::String suffixes[] = {".json", ".zip", ".zip", ".zip",
+                                      ".zip",  ".zip", ".zip", ".zip"};
+    const godot::Array assets = assets_value;
+    for (int prefix_index = 0; prefix_index < 8; prefix_index++) {
+        for (int asset_index = 0; asset_index < assets.size(); asset_index++) {
+            const godot::Variant asset_value = assets[asset_index];
+            if (asset_value.get_type() != godot::Variant::DICTIONARY) {
+                continue;
+            }
+            const godot::String version = extract_asset_version(
+                godot::Dictionary(asset_value).get("name", ""), prefixes[prefix_index],
+                suffixes[prefix_index]);
+            if (!version.is_empty()) {
+                return version;
+            }
+        }
+    }
+    return "";
+}
+
+Result stable_result(const release_identity::Identity &current, int timeout_ms) {
+    Result result;
+    result.current = current;
+    const HttpResponse response =
+        request_github(kLatestReleasePath, "application/vnd.github+json", timeout_ms);
+    if (!response.error.is_empty() || response.code != 200) {
+        result.error = response.error.is_empty() ? "Stable release lookup failed." : response.error;
+        return result;
+    }
+    const godot::Variant parsed = godot::JSON::parse_string(response.body);
+    if (parsed.get_type() != godot::Variant::DICTIONARY) {
+        result.error = "Stable release metadata was not valid JSON.";
+        return result;
+    }
+    result.target_version = stable_version(parsed);
+    if (result.target_version.is_empty()) {
+        result.error = "Stable release metadata did not contain a version.";
+        return result;
+    }
+    result.target_release_tag = "v" + result.target_version;
+    result.update_available =
+        release_version::compare(result.target_version, current.version).value_or(0) > 0;
+    result.success = true;
+    return result;
+}
+
+Result staging_result(const release_identity::Identity &current, int timeout_ms) {
+    Result result;
+    result.current = current;
+    const godot::String pointer_name = release_identity::channel_pointer_name(current);
+    const godot::String reference = release_identity::channel_pointer_ref(current);
+    const godot::String encoded_reference = reference.replace("/", "%2F");
+    const godot::String path = "/repos/fennaraOfficial/fennara-godot-ai/contents/" +
+                               pointer_name + "?ref=" + encoded_reference;
+    const ChannelCache cache = load_channel_cache(current.channel);
+    HttpResponse response;
+    bool refresh_cache = false;
+    if (cache_is_fresh(cache)) {
+        response.code = cache.code;
+        response.body = cache.body;
+        response.etag = cache.etag;
+    } else {
+        refresh_cache = true;
+        response = request_github(path, "application/vnd.github.raw+json", timeout_ms,
+                                  cache.valid ? cache.etag : godot::String());
+        if (response.code == 304 && cache.valid) {
+            response.code = cache.code;
+            response.body = cache.body;
+            response.etag = cache.etag;
+        }
+    }
+    if (response.code == 404) {
+        if (refresh_cache) {
+            save_channel_cache(current.channel, 404, response.etag, "");
+        }
+        result.success = true;
+        result.detail = "No staging updates are available for " + current.channel + ".";
+        return result;
+    }
+    if (!response.error.is_empty() || response.code != 200) {
+        result.error = response.error.is_empty() ? "Staging channel lookup failed." : response.error;
+        return result;
+    }
+    const godot::Variant parsed = godot::JSON::parse_string(response.body);
+    if (parsed.get_type() != godot::Variant::DICTIONARY) {
+        result.error = "The staging channel pointer is not valid JSON.";
+        return result;
+    }
+    const godot::Dictionary pointer = parsed;
+    if ((int64_t)pointer.get("schema_version", 0) != 1 ||
+        godot::String(pointer.get("channel", "")) != current.channel) {
+        result.error = "The staging channel pointer does not match this addon channel.";
+        return result;
+    }
+    godot::Dictionary identity_value;
+    identity_value["schema_version"] = 1;
+    identity_value["track"] = "staging";
+    identity_value["channel"] = pointer.get("channel", "");
+    identity_value["version"] = pointer.get("version", "");
+    identity_value["release_tag"] = pointer.get("release_tag", "");
+    identity_value["source_commit"] = pointer.get("source_commit", "");
+    godot::String identity_error;
+    const godot::String target_version = pointer.get("version", "");
+    const std::optional<release_identity::Identity> target =
+        release_identity::parse(identity_value, target_version, identity_error);
+    const godot::String manifest_hash = pointer.get("release_manifest_sha256", "");
+    if (!target.has_value() || target->channel != current.channel ||
+        manifest_hash.length() != 64 || manifest_hash != manifest_hash.to_lower() ||
+        !manifest_hash.is_valid_hex_number(false)) {
+        result.error = identity_error.is_empty() ? "The staging channel pointer is invalid."
+                                                : identity_error;
+        return result;
+    }
+    result.target_version = target->version;
+    result.target_release_tag = target->release_tag;
+    result.target_source_commit = target->source_commit;
+    result.target_manifest_sha256 = manifest_hash;
+    result.update_available =
+        release_version::compare(target->version, current.version).value_or(0) > 0;
+    if (refresh_cache) {
+        save_channel_cache(current.channel, 200, response.etag, response.body);
+    }
+    result.success = true;
+    return result;
+}
+
+} // namespace
+
+Result check(int timeout_ms) {
+    Result result;
+    const godot::String version = release_version::normalize(addon_version());
+    godot::String identity_error;
+    const std::optional<release_identity::Identity> identity =
+        release_identity::load_addon(version, identity_error);
+    if (!identity.has_value()) {
+        result.error = identity_error;
+        return result;
+    }
+    return identity->is_staging() ? staging_result(*identity, timeout_ms)
+                                  : stable_result(*identity, timeout_ms);
+}
+
+} // namespace fennara::release_discovery

--- a/fennara-cpp/src/release/discovery.cpp
+++ b/fennara-cpp/src/release/discovery.cpp
@@ -47,6 +47,7 @@ godot::String addon_version() {
 HttpResponse request_github(const godot::String &path, const godot::String &accept,
                             int timeout_ms, const godot::String &etag = "") {
     HttpResponse result;
+    godot::PackedByteArray response_body;
     godot::Ref<godot::HTTPClient> http;
     http.instantiate();
     if (http->connect_to_host("https://api.github.com", 443,
@@ -82,10 +83,10 @@ HttpResponse request_github(const godot::String &path, const godot::String &acce
         if (status == godot::HTTPClient::STATUS_BODY) {
             const godot::PackedByteArray chunk = http->read_response_body_chunk();
             if (!chunk.is_empty()) {
-                result.body += chunk.get_string_from_utf8();
+                response_body.append_array(chunk);
             }
             if (http->get_response_body_length() >= 0 &&
-                result.body.to_utf8_buffer().size() >= http->get_response_body_length()) {
+                response_body.size() >= http->get_response_body_length()) {
                 break;
             }
         }
@@ -95,6 +96,7 @@ HttpResponse request_github(const godot::String &path, const godot::String &acce
         result.error = "Timed out waiting for GitHub.";
         return result;
     }
+    result.body = response_body.get_string_from_utf8();
     result.code = http->get_response_code();
     const godot::PackedStringArray response_headers = http->get_response_headers();
     for (int index = 0; index < response_headers.size(); index++) {

--- a/fennara-cpp/src/release/discovery.cpp
+++ b/fennara-cpp/src/release/discovery.cpp
@@ -61,7 +61,7 @@ HttpResponse request_github(const godot::String &path, const godot::String &acce
     godot::PackedByteArray response_body;
     godot::Ref<godot::HTTPClient> http;
     http.instantiate();
-    if (http->connect_to_host("https://api.github.com", 443,
+    if (http->connect_to_host("api.github.com", 443,
                               godot::TLSOptions::client()) != godot::OK) {
         result.error = "Failed to connect to GitHub.";
         return result;
@@ -75,6 +75,7 @@ HttpResponse request_github(const godot::String &path, const godot::String &acce
     const uint64_t deadline =
         godot::Time::get_singleton()->get_ticks_msec() + static_cast<uint64_t>(timeout_ms);
     bool sent = false;
+    bool response_complete = false;
     while (godot::Time::get_singleton()->get_ticks_msec() < deadline) {
         if (is_cancelled(cancelled)) {
             result.cancelled = true;
@@ -103,13 +104,21 @@ HttpResponse request_github(const godot::String &path, const godot::String &acce
             }
             if (http->get_response_body_length() >= 0 &&
                 response_body.size() >= http->get_response_body_length()) {
+                response_complete = true;
                 break;
             }
         }
+        if (sent && http->has_response() &&
+            (http->get_response_body_length() == 0 ||
+             status == godot::HTTPClient::STATUS_CONNECTED)) {
+            response_complete = true;
+            break;
+        }
         godot::OS::get_singleton()->delay_usec(10000);
     }
-    if (!http->has_response()) {
-        result.error = "Timed out waiting for GitHub.";
+    if (!response_complete) {
+        result.error = http->has_response() ? "Timed out reading the GitHub response."
+                                            : "Timed out waiting for GitHub.";
         return result;
     }
     result.body = response_body.get_string_from_utf8();

--- a/fennara-cpp/src/release/discovery.cpp
+++ b/fennara-cpp/src/release/discovery.cpp
@@ -22,6 +22,7 @@ constexpr uint64_t kChannelCacheSeconds = 300;
 
 struct HttpResponse {
     int code = 0;
+    bool cancelled = false;
     godot::String body;
     godot::String etag;
     godot::String error;
@@ -35,6 +36,10 @@ struct ChannelCache {
     godot::String body;
 };
 
+bool is_cancelled(const std::atomic_bool *cancelled) {
+    return cancelled != nullptr && cancelled->load(std::memory_order_acquire);
+}
+
 godot::String addon_version() {
     const godot::String path = "res://addons/fennara/VERSION";
     const godot::String value =
@@ -45,8 +50,14 @@ godot::String addon_version() {
 }
 
 HttpResponse request_github(const godot::String &path, const godot::String &accept,
-                            int timeout_ms, const godot::String &etag = "") {
+                            int timeout_ms, const godot::String &etag,
+                            const std::atomic_bool *cancelled) {
     HttpResponse result;
+    if (is_cancelled(cancelled)) {
+        result.cancelled = true;
+        result.error = "Update check cancelled.";
+        return result;
+    }
     godot::PackedByteArray response_body;
     godot::Ref<godot::HTTPClient> http;
     http.instantiate();
@@ -65,6 +76,11 @@ HttpResponse request_github(const godot::String &path, const godot::String &acce
         godot::Time::get_singleton()->get_ticks_msec() + static_cast<uint64_t>(timeout_ms);
     bool sent = false;
     while (godot::Time::get_singleton()->get_ticks_msec() < deadline) {
+        if (is_cancelled(cancelled)) {
+            result.cancelled = true;
+            result.error = "Update check cancelled.";
+            return result;
+        }
         http->poll();
         const godot::HTTPClient::Status status = http->get_status();
         if (status == godot::HTTPClient::STATUS_CANT_CONNECT ||
@@ -212,11 +228,14 @@ godot::String stable_version(const godot::Dictionary &release) {
     return "";
 }
 
-Result stable_result(const release_identity::Identity &current, int timeout_ms) {
+Result stable_result(const release_identity::Identity &current, int timeout_ms,
+                     const std::atomic_bool *cancelled) {
     Result result;
     result.current = current;
     const HttpResponse response =
-        request_github(kLatestReleasePath, "application/vnd.github+json", timeout_ms);
+        request_github(kLatestReleasePath, "application/vnd.github+json", timeout_ms, "",
+                       cancelled);
+    result.cancelled = response.cancelled;
     if (!response.error.is_empty() || response.code != 200) {
         result.error = response.error.is_empty() ? "Stable release lookup failed." : response.error;
         return result;
@@ -238,7 +257,8 @@ Result stable_result(const release_identity::Identity &current, int timeout_ms) 
     return result;
 }
 
-Result staging_result(const release_identity::Identity &current, int timeout_ms) {
+Result staging_result(const release_identity::Identity &current, int timeout_ms,
+                      const std::atomic_bool *cancelled) {
     Result result;
     result.current = current;
     const godot::String pointer_name = release_identity::channel_pointer_name(current);
@@ -256,13 +276,14 @@ Result staging_result(const release_identity::Identity &current, int timeout_ms)
     } else {
         refresh_cache = true;
         response = request_github(path, "application/vnd.github.raw+json", timeout_ms,
-                                  cache.valid ? cache.etag : godot::String());
+                                  cache.valid ? cache.etag : godot::String(), cancelled);
         if (response.code == 304 && cache.valid) {
             response.code = cache.code;
             response.body = cache.body;
             response.etag = cache.etag;
         }
     }
+    result.cancelled = response.cancelled;
     if (response.code == 404) {
         if (refresh_cache) {
             save_channel_cache(current.channel, 404, response.etag, "");
@@ -320,8 +341,13 @@ Result staging_result(const release_identity::Identity &current, int timeout_ms)
 
 } // namespace
 
-Result check(int timeout_ms) {
+Result check(int timeout_ms, const std::atomic_bool *cancelled) {
     Result result;
+    if (is_cancelled(cancelled)) {
+        result.cancelled = true;
+        result.error = "Update check cancelled.";
+        return result;
+    }
     const godot::String version = release_version::normalize(addon_version());
     godot::String identity_error;
     const std::optional<release_identity::Identity> identity =
@@ -330,8 +356,8 @@ Result check(int timeout_ms) {
         result.error = identity_error;
         return result;
     }
-    return identity->is_staging() ? staging_result(*identity, timeout_ms)
-                                  : stable_result(*identity, timeout_ms);
+    return identity->is_staging() ? staging_result(*identity, timeout_ms, cancelled)
+                                  : stable_result(*identity, timeout_ms, cancelled);
 }
 
 } // namespace fennara::release_discovery

--- a/fennara-cpp/src/release/identity.cpp
+++ b/fennara-cpp/src/release/identity.cpp
@@ -69,7 +69,10 @@ std::optional<Identity> parse(const godot::Dictionary &value,
                               const godot::String &expected_version,
                               godot::String &error) {
     Identity identity;
-    if ((int64_t)value.get("schema_version", 0) != 1) {
+    const godot::Variant schema_version = value.get("schema_version", godot::Variant());
+    const godot::Variant::Type schema_type = schema_version.get_type();
+    if ((schema_type != godot::Variant::INT && schema_type != godot::Variant::FLOAT) ||
+        (double)schema_version != 1.0) {
         error = "The addon release identity uses an unsupported schema.";
         return std::nullopt;
     }

--- a/fennara-cpp/src/release/identity.cpp
+++ b/fennara-cpp/src/release/identity.cpp
@@ -100,13 +100,16 @@ std::optional<Identity> parse(const godot::Dictionary &value,
         return std::nullopt;
     }
     const godot::String pull_request = identity.channel.substr(3);
-    const godot::String prefix = "-pr." + pull_request + ".";
-    const int prefix_index = identity.version.find(prefix);
-    if (prefix_index < 0 || prefix_index + prefix.length() >= identity.version.length()) {
+    const int prerelease_index = identity.version.find("-");
+    const godot::String prefix = "pr." + pull_request + ".";
+    const godot::String prerelease = prerelease_index >= 0
+                                         ? identity.version.substr(prerelease_index + 1)
+                                         : godot::String();
+    if (!prerelease.begins_with(prefix) || prerelease.length() <= prefix.length()) {
         error = "The staging addon version does not belong to its channel.";
         return std::nullopt;
     }
-    const godot::String candidate = identity.version.substr(prefix_index + prefix.length());
+    const godot::String candidate = prerelease.substr(prefix.length());
     if (!candidate.is_valid_int() || candidate.begins_with("0") || candidate.to_int() <= 0) {
         error = "The staging addon candidate number is invalid.";
         return std::nullopt;

--- a/fennara-cpp/src/release/identity.cpp
+++ b/fennara-cpp/src/release/identity.cpp
@@ -1,0 +1,150 @@
+#include "fennara/release/identity.hpp"
+
+#include "fennara/release/version.hpp"
+
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/json.hpp>
+
+namespace fennara::release_identity {
+namespace {
+
+constexpr const char *kAddonIdentityPath = "res://addons/fennara/release.json";
+
+bool valid_channel(const godot::String &channel) {
+    if (!channel.begins_with("pr-")) {
+        return false;
+    }
+    const godot::String number = channel.substr(3);
+    return !number.is_empty() && !number.begins_with("0") && number.is_valid_int() &&
+           number.to_int() > 0;
+}
+
+bool valid_source_commit(const godot::String &value) {
+    if (value.length() != 40 || value != value.to_lower()) {
+        return false;
+    }
+    for (int index = 0; index < value.length(); index++) {
+        const char32_t character = value[index];
+        if (!((character >= '0' && character <= '9') ||
+              (character >= 'a' && character <= 'f'))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+Identity legacy_stable(const godot::String &version) {
+    Identity identity;
+    identity.track = "stable";
+    identity.version = version;
+    identity.release_tag = "v" + version;
+    return identity;
+}
+
+} // namespace
+
+bool Identity::is_staging() const {
+    return track == "staging";
+}
+
+std::optional<Identity> load_addon(const godot::String &expected_version,
+                                   godot::String &error) {
+    if (!godot::FileAccess::file_exists(kAddonIdentityPath)) {
+        if (!release_version::is_valid(expected_version) || expected_version.contains("-")) {
+            error = "A prerelease addon requires release.json identity metadata.";
+            return std::nullopt;
+        }
+        return legacy_stable(expected_version);
+    }
+    const godot::Variant parsed = godot::JSON::parse_string(
+        godot::FileAccess::get_file_as_string(kAddonIdentityPath));
+    if (parsed.get_type() != godot::Variant::DICTIONARY) {
+        error = "The addon release identity is not valid JSON.";
+        return std::nullopt;
+    }
+    return parse(parsed, expected_version, error);
+}
+
+std::optional<Identity> parse(const godot::Dictionary &value,
+                              const godot::String &expected_version,
+                              godot::String &error) {
+    Identity identity;
+    if ((int64_t)value.get("schema_version", 0) != 1) {
+        error = "The addon release identity uses an unsupported schema.";
+        return std::nullopt;
+    }
+    identity.track = value.get("track", "");
+    identity.channel = value.get("channel", "");
+    identity.version = value.get("version", "");
+    identity.release_tag = value.get("release_tag", "");
+    identity.source_commit = value.get("source_commit", "");
+    if (!release_version::is_valid(identity.version) || identity.version != expected_version ||
+        identity.release_tag != "v" + identity.version) {
+        error = "The addon release identity does not match its VERSION and release tag.";
+        return std::nullopt;
+    }
+    if (identity.track == "stable") {
+        if (identity.version.contains("-") || !identity.channel.is_empty()) {
+            error = "Stable addon release identity contains staging fields.";
+            return std::nullopt;
+        }
+        if (!identity.source_commit.is_empty() && !valid_source_commit(identity.source_commit)) {
+            error = "Stable addon release identity contains an invalid source commit.";
+            return std::nullopt;
+        }
+        return identity;
+    }
+    if (identity.track != "staging" || !valid_channel(identity.channel) ||
+        !valid_source_commit(identity.source_commit)) {
+        error = "Staging addon release identity is incomplete or invalid.";
+        return std::nullopt;
+    }
+    const godot::String pull_request = identity.channel.substr(3);
+    const godot::String prefix = "-pr." + pull_request + ".";
+    const int prefix_index = identity.version.find(prefix);
+    if (prefix_index < 0 || prefix_index + prefix.length() >= identity.version.length()) {
+        error = "The staging addon version does not belong to its channel.";
+        return std::nullopt;
+    }
+    const godot::String candidate = identity.version.substr(prefix_index + prefix.length());
+    if (!candidate.is_valid_int() || candidate.begins_with("0") || candidate.to_int() <= 0) {
+        error = "The staging addon candidate number is invalid.";
+        return std::nullopt;
+    }
+    return identity;
+}
+
+bool manifest_matches(const godot::Dictionary &manifest, const Identity &expected,
+                      godot::String &error) {
+    const godot::Variant release_value = manifest.get("release", godot::Variant());
+    if (release_value.get_type() == godot::Variant::NIL && !expected.is_staging()) {
+        return true;
+    }
+    if (release_value.get_type() != godot::Variant::DICTIONARY) {
+        error = "The staging release manifest is missing release identity metadata.";
+        return false;
+    }
+    std::optional<Identity> actual = parse(release_value, expected.version, error);
+    if (!actual.has_value() || actual->track != expected.track ||
+        actual->channel != expected.channel || actual->version != expected.version ||
+        actual->release_tag != expected.release_tag ||
+        actual->source_commit != expected.source_commit) {
+        if (error.is_empty()) {
+            error = "The release manifest identity does not match this addon.";
+        }
+        return false;
+    }
+    return true;
+}
+
+godot::String channel_pointer_ref(const Identity &identity) {
+    return identity.is_staging() ? "fennara-staging/" + identity.channel : godot::String();
+}
+
+godot::String channel_pointer_name(const Identity &identity) {
+    return identity.is_staging()
+               ? "fennara-staging-channel-" + identity.channel + ".json"
+               : godot::String();
+}
+
+} // namespace fennara::release_identity

--- a/fennara-cpp/src/release/version.cpp
+++ b/fennara-cpp/src/release/version.cpp
@@ -1,0 +1,180 @@
+#include "fennara/release/version.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace fennara::release_version {
+namespace {
+
+struct Identifier {
+    bool numeric = false;
+    uint64_t number = 0;
+    std::string text;
+};
+
+struct Version {
+    uint64_t major = 0;
+    uint64_t minor = 0;
+    uint64_t patch = 0;
+    std::vector<Identifier> prerelease;
+};
+
+bool valid_identifier_character(char character) {
+    return (character >= '0' && character <= '9') ||
+           (character >= 'A' && character <= 'Z') ||
+           (character >= 'a' && character <= 'z') || character == '-';
+}
+
+bool parse_number(const std::string &value, uint64_t &number) {
+    if (value.empty() || (value.size() > 1 && value.front() == '0')) {
+        return false;
+    }
+    uint64_t parsed = 0;
+    for (char character : value) {
+        if (character < '0' || character > '9') {
+            return false;
+        }
+        const uint64_t digit = static_cast<uint64_t>(character - '0');
+        if (parsed > (std::numeric_limits<uint64_t>::max() - digit) / 10) {
+            return false;
+        }
+        parsed = parsed * 10 + digit;
+    }
+    number = parsed;
+    return true;
+}
+
+std::vector<std::string> split(const std::string &value, char delimiter) {
+    std::vector<std::string> parts;
+    size_t start = 0;
+    while (true) {
+        const size_t end = value.find(delimiter, start);
+        parts.push_back(value.substr(start, end == std::string::npos ? end : end - start));
+        if (end == std::string::npos) {
+            return parts;
+        }
+        start = end + 1;
+    }
+}
+
+std::optional<Version> parse(godot::String input) {
+    input = normalize(input);
+    const std::string raw = input.utf8().get_data();
+    if (raw.empty()) {
+        return std::nullopt;
+    }
+
+    const size_t plus = raw.find('+');
+    if (plus != std::string::npos) {
+        return std::nullopt;
+    }
+    const std::string &without_build = raw;
+    const size_t dash = without_build.find('-');
+    const std::string core = without_build.substr(0, dash);
+    const std::vector<std::string> core_parts = split(core, '.');
+    if (core_parts.size() != 3) {
+        return std::nullopt;
+    }
+
+    Version version;
+    if (!parse_number(core_parts[0], version.major) ||
+        !parse_number(core_parts[1], version.minor) ||
+        !parse_number(core_parts[2], version.patch)) {
+        return std::nullopt;
+    }
+
+    if (dash == std::string::npos) {
+        return version;
+    }
+    const std::string prerelease = without_build.substr(dash + 1);
+    if (prerelease.empty()) {
+        return std::nullopt;
+    }
+    for (const std::string &part : split(prerelease, '.')) {
+        if (part.empty()) {
+            return std::nullopt;
+        }
+        bool numeric = true;
+        for (char character : part) {
+            if (!valid_identifier_character(character)) {
+                return std::nullopt;
+            }
+            numeric = numeric && character >= '0' && character <= '9';
+        }
+        Identifier identifier;
+        identifier.numeric = numeric;
+        identifier.text = part;
+        if (numeric && !parse_number(part, identifier.number)) {
+            return std::nullopt;
+        }
+        version.prerelease.push_back(identifier);
+    }
+    return version;
+}
+
+int compare_number(uint64_t left, uint64_t right) {
+    return left < right ? -1 : left > right ? 1 : 0;
+}
+
+int compare_prerelease(const std::vector<Identifier> &left,
+                       const std::vector<Identifier> &right) {
+    if (left.empty() || right.empty()) {
+        return left.empty() == right.empty() ? 0 : left.empty() ? 1 : -1;
+    }
+    const size_t count = left.size() < right.size() ? left.size() : right.size();
+    for (size_t index = 0; index < count; index++) {
+        const Identifier &left_identifier = left[index];
+        const Identifier &right_identifier = right[index];
+        if (left_identifier.numeric && right_identifier.numeric) {
+            const int result = compare_number(left_identifier.number, right_identifier.number);
+            if (result != 0) {
+                return result;
+            }
+            continue;
+        }
+        if (left_identifier.numeric != right_identifier.numeric) {
+            return left_identifier.numeric ? -1 : 1;
+        }
+        if (left_identifier.text != right_identifier.text) {
+            return left_identifier.text < right_identifier.text ? -1 : 1;
+        }
+    }
+    return compare_number(left.size(), right.size());
+}
+
+} // namespace
+
+godot::String normalize(godot::String version) {
+    version = version.strip_edges();
+    if (version.begins_with("v")) {
+        version = version.substr(1);
+    }
+    return version;
+}
+
+bool is_valid(const godot::String &version) {
+    return parse(version).has_value();
+}
+
+std::optional<int> compare(const godot::String &left, const godot::String &right) {
+    const std::optional<Version> left_version = parse(left);
+    const std::optional<Version> right_version = parse(right);
+    if (!left_version.has_value() || !right_version.has_value()) {
+        return std::nullopt;
+    }
+    int result = compare_number(left_version->major, right_version->major);
+    if (result == 0) {
+        result = compare_number(left_version->minor, right_version->minor);
+    }
+    if (result == 0) {
+        result = compare_number(left_version->patch, right_version->patch);
+    }
+    if (result == 0) {
+        result = compare_prerelease(left_version->prerelease, right_version->prerelease);
+    }
+    return result;
+}
+
+} // namespace fennara::release_version

--- a/fennara-cpp/src/release/version.cpp
+++ b/fennara-cpp/src/release/version.cpp
@@ -60,7 +60,6 @@ std::vector<std::string> split(const std::string &value, char delimiter) {
 }
 
 std::optional<Version> parse(godot::String input) {
-    input = normalize(input);
     const std::string raw = input.utf8().get_data();
     if (raw.empty()) {
         return std::nullopt;

--- a/fennara-cpp/src/setup/first_run_download.cpp
+++ b/fennara-cpp/src/setup/first_run_download.cpp
@@ -1,6 +1,9 @@
 #include "fennara/app_paths.hpp"
 #include "fennara/setup/first_run_setup.hpp"
 
+#include "fennara/release/identity.hpp"
+#include "fennara/release/version.hpp"
+
 #include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/hashing_context.hpp>
@@ -61,6 +64,18 @@ void FirstRunSetup::_on_manifest_request_completed(int64_t result, int64_t respo
               "The release manifest does not match this addon version.");
         return;
     }
+    godot::String identity_error;
+    if (!release_identity::manifest_matches(manifest, addon_identity, identity_error)) {
+        _fail("FEN-SETUP-MANIFEST-IDENTITY", identity_error);
+        return;
+    }
+    const godot::String minimum_cli_version = manifest.get("minimum_cli_version", "");
+    if (!release_version::is_valid(minimum_cli_version) ||
+        release_version::compare(addon_version, minimum_cli_version).value_or(-1) < 0) {
+        _fail("FEN-SETUP-MANIFEST-INVALID",
+              "The release manifest has an incompatible minimum CLI version.");
+        return;
+    }
 
     const godot::Variant assets_value = manifest.get("assets", godot::Dictionary());
     if (assets_value.get_type() != godot::Variant::DICTIONARY) {
@@ -85,7 +100,10 @@ void FirstRunSetup::_on_manifest_request_completed(int64_t result, int64_t respo
     const godot::Dictionary asset = asset_value;
     cli_asset_name = asset.get("name", "");
     expected_cli_sha256 = godot::String(asset.get("sha256", "")).to_lower();
-    if (!valid_asset_name(cli_asset_name) || !valid_sha256(expected_cli_sha256)) {
+    const godot::String expected_cli_name =
+        "fennara-cli-" + platform_key + "-v" + addon_version + ".zip";
+    if (!valid_asset_name(cli_asset_name) || cli_asset_name != expected_cli_name ||
+        !valid_sha256(expected_cli_sha256)) {
         _fail("FEN-SETUP-MANIFEST-INVALID", "The selected CLI asset metadata is invalid.");
         return;
     }

--- a/fennara-cpp/src/setup/first_run_operation.cpp
+++ b/fennara-cpp/src/setup/first_run_operation.cpp
@@ -74,6 +74,10 @@ bool FirstRunSetup::_launch_installer() {
     args.append(project_path);
     args.append("--version");
     args.append(addon_version);
+    if (addon_identity.is_staging()) {
+        args.append("--channel");
+        args.append(addon_identity.channel);
+    }
     args.append("--operation-id");
     args.append(operation_id);
     const godot::String executable =
@@ -201,6 +205,12 @@ void FirstRunSetup::_cleanup_download() const {
 
 godot::String FirstRunSetup::_diagnostic_report() const {
     godot::String report = "Fennara setup report\n";
+    report += "Track: " + addon_identity.track + "\n";
+    if (addon_identity.is_staging()) {
+        report += "Channel: " + addon_identity.channel + "\n";
+        report += "Source commit: " + addon_identity.source_commit + "\n";
+        report += "Release tag: " + addon_identity.release_tag + "\n";
+    }
     report += "Addon version: " + addon_version + "\n";
     report += "Operation: " + (operation_id.is_empty() ? "not created" : operation_id) + "\n";
     report += "Code: " + (error_code.is_empty() ? "none" : error_code) + "\n";

--- a/fennara-cpp/src/setup/first_run_setup.cpp
+++ b/fennara-cpp/src/setup/first_run_setup.cpp
@@ -157,6 +157,14 @@ void FirstRunSetup::start(const godot::String &next_project_path,
               "The project path or addon version is missing or invalid.");
         return;
     }
+    godot::String identity_error;
+    const std::optional<release_identity::Identity> identity =
+        release_identity::load_addon(addon_version, identity_error);
+    if (!identity.has_value()) {
+        _fail("FEN-SETUP-IDENTITY-INVALID", identity_error);
+        return;
+    }
+    addon_identity = *identity;
     if (!_try_acquire_lock()) {
         if (!has_failed()) {
             step = Step::WaitingForLock;
@@ -256,7 +264,7 @@ void FirstRunSetup::_fail(const godot::String &code, const godot::String &messag
 }
 
 godot::String FirstRunSetup::_release_asset_url(const godot::String &asset_name) const {
-    return godot::String(kReleaseBase) + "/v" + addon_version + "/" + asset_name;
+    return godot::String(kReleaseBase) + "/" + addon_identity.release_tag + "/" + asset_name;
 }
 
 godot::String FirstRunSetup::_platform_key() const {

--- a/fennara-cpp/src/ui/dock.cpp
+++ b/fennara-cpp/src/ui/dock.cpp
@@ -190,6 +190,11 @@ void FennaraDock::_build_ui() {
     root->add_child(margin);
     webview_region = margin;
 
+    godot::Control *badge_overlay = memnew(godot::Control);
+    badge_overlay->set_anchors_preset(godot::Control::PRESET_FULL_RECT);
+    badge_overlay->set_mouse_filter(godot::Control::MOUSE_FILTER_IGNORE);
+    root->add_child(badge_overlay);
+
     staging_badge = memnew(godot::Label);
     staging_badge->set_anchors_and_offsets_preset(godot::Control::PRESET_TOP_RIGHT);
     staging_badge->set_offset(godot::SIDE_LEFT, -118);
@@ -198,11 +203,8 @@ void FennaraDock::_build_ui() {
     staging_badge->set_mouse_filter(godot::Control::MOUSE_FILTER_IGNORE);
     staging_badge->set_z_index(20);
     staging_badge->add_theme_color_override("font_color", godot::Color("#ffd166"));
-    const godot::String channel = update_notice::channel();
-    staging_badge->set_text(channel.replace("pr-", "PR ") + " STAGING");
-    staging_badge->set_tooltip_text("Testing candidate " + update_notice::current_version());
-    staging_badge->set_visible(update_notice::track() == "staging");
-    root->add_child(staging_badge);
+    badge_overlay->add_child(staging_badge);
+    _refresh_staging_badge();
 
     fallback_label = make_fallback_label("Starting Fennara chat...");
     fallback_label->set_anchors_preset(godot::Control::PRESET_FULL_RECT);
@@ -371,6 +373,7 @@ void FennaraDock::_try_start_webview() {
 }
 
 void FennaraDock::_refresh_status() {
+    _refresh_staging_badge();
     if (fallback_label == nullptr) {
         return;
     }
@@ -378,6 +381,16 @@ void FennaraDock::_refresh_status() {
         return;
     }
     _try_start_webview();
+}
+
+void FennaraDock::_refresh_staging_badge() {
+    if (staging_badge == nullptr) {
+        return;
+    }
+    const godot::String channel = update_notice::channel();
+    staging_badge->set_text(channel.replace("pr-", "PR ") + " STAGING");
+    staging_badge->set_tooltip_text("Testing candidate " + update_notice::current_version());
+    staging_badge->set_visible(update_notice::track() == "staging");
 }
 
 bool FennaraDock::_show_update_if_needed() {

--- a/fennara-cpp/src/ui/dock.cpp
+++ b/fennara-cpp/src/ui/dock.cpp
@@ -8,6 +8,7 @@
 #include "fennara/ui/update_panel.hpp"
 #include "fennara/ui/webview_host.hpp"
 #include "fennara/update/update_coordinator.hpp"
+#include "fennara/update_notice.hpp"
 
 #include <godot_cpp/classes/h_box_container.hpp>
 #include <godot_cpp/classes/input_event_key.hpp>
@@ -188,6 +189,20 @@ void FennaraDock::_build_ui() {
     margin->add_theme_constant_override("margin_bottom", 0);
     root->add_child(margin);
     webview_region = margin;
+
+    staging_badge = memnew(godot::Label);
+    staging_badge->set_anchors_and_offsets_preset(godot::Control::PRESET_TOP_RIGHT);
+    staging_badge->set_offset(godot::SIDE_LEFT, -118);
+    staging_badge->set_offset(godot::SIDE_BOTTOM, 26);
+    staging_badge->set_horizontal_alignment(godot::HORIZONTAL_ALIGNMENT_CENTER);
+    staging_badge->set_mouse_filter(godot::Control::MOUSE_FILTER_IGNORE);
+    staging_badge->set_z_index(20);
+    staging_badge->add_theme_color_override("font_color", godot::Color("#ffd166"));
+    const godot::String channel = update_notice::channel();
+    staging_badge->set_text(channel.replace("pr-", "PR ") + " STAGING");
+    staging_badge->set_tooltip_text("Testing candidate " + update_notice::current_version());
+    staging_badge->set_visible(update_notice::track() == "staging");
+    root->add_child(staging_badge);
 
     fallback_label = make_fallback_label("Starting Fennara chat...");
     fallback_label->set_anchors_preset(godot::Control::PRESET_FULL_RECT);

--- a/fennara-cpp/src/ui/fennara_plugin.cpp
+++ b/fennara-cpp/src/ui/fennara_plugin.cpp
@@ -32,6 +32,12 @@ void FennaraPlugin::_bind_methods() {
 FennaraPlugin::FennaraPlugin() {
 }
 
+FennaraPlugin::~FennaraPlugin() {
+    if (update_check_thread.joinable()) {
+        update_check_thread.join();
+    }
+}
+
 void FennaraPlugin::_enter_tree() {
     Logger::init();
     csharp_build::begin_build_lifecycle();
@@ -70,7 +76,7 @@ void FennaraPlugin::_enter_tree() {
     add_context_menu_plugin(godot::EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE,
                             script_context_menu_plugin);
     if (godot::FileAccess::file_exists(app_paths::daemon_binary_path())) {
-        update_notice::check_once();
+        update_check_thread = std::thread([]() { update_notice::check_once(); });
     } else {
         FLOG_SYS("Update check deferred until first-run setup is complete");
     }
@@ -274,6 +280,9 @@ void FennaraPlugin::_ensure_export_presets_exclude_fennara() {
 
 void FennaraPlugin::_exit_tree() {
     set_process(false);
+    if (update_check_thread.joinable()) {
+        update_check_thread.join();
+    }
     csharp_preparation_pending = false;
     initial_filesystem_scan_completed = false;
     csharp_build::request_build_shutdown();

--- a/fennara-cpp/src/ui/fennara_plugin.cpp
+++ b/fennara-cpp/src/ui/fennara_plugin.cpp
@@ -33,6 +33,11 @@ FennaraPlugin::FennaraPlugin() {
 }
 
 FennaraPlugin::~FennaraPlugin() {
+    _stop_update_check();
+}
+
+void FennaraPlugin::_stop_update_check() {
+    update_check_cancelled.store(true, std::memory_order_release);
     if (update_check_thread.joinable()) {
         update_check_thread.join();
     }
@@ -76,7 +81,9 @@ void FennaraPlugin::_enter_tree() {
     add_context_menu_plugin(godot::EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE,
                             script_context_menu_plugin);
     if (godot::FileAccess::file_exists(app_paths::daemon_binary_path())) {
-        update_check_thread = std::thread([]() { update_notice::check_once(); });
+        update_check_cancelled.store(false, std::memory_order_release);
+        update_check_thread =
+            std::thread([this]() { update_notice::check_once(&update_check_cancelled); });
     } else {
         FLOG_SYS("Update check deferred until first-run setup is complete");
     }
@@ -280,9 +287,7 @@ void FennaraPlugin::_ensure_export_presets_exclude_fennara() {
 
 void FennaraPlugin::_exit_tree() {
     set_process(false);
-    if (update_check_thread.joinable()) {
-        update_check_thread.join();
-    }
+    _stop_update_check();
     csharp_preparation_pending = false;
     initial_filesystem_scan_completed = false;
     csharp_build::request_build_shutdown();

--- a/fennara-cpp/src/ui/update_panel.cpp
+++ b/fennara-cpp/src/ui/update_panel.cpp
@@ -167,14 +167,19 @@ void UpdatePanel::refresh() {
     if (coordinator == nullptr || title_label == nullptr) {
         return;
     }
+    const bool staging = coordinator->get_release_track() == "staging";
+    const godot::String channel_label = coordinator->get_release_channel().replace("pr-", "PR ");
+    const godot::String update_label = staging ? channel_label + godot::String(" staging update")
+                                               : godot::String("Fennara update");
     if (coordinator->is_preparing()) {
-        title_label->set_text("Preparing Fennara update");
+        title_label->set_text("Preparing " + update_label);
     } else if (coordinator->is_ready_to_close()) {
-        title_label->set_text("Ready to install Fennara");
+        title_label->set_text("Ready to install " + update_label);
     } else if (coordinator->is_waiting_for_godot()) {
-        title_label->set_text("Installing Fennara update");
+        title_label->set_text("Installing " + update_label);
     } else {
-        title_label->set_text("Update Fennara");
+        title_label->set_text(staging ? channel_label + godot::String(" staging update")
+                                      : godot::String("Update Fennara"));
     }
     status_label->set_text(coordinator->get_status() + "\n\n" + coordinator->get_detail());
     progress->set_visible(coordinator->is_preparing() || coordinator->is_waiting_for_godot());

--- a/fennara-cpp/src/update/update_coordinator.cpp
+++ b/fennara-cpp/src/update/update_coordinator.cpp
@@ -188,11 +188,11 @@ void UpdateCoordinator::copy_report() {
     const godot::String cli = components.get("cli", "unknown");
     const godot::String runtime = components.get("installed_runtime", "unknown");
     godot::String report = "Fennara update report\nOperation: " + operation_id +
-                           "\nTrack: " + release_track +
+                           "\nTrack: " + (release_track.is_empty() ? "unknown" : release_track) +
                            "\nChannel: " + (release_channel.is_empty() ? "none" : release_channel) +
                            "\nInstalled addon: " + addon + "\nActive CLI: " + cli +
                            "\nActive runtime: " + runtime + "\nResolved target: " + target_version +
-                           "\nRelease tag: " + release_tag +
+                           "\nRelease tag: " + (release_tag.is_empty() ? "none" : release_tag) +
                            "\nSource commit: " + (source_commit.is_empty() ? "unknown" : source_commit) +
                            "\nLast stage: " + phase + "\nStatus: " + status_text +
                            "\nDetail: " + detail_text +

--- a/fennara-cpp/src/update/update_coordinator.cpp
+++ b/fennara-cpp/src/update/update_coordinator.cpp
@@ -57,6 +57,10 @@ void UpdateCoordinator::_bind_methods() {
                                 &UpdateCoordinator::get_operation_id);
     godot::ClassDB::bind_method(godot::D_METHOD("get_target_version"),
                                 &UpdateCoordinator::get_target_version);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_release_track"),
+                                &UpdateCoordinator::get_release_track);
+    godot::ClassDB::bind_method(godot::D_METHOD("get_release_channel"),
+                                &UpdateCoordinator::get_release_channel);
 }
 
 void UpdateCoordinator::_ready() {
@@ -93,6 +97,14 @@ void UpdateCoordinator::start_prepare() {
     dismissed = false;
     error_code = "";
     target_version = update_notice::latest_version();
+    release_track = update_notice::track();
+    release_channel = update_notice::channel();
+    release_tag = update_notice::target_release_tag();
+    source_commit = update_notice::source_commit();
+    if (target_version.is_empty()) {
+        _fail("FEN-UPDATE-TARGET-MISSING", "No exact Fennara update target was resolved.");
+        return;
+    }
     const uint64_t now = static_cast<uint64_t>(
         godot::Time::get_singleton()->get_unix_time_from_system() * 1000.0);
     operation_id = "update-" + godot::String::num_uint64(now) + "-godot-" +
@@ -102,6 +114,8 @@ void UpdateCoordinator::start_prepare() {
     godot::PackedStringArray args;
     args.append("update");
     args.append("--prepare");
+    args.append("--version");
+    args.append(target_version);
     args.append("--project");
     args.append(_project_path());
     args.append("--operation-id");
@@ -167,8 +181,21 @@ void UpdateCoordinator::copy_report() {
     if (display == nullptr) {
         return;
     }
+    const godot::Dictionary state = _read_operation();
+    const godot::Dictionary components = state.get("components", godot::Dictionary());
+    const godot::String phase = state.get("phase", "unknown");
+    const godot::String addon = components.get("addon", update_notice::current_version());
+    const godot::String cli = components.get("cli", "unknown");
+    const godot::String runtime = components.get("installed_runtime", "unknown");
     godot::String report = "Fennara update report\nOperation: " + operation_id +
-                           "\nStatus: " + status_text + "\nDetail: " + detail_text +
+                           "\nTrack: " + release_track +
+                           "\nChannel: " + (release_channel.is_empty() ? "none" : release_channel) +
+                           "\nInstalled addon: " + addon + "\nActive CLI: " + cli +
+                           "\nActive runtime: " + runtime + "\nResolved target: " + target_version +
+                           "\nRelease tag: " + release_tag +
+                           "\nSource commit: " + (source_commit.is_empty() ? "unknown" : source_commit) +
+                           "\nLast stage: " + phase + "\nStatus: " + status_text +
+                           "\nDetail: " + detail_text +
                            "\nCode: " + (error_code.is_empty() ? "none" : error_code) + "\n";
     display->clipboard_set(report);
 }
@@ -194,6 +221,8 @@ godot::String UpdateCoordinator::get_detail() const { return detail_text; }
 godot::String UpdateCoordinator::get_error_code() const { return error_code; }
 godot::String UpdateCoordinator::get_operation_id() const { return operation_id; }
 godot::String UpdateCoordinator::get_target_version() const { return target_version; }
+godot::String UpdateCoordinator::get_release_track() const { return release_track; }
+godot::String UpdateCoordinator::get_release_channel() const { return release_channel; }
 
 bool UpdateCoordinator::_launch_completion(const godot::String &command) {
     godot::OS *os = godot::OS::get_singleton();

--- a/fennara-cpp/src/update/update_coordinator.cpp
+++ b/fennara-cpp/src/update/update_coordinator.cpp
@@ -191,7 +191,8 @@ void UpdateCoordinator::copy_report() {
                            "\nTrack: " + (release_track.is_empty() ? "unknown" : release_track) +
                            "\nChannel: " + (release_channel.is_empty() ? "none" : release_channel) +
                            "\nInstalled addon: " + addon + "\nActive CLI: " + cli +
-                           "\nActive runtime: " + runtime + "\nResolved target: " + target_version +
+                           "\nActive runtime: " + runtime + "\nResolved target: " +
+                           (target_version.is_empty() ? "unknown" : target_version) +
                            "\nRelease tag: " + (release_tag.is_empty() ? "none" : release_tag) +
                            "\nSource commit: " + (source_commit.is_empty() ? "unknown" : source_commit) +
                            "\nLast stage: " + phase + "\nStatus: " + status_text +

--- a/fennara-cpp/src/update_notice.cpp
+++ b/fennara-cpp/src/update_notice.cpp
@@ -1,202 +1,15 @@
 #include "fennara/update_notice.hpp"
 
-#include "fennara/local_bridge.hpp"
 #include "fennara/logger.hpp"
-#include "fennara/release/version.hpp"
+#include "fennara/release/discovery.hpp"
 
-#include <godot_cpp/classes/file_access.hpp>
-#include <godot_cpp/classes/http_client.hpp>
-#include <godot_cpp/classes/json.hpp>
-#include <godot_cpp/classes/os.hpp>
-#include <godot_cpp/classes/time.hpp>
-#include <godot_cpp/classes/tls_options.hpp>
-#include <godot_cpp/variant/array.hpp>
-#include <godot_cpp/variant/packed_string_array.hpp>
-
-#include <string>
+#include <godot_cpp/variant/variant.hpp>
 
 namespace fennara::update_notice {
 namespace {
 
-constexpr const char *kLatestReleasePath =
-    "/repos/fennaraOfficial/fennara-godot-ai/releases/latest";
-
 bool g_checked = false;
-bool g_update_available = false;
-bool g_check_failed = false;
-std::string g_current_version;
-std::string g_latest_version;
-std::string g_error;
-
-bool is_version_candidate(godot::String version) {
-    return release_version::is_valid(release_version::normalize(version));
-}
-
-godot::String extract_asset_version(const godot::String &name,
-                                    const godot::String &prefix,
-                                    const godot::String &suffix) {
-    if (!name.begins_with(prefix) || !name.ends_with(suffix)) {
-        return "";
-    }
-    int start = prefix.length();
-    int count = name.length() - start - suffix.length();
-    if (count <= 0) {
-        return "";
-    }
-    godot::String version = release_version::normalize(name.substr(start, count));
-    return is_version_candidate(version) ? version : godot::String();
-}
-
-godot::String latest_version_from_release(const godot::Dictionary &response) {
-    godot::String tag = release_version::normalize(godot::String(response.get("tag_name", "")));
-    if (is_version_candidate(tag)) {
-        return tag;
-    }
-
-    godot::Variant assets_value = response.get("assets", godot::Array());
-    if (assets_value.get_type() != godot::Variant::ARRAY) {
-        return "";
-    }
-
-    godot::Array assets = assets_value;
-    const godot::String prefixes[] = {
-        "fennara-release-manifest-v",
-        "fennara-release-addon-v",
-        "fennara-release-local-linux-x86_64-v",
-        "fennara-release-local-windows-x86_64-v",
-        "fennara-release-local-macos-arm64-v",
-        "fennara-cli-linux-x86_64-v",
-        "fennara-cli-windows-x86_64-v",
-        "fennara-cli-macos-arm64-v",
-    };
-    const godot::String suffixes[] = {
-        ".json",
-        ".zip",
-        ".zip",
-        ".zip",
-        ".zip",
-        ".zip",
-        ".zip",
-        ".zip",
-    };
-
-    for (int prefix_index = 0; prefix_index < 8; prefix_index++) {
-        for (int asset_index = 0; asset_index < assets.size(); asset_index++) {
-            godot::Variant asset_value = assets[asset_index];
-            if (asset_value.get_type() != godot::Variant::DICTIONARY) {
-                continue;
-            }
-            godot::Dictionary asset = asset_value;
-            godot::String name = asset.get("name", "");
-            godot::String version =
-                extract_asset_version(name, prefixes[prefix_index], suffixes[prefix_index]);
-            if (!version.is_empty()) {
-                return version;
-            }
-        }
-    }
-
-    return "";
-}
-
-bool version_is_newer(const godot::String &latest, const godot::String &current) {
-    return release_version::compare(latest, current).value_or(0) > 0;
-}
-
-godot::String read_addon_version() {
-    godot::String path = "res://addons/fennara/VERSION";
-    if (!godot::FileAccess::file_exists(path)) {
-        return FennaraLocalBridge::PLUGIN_VERSION;
-    }
-    godot::Ref<godot::FileAccess> file = godot::FileAccess::open(path, godot::FileAccess::READ);
-    if (file.is_null()) {
-        return FennaraLocalBridge::PLUGIN_VERSION;
-    }
-    godot::String version = file->get_as_text().strip_edges();
-    return version.is_empty() ? godot::String(FennaraLocalBridge::PLUGIN_VERSION) : version;
-}
-
-godot::Dictionary get_github_latest_release(int timeout_ms) {
-    godot::Dictionary result;
-    godot::Ref<godot::HTTPClient> http;
-    http.instantiate();
-
-    godot::Error err = http->connect_to_host(
-        "https://api.github.com",
-        443,
-        godot::TLSOptions::client());
-    if (err != godot::OK) {
-        result["success"] = false;
-        result["error"] = "Failed to connect to GitHub.";
-        return result;
-    }
-
-    godot::PackedStringArray headers;
-    headers.append("Accept: application/vnd.github+json");
-    headers.append("User-Agent: fennara-godot-ai");
-
-    uint64_t deadline = godot::Time::get_singleton()->get_ticks_msec() + timeout_ms;
-    bool request_sent = false;
-    godot::String response_body;
-
-    while (godot::Time::get_singleton()->get_ticks_msec() < deadline) {
-        http->poll();
-        godot::HTTPClient::Status status = http->get_status();
-
-        if (status == godot::HTTPClient::STATUS_CANT_CONNECT ||
-            status == godot::HTTPClient::STATUS_TLS_HANDSHAKE_ERROR ||
-            status == godot::HTTPClient::STATUS_CONNECTION_ERROR) {
-            result["success"] = false;
-            result["error"] = "Failed to connect to GitHub.";
-            return result;
-        }
-
-        if (status == godot::HTTPClient::STATUS_CONNECTED && !request_sent) {
-            err = http->request(godot::HTTPClient::METHOD_GET, kLatestReleasePath, headers);
-            if (err != godot::OK) {
-                result["success"] = false;
-                result["error"] = "Failed to send GitHub request.";
-                return result;
-            }
-            request_sent = true;
-        }
-
-        if (status == godot::HTTPClient::STATUS_BODY) {
-            godot::PackedByteArray chunk = http->read_response_body_chunk();
-            if (!chunk.is_empty()) {
-                response_body += chunk.get_string_from_utf8();
-            }
-            if (http->get_response_body_length() >= 0 &&
-                response_body.to_utf8_buffer().size() >= http->get_response_body_length()) {
-                break;
-            }
-        }
-
-        godot::OS::get_singleton()->delay_usec(10000);
-    }
-
-    if (!http->has_response()) {
-        result["success"] = false;
-        result["error"] = "Timed out waiting for GitHub.";
-        return result;
-    }
-
-    godot::Variant parsed = godot::JSON::parse_string(response_body);
-    if (parsed.get_type() != godot::Variant::DICTIONARY) {
-        result["success"] = false;
-        result["error"] = "GitHub response was not JSON.";
-        return result;
-    }
-
-    result = parsed;
-    result["success"] = true;
-    return result;
-}
-
-void set_error(const godot::String &message) {
-    g_check_failed = true;
-    g_error = message.utf8().get_data();
-}
+release_discovery::Result g_result;
 
 } // namespace
 
@@ -205,58 +18,67 @@ void check_once() {
         return;
     }
     g_checked = true;
-
-    godot::String current = release_version::normalize(read_addon_version());
-    g_current_version = current.utf8().get_data();
-
-    godot::Dictionary response = get_github_latest_release(5000);
-    if (!(bool)response.get("success", false)) {
-        set_error(response.get("error", "Latest version request failed."));
-        FLOG_TOOL("Update check skipped: latest release request failed");
-        return;
+    g_result = release_discovery::check(5000);
+    if (!g_result.success) {
+        FLOG_TOOL("Update check skipped: " + g_result.error);
     }
-
-    godot::String latest = latest_version_from_release(response);
-    if (latest.is_empty()) {
-        set_error("Latest release did not include a versioned tag or asset.");
-        return;
-    }
-
-    g_latest_version = latest.utf8().get_data();
-    g_update_available = version_is_newer(latest, current);
 }
 
 bool is_update_available() {
-    return g_update_available;
+    return g_result.update_available;
 }
 
 godot::String current_version() {
-    return godot::String(g_current_version.c_str());
+    return g_result.current.version;
 }
 
 godot::String latest_version() {
-    return godot::String(g_latest_version.c_str());
+    return g_result.target_version;
+}
+
+godot::String channel() {
+    return g_result.current.channel;
+}
+
+godot::String track() {
+    return g_result.current.track;
+}
+
+godot::String target_release_tag() {
+    return g_result.target_release_tag;
+}
+
+godot::String source_commit() {
+    return g_result.target_source_commit.is_empty() ? g_result.current.source_commit
+                                                    : g_result.target_source_commit;
 }
 
 godot::String warning_text() {
-    if (!g_update_available) {
+    if (!g_result.update_available) {
         return "";
     }
-    return "Fennara is out of date. Current addon: " + current_version() +
-           ". Latest release: " + latest_version() +
-           ". Ask the user to run `fennara update` inside this Godot project or pass `--project <path>`.";
+    const godot::String label = g_result.current.is_staging()
+                                    ? g_result.current.channel + " staging"
+                                    : godot::String("stable");
+    return "Fennara " + label + " is out of date. Current addon: " +
+           current_version() + ". Available release: " + latest_version() + ".";
 }
 
 godot::Dictionary status() {
     godot::Dictionary result;
     result["checked"] = g_checked;
-    result["check_failed"] = g_check_failed;
+    result["check_failed"] = g_checked && !g_result.success;
+    result["track"] = track();
+    result["channel"] = channel();
     result["current_version"] = current_version();
     result["latest_version"] = latest_version();
-    result["outdated"] = g_update_available;
-    result["message"] = g_update_available ? warning_text() : "";
-    if (g_check_failed) {
-        result["error"] = godot::String(g_error.c_str());
+    result["target_release_tag"] = target_release_tag();
+    result["source_commit"] = source_commit();
+    result["installed_source_commit"] = g_result.current.source_commit;
+    result["outdated"] = g_result.update_available;
+    result["message"] = g_result.update_available ? warning_text() : g_result.detail;
+    if (!g_result.error.is_empty()) {
+        result["error"] = g_result.error;
     }
     return result;
 }

--- a/fennara-cpp/src/update_notice.cpp
+++ b/fennara-cpp/src/update_notice.cpp
@@ -10,10 +10,17 @@
 namespace fennara::update_notice {
 namespace {
 
-bool g_check_started = false;
-bool g_checked = false;
-release_discovery::Result g_result;
-std::mutex g_mutex;
+struct State {
+    bool check_started = false;
+    bool checked = false;
+    release_discovery::Result result;
+    std::mutex mutex;
+};
+
+State &state() {
+    static State instance;
+    return instance;
+}
 
 struct Snapshot {
     bool check_started = false;
@@ -22,8 +29,9 @@ struct Snapshot {
 };
 
 Snapshot snapshot() {
-    std::lock_guard<std::mutex> lock(g_mutex);
-    return {g_check_started, g_checked, g_result};
+    State &current = state();
+    std::lock_guard<std::mutex> lock(current.mutex);
+    return {current.check_started, current.checked, current.result};
 }
 
 godot::String warning_text_for(const release_discovery::Result &result) {
@@ -40,26 +48,27 @@ godot::String warning_text_for(const release_discovery::Result &result) {
 } // namespace
 
 void check_once(const std::atomic_bool *cancelled) {
+    State &current = state();
     {
-        std::lock_guard<std::mutex> lock(g_mutex);
-        if (g_check_started) {
+        std::lock_guard<std::mutex> lock(current.mutex);
+        if (current.check_started) {
             return;
         }
-        g_check_started = true;
+        current.check_started = true;
     }
     release_discovery::Result result = release_discovery::check(5000, cancelled);
     if (!result.success) {
         FLOG_TOOL("Update check skipped: " + result.error);
     }
     {
-        std::lock_guard<std::mutex> lock(g_mutex);
+        std::lock_guard<std::mutex> lock(current.mutex);
         if (result.cancelled) {
-            g_check_started = false;
-            g_checked = false;
+            current.check_started = false;
+            current.checked = false;
             return;
         }
-        g_result = result;
-        g_checked = true;
+        current.result = result;
+        current.checked = true;
     }
 }
 

--- a/fennara-cpp/src/update_notice.cpp
+++ b/fennara-cpp/src/update_notice.cpp
@@ -2,6 +2,7 @@
 
 #include "fennara/local_bridge.hpp"
 #include "fennara/logger.hpp"
+#include "fennara/release/version.hpp"
 
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/http_client.hpp>
@@ -27,43 +28,8 @@ std::string g_current_version;
 std::string g_latest_version;
 std::string g_error;
 
-int parse_part(const godot::String &part) {
-    godot::String digits;
-    for (int i = 0; i < part.length(); i++) {
-        char32_t c = part[i];
-        if (c < '0' || c > '9') {
-            break;
-        }
-        digits += godot::String::chr(c);
-    }
-    return digits.is_empty() ? 0 : digits.to_int();
-}
-
-godot::String normalize_version(godot::String version) {
-    version = version.strip_edges();
-    if (version.begins_with("v")) {
-        version = version.substr(1);
-    }
-    return version;
-}
-
 bool is_version_candidate(godot::String version) {
-    version = normalize_version(version);
-    godot::PackedStringArray parts = version.split(".");
-    if (parts.size() < 2) {
-        return false;
-    }
-    for (int i = 0; i < parts.size(); i++) {
-        godot::String part = parts[i];
-        if (part.is_empty()) {
-            return false;
-        }
-        char32_t c = part[0];
-        if (c < '0' || c > '9') {
-            return false;
-        }
-    }
-    return true;
+    return release_version::is_valid(release_version::normalize(version));
 }
 
 godot::String extract_asset_version(const godot::String &name,
@@ -77,12 +43,12 @@ godot::String extract_asset_version(const godot::String &name,
     if (count <= 0) {
         return "";
     }
-    godot::String version = normalize_version(name.substr(start, count));
+    godot::String version = release_version::normalize(name.substr(start, count));
     return is_version_candidate(version) ? version : godot::String();
 }
 
 godot::String latest_version_from_release(const godot::Dictionary &response) {
-    godot::String tag = normalize_version(godot::String(response.get("tag_name", "")));
+    godot::String tag = release_version::normalize(godot::String(response.get("tag_name", "")));
     if (is_version_candidate(tag)) {
         return tag;
     }
@@ -134,22 +100,7 @@ godot::String latest_version_from_release(const godot::Dictionary &response) {
 }
 
 bool version_is_newer(const godot::String &latest, const godot::String &current) {
-    godot::PackedStringArray latest_parts = latest.split(".");
-    godot::PackedStringArray current_parts = current.split(".");
-    int count = latest_parts.size() > current_parts.size()
-                    ? latest_parts.size()
-                    : current_parts.size();
-    for (int i = 0; i < count; i++) {
-        int latest_part = i < latest_parts.size() ? parse_part(latest_parts[i]) : 0;
-        int current_part = i < current_parts.size() ? parse_part(current_parts[i]) : 0;
-        if (latest_part > current_part) {
-            return true;
-        }
-        if (latest_part < current_part) {
-            return false;
-        }
-    }
-    return false;
+    return release_version::compare(latest, current).value_or(0) > 0;
 }
 
 godot::String read_addon_version() {
@@ -255,7 +206,7 @@ void check_once() {
     }
     g_checked = true;
 
-    godot::String current = normalize_version(read_addon_version());
+    godot::String current = release_version::normalize(read_addon_version());
     g_current_version = current.utf8().get_data();
 
     godot::Dictionary response = get_github_latest_release(5000);

--- a/fennara-cpp/src/update_notice.cpp
+++ b/fennara-cpp/src/update_notice.cpp
@@ -5,80 +5,114 @@
 
 #include <godot_cpp/variant/variant.hpp>
 
+#include <mutex>
+
 namespace fennara::update_notice {
 namespace {
 
+bool g_check_started = false;
 bool g_checked = false;
 release_discovery::Result g_result;
+std::mutex g_mutex;
+
+struct Snapshot {
+    bool check_started = false;
+    bool checked = false;
+    release_discovery::Result result;
+};
+
+Snapshot snapshot() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return {g_check_started, g_checked, g_result};
+}
+
+godot::String warning_text_for(const release_discovery::Result &result) {
+    if (!result.update_available) {
+        return "";
+    }
+    const godot::String label = result.current.is_staging()
+                                    ? result.current.channel + godot::String(" staging")
+                                    : godot::String("stable");
+    return "Fennara " + label + " is out of date. Current addon: " +
+           result.current.version + ". Available release: " + result.target_version + ".";
+}
 
 } // namespace
 
 void check_once() {
-    if (g_checked) {
-        return;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        if (g_check_started) {
+            return;
+        }
+        g_check_started = true;
     }
-    g_checked = true;
-    g_result = release_discovery::check(5000);
-    if (!g_result.success) {
-        FLOG_TOOL("Update check skipped: " + g_result.error);
+    release_discovery::Result result = release_discovery::check(5000);
+    if (!result.success) {
+        FLOG_TOOL("Update check skipped: " + result.error);
+    }
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        g_result = result;
+        g_checked = true;
     }
 }
 
 bool is_update_available() {
-    return g_result.update_available;
+    return snapshot().result.update_available;
 }
 
 godot::String current_version() {
-    return g_result.current.version;
+    return snapshot().result.current.version;
 }
 
 godot::String latest_version() {
-    return g_result.target_version;
+    return snapshot().result.target_version;
 }
 
 godot::String channel() {
-    return g_result.current.channel;
+    return snapshot().result.current.channel;
 }
 
 godot::String track() {
-    return g_result.current.track;
+    return snapshot().result.current.track;
 }
 
 godot::String target_release_tag() {
-    return g_result.target_release_tag;
+    return snapshot().result.target_release_tag;
 }
 
 godot::String source_commit() {
-    return g_result.target_source_commit.is_empty() ? g_result.current.source_commit
-                                                    : g_result.target_source_commit;
+    const release_discovery::Result result = snapshot().result;
+    return result.target_source_commit.is_empty() ? result.current.source_commit
+                                                  : result.target_source_commit;
 }
 
 godot::String warning_text() {
-    if (!g_result.update_available) {
-        return "";
-    }
-    const godot::String label = g_result.current.is_staging()
-                                    ? g_result.current.channel + " staging"
-                                    : godot::String("stable");
-    return "Fennara " + label + " is out of date. Current addon: " +
-           current_version() + ". Available release: " + latest_version() + ".";
+    return warning_text_for(snapshot().result);
 }
 
 godot::Dictionary status() {
+    const Snapshot state = snapshot();
+    const release_discovery::Result &result_state = state.result;
     godot::Dictionary result;
-    result["checked"] = g_checked;
-    result["check_failed"] = g_checked && !g_result.success;
-    result["track"] = track();
-    result["channel"] = channel();
-    result["current_version"] = current_version();
-    result["latest_version"] = latest_version();
-    result["target_release_tag"] = target_release_tag();
-    result["source_commit"] = source_commit();
-    result["installed_source_commit"] = g_result.current.source_commit;
-    result["outdated"] = g_result.update_available;
-    result["message"] = g_result.update_available ? warning_text() : g_result.detail;
-    if (!g_result.error.is_empty()) {
-        result["error"] = g_result.error;
+    result["checking"] = state.check_started && !state.checked;
+    result["checked"] = state.checked;
+    result["check_failed"] = state.checked && !result_state.success;
+    result["track"] = result_state.current.track;
+    result["channel"] = result_state.current.channel;
+    result["current_version"] = result_state.current.version;
+    result["latest_version"] = result_state.target_version;
+    result["target_release_tag"] = result_state.target_release_tag;
+    result["source_commit"] = result_state.target_source_commit.is_empty()
+                                  ? result_state.current.source_commit
+                                  : result_state.target_source_commit;
+    result["installed_source_commit"] = result_state.current.source_commit;
+    result["outdated"] = result_state.update_available;
+    result["message"] = result_state.update_available ? warning_text_for(result_state)
+                                                       : result_state.detail;
+    if (!result_state.error.is_empty()) {
+        result["error"] = result_state.error;
     }
     return result;
 }

--- a/fennara-cpp/src/update_notice.cpp
+++ b/fennara-cpp/src/update_notice.cpp
@@ -39,7 +39,7 @@ godot::String warning_text_for(const release_discovery::Result &result) {
 
 } // namespace
 
-void check_once() {
+void check_once(const std::atomic_bool *cancelled) {
     {
         std::lock_guard<std::mutex> lock(g_mutex);
         if (g_check_started) {
@@ -47,12 +47,17 @@ void check_once() {
         }
         g_check_started = true;
     }
-    release_discovery::Result result = release_discovery::check(5000);
+    release_discovery::Result result = release_discovery::check(5000, cancelled);
     if (!result.success) {
         FLOG_TOOL("Update check skipped: " + result.error);
     }
     {
         std::lock_guard<std::mutex> lock(g_mutex);
+        if (result.cancelled) {
+            g_check_started = false;
+            g_checked = false;
+            return;
+        }
         g_result = result;
         g_checked = true;
     }

--- a/godot_demo/addons/fennara/release.json
+++ b/godot_demo/addons/fennara/release.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": 1,
+  "track": "stable",
+  "version": "0.3.8",
+  "release_tag": "v0.3.8"
+}

--- a/godot_demo/tests/first_run_setup_test.gd
+++ b/godot_demo/tests/first_run_setup_test.gd
@@ -1,12 +1,37 @@
 extends SceneTree
 
 
+func _on_test_watchdog_timeout() -> void:
+	push_error("Native first-run setup test did not finish within 10 seconds.")
+	quit(1)
+
+
+func _remove_tree(path: String) -> void:
+	var directory := DirAccess.open(path)
+	if directory != null:
+		directory.list_dir_begin()
+		var entry := directory.get_next()
+		while not entry.is_empty():
+			var entry_path := path.path_join(entry)
+			if directory.current_is_dir():
+				_remove_tree(entry_path)
+			else:
+				DirAccess.remove_absolute(entry_path)
+			entry = directory.get_next()
+		directory.list_dir_end()
+	DirAccess.remove_absolute(path)
+
+
 func _initialize() -> void:
+	var watchdog := create_timer(10.0)
+	watchdog.timeout.connect(_on_test_watchdog_timeout)
 	var original_local_app_data := OS.get_environment("LOCALAPPDATA")
+	var original_user_profile := OS.get_environment("USERPROFILE")
 	var test_local_app_data := ProjectSettings.globalize_path(
 		"res://.godot/first-run-setup-test-appdata",
 	)
 	OS.set_environment("LOCALAPPDATA", test_local_app_data)
+	OS.set_environment("USERPROFILE", test_local_app_data.path_join("profile"))
 	var extension := load("res://addons/fennara/fennara.gdextension")
 	assert(extension != null)
 	OS.set_environment("FENNARA_FORCE_FIRST_RUN_SETUP", "1")
@@ -41,7 +66,10 @@ func _initialize() -> void:
 
 	setup.start(ProjectSettings.globalize_path("res://"), "0.3.8")
 	assert(setup.has_failed())
-	assert(setup.get_error_code() == "FEN-SETUP-MANIFEST-DOWNLOAD")
+	assert(
+		setup.get_error_code() == "FEN-SETUP-MANIFEST-DOWNLOAD",
+		"Expected manifest download failure, got %s" % setup.get_error_code(),
+	)
 	assert(setup.get_status() == "Fennara setup could not finish.")
 	assert(setup.get_operation_id().is_empty())
 
@@ -67,10 +95,8 @@ func _initialize() -> void:
 	OS.set_environment("FENNARA_SETUP_TEST_SUCCESS", "")
 	OS.set_environment("FENNARA_FORCE_FIRST_RUN_SETUP", "")
 	OS.set_environment("LOCALAPPDATA", original_local_app_data)
+	OS.set_environment("USERPROFILE", original_user_profile)
 	setup.queue_free()
-	DirAccess.remove_absolute(test_local_app_data.path_join("Fennara/cache/setup"))
-	DirAccess.remove_absolute(test_local_app_data.path_join("Fennara/cache"))
-	DirAccess.remove_absolute(test_local_app_data.path_join("Fennara"))
-	DirAccess.remove_absolute(test_local_app_data)
+	_remove_tree(test_local_app_data)
 	print("first-run setup state test passed")
 	quit(0)

--- a/local/Cargo.lock
+++ b/local/Cargo.lock
@@ -271,6 +271,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 name = "fennara-cli"
 version = "0.3.8"
 dependencies = [
+ "base64",
+ "getrandom 0.3.4",
+ "hmac",
  "json5",
  "semver",
  "serde",

--- a/local/Cargo.lock
+++ b/local/Cargo.lock
@@ -272,6 +272,7 @@ name = "fennara-cli"
 version = "0.3.8"
 dependencies = [
  "json5",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
@@ -1149,6 +1150,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/local/crates/fennara-cli/Cargo.toml
+++ b/local/crates/fennara-cli/Cargo.toml
@@ -11,6 +11,9 @@ name = "fennara"
 path = "src/main.rs"
 
 [dependencies]
+base64 = "0.22"
+getrandom = "0.3"
+hmac = "0.12"
 json5 = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/local/crates/fennara-cli/Cargo.toml
+++ b/local/crates/fennara-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 json5 = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+semver = "1.0"
 sha2 = "0.10"
 sysinfo = "0.30"
 toml_edit = "0.22"

--- a/local/crates/fennara-cli/src/daemon_setup.rs
+++ b/local/crates/fennara-cli/src/daemon_setup.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::net::TcpStream;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -162,6 +163,12 @@ pub fn shutdown_if_running(layout: &AppLayout) -> Result<(), String> {
         .read_to_string(&mut response)
         .map_err(|error| format!("failed to read daemon shutdown response: {error}"))?;
     if !response.starts_with("HTTP/1.1 200") && !response.starts_with("HTTP/1.0 200") {
+        if response.starts_with("HTTP/1.1 409") || response.starts_with("HTTP/1.0 409") {
+            return Err(
+                "another Godot project is still connected to Fennara; close every other Fennara-enabled editor before switching the active version"
+                    .to_string(),
+            );
+        }
         return Err("daemon rejected the authenticated shutdown request".to_string());
     }
     let deadline = Instant::now() + START_TIMEOUT;
@@ -178,6 +185,57 @@ pub fn shutdown_if_running(layout: &AppLayout) -> Result<(), String> {
         thread::sleep(POLL_INTERVAL);
     }
     Err("the previous Fennara daemon did not stop before update activation".to_string())
+}
+
+pub fn ensure_switch_available(
+    layout: &AppLayout,
+    allowed_project: Option<&Path>,
+) -> Result<(), String> {
+    if matches!(
+        health(),
+        Err(HealthError {
+            kind: HealthErrorKind::NotRunning,
+            ..
+        })
+    ) {
+        return Ok(());
+    }
+    let token_path = layout.app_dir.join("daemon-control-token");
+    let token = std::fs::read_to_string(&token_path)
+        .map_err(|error| format!("failed to read {}: {error}", display_path(&token_path)))?
+        .trim()
+        .to_string();
+    if token.is_empty() || token.contains(['\r', '\n']) {
+        return Err("the local daemon control token is invalid".to_string());
+    }
+    let mut stream = TcpStream::connect(DAEMON_ADDR)
+        .map_err(|error| format!("failed to connect to the running daemon: {error}"))?;
+    stream
+        .set_read_timeout(Some(HEALTH_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    stream
+        .set_write_timeout(Some(HEALTH_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    let request = format!(
+        "GET /status HTTP/1.1\r\nHost: 127.0.0.1\r\nX-Fennara-Control-Token: {token}\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("failed to request daemon status: {error}"))?;
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .map_err(|error| format!("failed to read daemon status: {error}"))?;
+    let status = parse_success_response(&response)?;
+    let conflicts = conflicting_project_count(&status, allowed_project)?;
+    if conflicts == 0 {
+        Ok(())
+    } else {
+        Err(format!(
+            "{conflicts} other Fennara-enabled Godot project{} still connected; close every other editor before switching the active version",
+            if conflicts == 1 { " is" } else { "s are" }
+        ))
+    }
 }
 
 pub fn health() -> Result<Value, HealthError> {
@@ -217,6 +275,42 @@ fn parse_health_response(response: &str) -> Result<Value, HealthError> {
         return Err(other_health_message("daemon returned non-200 status"));
     }
     serde_json::from_str(body).map_err(|error| other_health_message(error.to_string()))
+}
+
+fn parse_success_response(response: &str) -> Result<Value, String> {
+    let (headers, body) = response
+        .split_once("\r\n\r\n")
+        .ok_or_else(|| "invalid daemon HTTP response".to_string())?;
+    if !headers.starts_with("HTTP/1.1 200") && !headers.starts_with("HTTP/1.0 200") {
+        return Err("daemon returned non-200 status".to_string());
+    }
+    serde_json::from_str(body).map_err(|error| format!("invalid daemon status JSON: {error}"))
+}
+
+fn conflicting_project_count(
+    status: &Value,
+    allowed_project: Option<&Path>,
+) -> Result<usize, String> {
+    let allowed = allowed_project.map(canonical_or_original);
+    let projects = status
+        .get("connected_projects")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "daemon status is missing connected_projects".to_string())?;
+    Ok(projects
+        .iter()
+        .filter(|project| {
+            let Some(path) = project.get("project_path").and_then(Value::as_str) else {
+                return true;
+            };
+            allowed
+                .as_ref()
+                .is_none_or(|allowed| canonical_or_original(Path::new(path)) != *allowed)
+        })
+        .count())
+}
+
+fn canonical_or_original(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn ensure_version(health: &Value, expected_version: &str) -> Result<(), String> {
@@ -274,5 +368,21 @@ mod tests {
     fn rejects_non_success_health_response() {
         let error = parse_health_response("HTTP/1.1 503 Unavailable\r\n\r\n{}").unwrap_err();
         assert!(error.message.contains("non-200"));
+    }
+
+    #[test]
+    fn connected_project_preflight_allows_only_the_selected_project() {
+        let current = std::env::current_dir().unwrap();
+        let status = json!({
+            "connected_projects": [
+                { "project_path": current },
+                { "project_path": current.join("other") }
+            ]
+        });
+        assert_eq!(
+            conflicting_project_count(&status, Some(&current)).unwrap(),
+            1
+        );
+        assert_eq!(conflicting_project_count(&status, None).unwrap(), 2);
     }
 }

--- a/local/crates/fennara-cli/src/daemon_setup.rs
+++ b/local/crates/fennara-cli/src/daemon_setup.rs
@@ -1,5 +1,8 @@
 use crate::app_layout::{AppLayout, binary_name, display_path};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use hmac::{Hmac, Mac};
 use serde_json::Value;
+use sha2::Sha256;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::net::TcpStream;
@@ -12,6 +15,8 @@ const DAEMON_ADDR: &str = "127.0.0.1:41287";
 const HEALTH_TIMEOUT: Duration = Duration::from_millis(500);
 const START_TIMEOUT: Duration = Duration::from_secs(10);
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MAX_CHALLENGE_RESPONSE_BYTES: usize = 4096;
+type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum HealthErrorKind {
@@ -137,13 +142,8 @@ pub fn shutdown_if_running(layout: &AppLayout) -> Result<(), String> {
         return Ok(());
     }
     let token_path = layout.app_dir.join("daemon-control-token");
-    let token = std::fs::read_to_string(&token_path)
-        .map_err(|error| format!("failed to read {}: {error}", display_path(&token_path)))?
-        .trim()
-        .to_string();
-    if token.is_empty() || token.contains(['\r', '\n']) {
-        return Err("the local daemon control token is invalid".to_string());
-    }
+    let token = read_control_token(&token_path)?;
+    verify_daemon_control(&token)?;
     let mut stream = TcpStream::connect(DAEMON_ADDR)
         .map_err(|error| format!("failed to connect to the running daemon: {error}"))?;
     stream
@@ -201,13 +201,8 @@ pub fn ensure_switch_available(
         return Ok(());
     }
     let token_path = layout.app_dir.join("daemon-control-token");
-    let token = std::fs::read_to_string(&token_path)
-        .map_err(|error| format!("failed to read {}: {error}", display_path(&token_path)))?
-        .trim()
-        .to_string();
-    if token.is_empty() || token.contains(['\r', '\n']) {
-        return Err("the local daemon control token is invalid".to_string());
-    }
+    let token = read_control_token(&token_path)?;
+    verify_daemon_control(&token)?;
     let mut stream = TcpStream::connect(DAEMON_ADDR)
         .map_err(|error| format!("failed to connect to the running daemon: {error}"))?;
     stream
@@ -285,6 +280,67 @@ fn parse_success_response(response: &str) -> Result<Value, String> {
         return Err("daemon returned non-200 status".to_string());
     }
     serde_json::from_str(body).map_err(|error| format!("invalid daemon status JSON: {error}"))
+}
+
+fn read_control_token(path: &Path) -> Result<String, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", display_path(path)))?;
+    let token = raw.trim();
+    let valid = URL_SAFE_NO_PAD
+        .decode(token)
+        .is_ok_and(|bytes| bytes.len() == 32);
+    if !valid {
+        return Err("the local daemon control token is invalid".to_string());
+    }
+    Ok(token.to_string())
+}
+
+fn verify_daemon_control(control_token: &str) -> Result<(), String> {
+    let mut nonce = [0_u8; 32];
+    getrandom::fill(&mut nonce)
+        .map_err(|error| format!("failed to create daemon challenge: {error}"))?;
+    let encoded_nonce = URL_SAFE_NO_PAD.encode(nonce);
+    let mut stream = TcpStream::connect(DAEMON_ADDR)
+        .map_err(|error| format!("failed to connect to the running daemon: {error}"))?;
+    stream
+        .set_read_timeout(Some(HEALTH_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    stream
+        .set_write_timeout(Some(HEALTH_TIMEOUT))
+        .map_err(|error| error.to_string())?;
+    let request = format!(
+        "GET /control/challenge?nonce={encoded_nonce} HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n"
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|error| format!("failed to request daemon identity proof: {error}"))?;
+    let mut response = String::new();
+    stream
+        .take(MAX_CHALLENGE_RESPONSE_BYTES as u64 + 1)
+        .read_to_string(&mut response)
+        .map_err(|error| format!("failed to read daemon identity proof: {error}"))?;
+    if response.len() > MAX_CHALLENGE_RESPONSE_BYTES {
+        return Err("daemon identity proof exceeded the local size limit".to_string());
+    }
+    let challenge = parse_success_response(&response)?;
+    let proof = challenge
+        .get("proof")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            "the process on the Fennara daemon port did not prove its identity".to_string()
+        })?;
+    let proof = URL_SAFE_NO_PAD.decode(proof).map_err(|_| {
+        "the process on the Fennara daemon port returned an invalid proof".to_string()
+    })?;
+    let token_bytes = URL_SAFE_NO_PAD
+        .decode(control_token)
+        .map_err(|_| "the local daemon control token is invalid".to_string())?;
+    let mut mac = HmacSha256::new_from_slice(&token_bytes)
+        .map_err(|_| "the local daemon control token is invalid".to_string())?;
+    mac.update(&nonce);
+    mac.verify_slice(&proof).map_err(|_| {
+        "the process on the Fennara daemon port failed identity verification".to_string()
+    })
 }
 
 fn conflicting_project_count(
@@ -384,5 +440,17 @@ mod tests {
             1
         );
         assert_eq!(conflicting_project_count(&status, None).unwrap(), 2);
+    }
+
+    #[test]
+    fn rejects_malformed_control_tokens_before_use() {
+        let path = std::env::temp_dir().join(format!(
+            "fennara-invalid-control-token-{}",
+            std::process::id()
+        ));
+        std::fs::write(&path, "not-a-token\n").unwrap();
+        let error = read_control_token(&path).unwrap_err();
+        assert!(error.contains("control token is invalid"));
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -28,6 +28,8 @@ mod release_version;
 #[cfg(test)]
 mod release_version_tests;
 mod self_update;
+#[cfg(test)]
+mod self_update_tests;
 mod update_apply;
 mod update_stage;
 mod webview_prereq;
@@ -136,7 +138,7 @@ Fennara CLI {VERSION}
 Usage:
   fennara doctor [--repair]
   fennara diagnostics [--operation <operation-id>] [--json]
-  fennara install [--project <path>] [--version <version>]
+  fennara install [--project <path>] [--version <version>] [--channel pr-<number>]
   fennara mcp-setup <target flags>
   fennara update [--version <version>] [--project <path>] [--no-self-update] [--prepare]
   fennara recover --project <path> [--operation <operation-id>]

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -8,14 +8,25 @@ mod operation;
 mod project_addon;
 mod project_guidance;
 mod project_install;
+mod release_channel;
+#[cfg(test)]
+mod release_channel_tests;
 mod release_client;
 #[cfg(test)]
 mod release_client_tests;
+mod release_identity;
+#[cfg(test)]
+mod release_identity_tests;
 mod release_manifest;
+#[cfg(test)]
+mod release_manifest_tests;
 mod release_package;
 #[cfg(test)]
 mod release_package_tests;
 mod release_update;
+mod release_version;
+#[cfg(test)]
+mod release_version_tests;
 mod self_update;
 mod update_apply;
 mod update_stage;

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -8,6 +8,8 @@ mod operation;
 mod project_addon;
 mod project_guidance;
 mod project_install;
+#[cfg(test)]
+mod project_install_tests;
 mod release_channel;
 #[cfg(test)]
 mod release_channel_tests;
@@ -24,6 +26,8 @@ mod release_package;
 #[cfg(test)]
 mod release_package_tests;
 mod release_update;
+#[cfg(test)]
+mod release_update_tests;
 mod release_version;
 #[cfg(test)]
 mod release_version_tests;

--- a/local/crates/fennara-cli/src/project_addon.rs
+++ b/local/crates/fennara-cli/src/project_addon.rs
@@ -166,6 +166,28 @@ mod tests {
     }
 
     #[test]
+    fn rejects_addon_identity_that_does_not_match_version() {
+        let root = test_root("identity-version-mismatch");
+        let project = root.join("project");
+        let addon = write_addon(&project, Some("1.2.3"), true);
+        fs::write(
+            addon.join("release.json"),
+            serde_json::to_vec(&serde_json::json!({
+                "schema_version": 1,
+                "track": "stable",
+                "version": "1.2.4",
+                "release_tag": "v1.2.4"
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let error = inspect(&project).unwrap_err();
+        assert!(error.contains("does not match VERSION"));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn rejects_existing_addon_without_current_library() {
         let root = test_root("missing-library");
         let project = root.join("project");

--- a/local/crates/fennara-cli/src/project_addon.rs
+++ b/local/crates/fennara-cli/src/project_addon.rs
@@ -1,5 +1,6 @@
 use crate::app_layout::{arch_name, display_path, platform_name};
 use crate::project_install::project_addon_dir;
+use crate::release_identity::ReleaseIdentity;
 use crate::release_manifest::compare_versions;
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -44,6 +45,7 @@ pub fn validate(addon_dir: &Path) -> Result<ExistingAddon, String> {
             display_path(&version_path)
         ));
     }
+    ReleaseIdentity::load(addon_dir, &version)?;
 
     let library_path = current_library_path(addon_dir, &manifest_path)?;
     if !library_path.is_file() {

--- a/local/crates/fennara-cli/src/project_install.rs
+++ b/local/crates/fennara-cli/src/project_install.rs
@@ -1,8 +1,10 @@
 use crate::app_layout::display_path;
+use crate::daemon_setup;
 use crate::existing_addon_install;
 use crate::operation::{self, FailureClass, Phase};
 use crate::project_addon;
 use crate::project_guidance;
+use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
 use crate::release_package;
 use crate::webview_prereq;
 use std::env;
@@ -29,6 +31,16 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
                 "--source cannot be used when adopting an existing project addon",
             ));
         }
+        validate_requested_channel(
+            &project_addon_dir(&project_dir),
+            &existing.version,
+            options.channel.as_deref(),
+        )?;
+        let layout = crate::app_layout::AppLayout::detect()?;
+        if active_version(&layout).as_deref() != Some(existing.version.as_str()) {
+            daemon_setup::ensure_switch_available(&layout, Some(&project_dir))
+                .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+        }
         return existing_addon_install::run(&project_dir, existing, options.version.as_deref());
     }
     if addon_dir.exists() {
@@ -37,16 +49,36 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             display_path(&addon_dir)
         );
     }
+    let layout = crate::app_layout::AppLayout::detect()?;
+    daemon_setup::ensure_switch_available(&layout, Some(&project_dir))
+        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
 
     let (version, source) = match options.source_dir {
         Some(path) => {
+            if options.channel.is_some() {
+                return Err(operation::failure(
+                    FailureClass::ProjectInvalid,
+                    "--channel cannot be combined with a local --source addon",
+                ));
+            }
             println!("package: using local addon source {}", display_path(&path));
             ("local".to_string(), path)
         }
         None => {
-            let requested_version = options.version.as_deref().unwrap_or("latest");
+            let requested_version = options.version.clone().unwrap_or_else(|| {
+                options
+                    .channel
+                    .as_ref()
+                    .map(|channel| format!("channel:{channel}"))
+                    .unwrap_or_else(|| "latest".to_string())
+            });
             println!("requested version: {requested_version}");
-            let package = release_package::ensure_package(requested_version)?;
+            let package = release_package::ensure_package(&requested_version)?;
+            validate_requested_channel(
+                &package.addon_dir,
+                &package.version,
+                options.channel.as_deref(),
+            )?;
             (package.version, package.addon_dir)
         }
     };
@@ -63,6 +95,18 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     webview_prereq::warn_for_current_platform()?;
     println!("next: run `fennara update` inside this project when a new release is available");
     Ok(())
+}
+
+fn active_version(layout: &crate::app_layout::AppLayout) -> Option<String> {
+    crate::app_layout::read_current_manifest(&layout.current_manifest_path)
+        .ok()
+        .flatten()
+        .and_then(|manifest| {
+            manifest
+                .get("version")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
 }
 
 pub fn resolve_project_dir(project_dir: Option<PathBuf>) -> Result<PathBuf, String> {
@@ -93,13 +137,6 @@ pub fn has_fennara_addon(project_dir: &Path) -> bool {
     project_addon_dir(project_dir)
         .join("fennara.gdextension")
         .is_file()
-}
-
-pub fn project_addon_version(project_dir: &Path) -> Option<String> {
-    fs::read_to_string(project_addon_dir(project_dir).join("VERSION"))
-        .ok()
-        .map(|version| version.trim().to_string())
-        .filter(|version| !version.is_empty())
 }
 
 pub fn install_addon(project_dir: &Path, source: &Path) -> Result<(), String> {
@@ -163,6 +200,7 @@ struct InstallOptions {
     project_dir: Option<PathBuf>,
     source_dir: Option<PathBuf>,
     version: Option<String>,
+    channel: Option<String>,
 }
 
 impl InstallOptions {
@@ -170,6 +208,7 @@ impl InstallOptions {
         let mut project_dir = None;
         let mut source_dir = None;
         let mut version = None;
+        let mut channel = None;
         let mut index = 0;
 
         while index < args.len() {
@@ -195,6 +234,13 @@ impl InstallOptions {
                 arg if arg.starts_with("--version=") => {
                     version = Some(arg.trim_start_matches("--version=").to_string());
                 }
+                "--channel" => {
+                    index += 1;
+                    channel = Some(value_arg(&args, index, "--channel")?.to_string());
+                }
+                arg if arg.starts_with("--channel=") => {
+                    channel = Some(arg.trim_start_matches("--channel=").to_string());
+                }
                 "--operation-id" => {
                     index += 1;
                     value_arg(&args, index, "--operation-id")?;
@@ -217,8 +263,47 @@ impl InstallOptions {
             project_dir,
             source_dir,
             version,
+            channel,
         })
     }
+}
+
+fn validate_requested_channel(
+    addon_dir: &Path,
+    version: &str,
+    requested_channel: Option<&str>,
+) -> Result<(), String> {
+    let identity = ReleaseIdentity::load(addon_dir, version)
+        .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?;
+    if let Some(channel) = requested_channel {
+        let actual = identity.channel.as_deref().ok_or_else(|| {
+            operation::failure(
+                FailureClass::ProjectInvalid,
+                format!("--channel requested {channel}, but the addon is on the stable track"),
+            )
+        })?;
+        if identity.track != ReleaseTrack::Staging || actual != channel {
+            return Err(operation::failure(
+                FailureClass::ProjectInvalid,
+                format!("--channel requested {channel}, but the addon belongs to {actual}"),
+            ));
+        }
+    }
+    operation::set_component(
+        "release_track",
+        match identity.track {
+            ReleaseTrack::Stable => "stable",
+            ReleaseTrack::Staging => "staging",
+        },
+    )?;
+    operation::set_component("activation_reason", "project_install")?;
+    if let Some(channel) = identity.channel.as_deref() {
+        operation::set_component("release_channel", channel)?;
+    }
+    if let Some(source_commit) = identity.source_commit.as_deref() {
+        operation::set_component("source_commit", source_commit)?;
+    }
+    Ok(())
 }
 
 fn value_arg<'a>(args: &'a [&str], index: usize, option: &str) -> Result<&'a str, String> {
@@ -238,6 +323,7 @@ Usage:
   fennara install
   fennara install --project <path>
   fennara install --version 0.2.8 --project <path>
+  fennara install --version 0.3.9-pr.101.2 --channel pr-101 --project <path>
 "
     );
 }

--- a/local/crates/fennara-cli/src/project_install.rs
+++ b/local/crates/fennara-cli/src/project_install.rs
@@ -49,10 +49,6 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             display_path(&addon_dir)
         );
     }
-    let layout = crate::app_layout::AppLayout::detect()?;
-    daemon_setup::ensure_switch_available(&layout, Some(&project_dir))
-        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
-
     let (version, source) = match options.source_dir {
         Some(path) => {
             if options.channel.is_some() {
@@ -73,12 +69,18 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
                     .unwrap_or_else(|| "latest".to_string())
             });
             println!("requested version: {requested_version}");
-            let package = release_package::ensure_package(&requested_version)?;
-            validate_requested_channel(
-                &package.addon_dir,
-                &package.version,
+            let resolved = release_package::resolve_package(&requested_version)?;
+            validate_resolved_channel(
+                resolved.identity(),
+                resolved.version(),
                 options.channel.as_deref(),
             )?;
+            let layout = crate::app_layout::AppLayout::detect()?;
+            if active_version(&layout).as_deref() != Some(resolved.version()) {
+                daemon_setup::ensure_switch_available(&layout, Some(&project_dir))
+                    .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+            }
+            let package = release_package::ensure_resolved_package(resolved)?;
             (package.version, package.addon_dir)
         }
     };
@@ -275,14 +277,28 @@ fn validate_requested_channel(
 ) -> Result<(), String> {
     let identity = ReleaseIdentity::load(addon_dir, version)
         .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?;
+    validate_resolved_channel(Some(&identity), version, requested_channel)
+}
+
+fn validate_resolved_channel(
+    identity: Option<&ReleaseIdentity>,
+    version: &str,
+    requested_channel: Option<&str>,
+) -> Result<(), String> {
     if let Some(channel) = requested_channel {
-        let actual = identity.channel.as_deref().ok_or_else(|| {
-            operation::failure(
-                FailureClass::ProjectInvalid,
-                format!("--channel requested {channel}, but the addon is on the stable track"),
-            )
-        })?;
-        if identity.track != ReleaseTrack::Staging || actual != channel {
+        let actual = identity
+            .and_then(|value| value.channel.as_deref())
+            .ok_or_else(|| {
+                operation::failure(
+                    FailureClass::ProjectInvalid,
+                    format!("--channel requested {channel}, but the addon is on the stable track"),
+                )
+            })?;
+        if !matches!(
+            identity.map(|value| &value.track),
+            Some(ReleaseTrack::Staging)
+        ) || actual != channel
+        {
             return Err(operation::failure(
                 FailureClass::ProjectInvalid,
                 format!("--channel requested {channel}, but the addon belongs to {actual}"),
@@ -291,16 +307,17 @@ fn validate_requested_channel(
     }
     operation::set_component(
         "release_track",
-        match identity.track {
-            ReleaseTrack::Stable => "stable",
-            ReleaseTrack::Staging => "staging",
+        match identity.map(|value| &value.track) {
+            Some(ReleaseTrack::Staging) => "staging",
+            Some(ReleaseTrack::Stable) | None => "stable",
         },
     )?;
+    operation::set_requested_version(version)?;
     operation::set_component("activation_reason", "project_install")?;
-    if let Some(channel) = identity.channel.as_deref() {
+    if let Some(channel) = identity.and_then(|value| value.channel.as_deref()) {
         operation::set_component("release_channel", channel)?;
     }
-    if let Some(source_commit) = identity.source_commit.as_deref() {
+    if let Some(source_commit) = identity.and_then(|value| value.source_commit.as_deref()) {
         operation::set_component("source_commit", source_commit)?;
     }
     Ok(())

--- a/local/crates/fennara-cli/src/project_install.rs
+++ b/local/crates/fennara-cli/src/project_install.rs
@@ -285,26 +285,8 @@ fn validate_resolved_channel(
     version: &str,
     requested_channel: Option<&str>,
 ) -> Result<(), String> {
-    if let Some(channel) = requested_channel {
-        let actual = identity
-            .and_then(|value| value.channel.as_deref())
-            .ok_or_else(|| {
-                operation::failure(
-                    FailureClass::ProjectInvalid,
-                    format!("--channel requested {channel}, but the addon is on the stable track"),
-                )
-            })?;
-        if !matches!(
-            identity.map(|value| &value.track),
-            Some(ReleaseTrack::Staging)
-        ) || actual != channel
-        {
-            return Err(operation::failure(
-                FailureClass::ProjectInvalid,
-                format!("--channel requested {channel}, but the addon belongs to {actual}"),
-            ));
-        }
-    }
+    validate_channel_selection(identity, requested_channel)
+        .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?;
     operation::set_component(
         "release_track",
         match identity.map(|value| &value.track) {
@@ -319,6 +301,39 @@ fn validate_resolved_channel(
     }
     if let Some(source_commit) = identity.and_then(|value| value.source_commit.as_deref()) {
         operation::set_component("source_commit", source_commit)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_channel_selection(
+    identity: Option<&ReleaseIdentity>,
+    requested_channel: Option<&str>,
+) -> Result<(), String> {
+    if matches!(
+        identity.map(|value| &value.track),
+        Some(ReleaseTrack::Staging)
+    ) && identity
+        .and_then(|value| value.channel.as_deref())
+        .is_none()
+    {
+        return Err("staging addon release identity is missing its channel".into());
+    }
+    let Some(channel) = requested_channel else {
+        return Ok(());
+    };
+    let actual = identity
+        .and_then(|value| value.channel.as_deref())
+        .ok_or_else(|| {
+            format!("--channel requested {channel}, but the addon is on the stable track")
+        })?;
+    if !matches!(
+        identity.map(|value| &value.track),
+        Some(ReleaseTrack::Staging)
+    ) || actual != channel
+    {
+        return Err(format!(
+            "--channel requested {channel}, but the addon belongs to {actual}"
+        ));
     }
     Ok(())
 }

--- a/local/crates/fennara-cli/src/project_install_tests.rs
+++ b/local/crates/fennara-cli/src/project_install_tests.rs
@@ -1,0 +1,46 @@
+use crate::project_install::validate_channel_selection;
+use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
+
+#[test]
+fn validates_requested_staging_channel() {
+    let identity = staging_identity(Some("pr-101"));
+    assert!(validate_channel_selection(Some(&identity), Some("pr-101")).is_ok());
+    assert!(
+        validate_channel_selection(Some(&identity), Some("pr-102"))
+            .unwrap_err()
+            .contains("belongs to pr-101")
+    );
+}
+
+#[test]
+fn rejects_channels_for_stable_or_incomplete_staging_identity() {
+    let stable = ReleaseIdentity {
+        schema_version: 1,
+        track: ReleaseTrack::Stable,
+        version: "0.3.9".into(),
+        release_tag: "v0.3.9".into(),
+        channel: None,
+        source_commit: None,
+    };
+    assert!(
+        validate_channel_selection(Some(&stable), Some("pr-101"))
+            .unwrap_err()
+            .contains("stable track")
+    );
+    assert!(
+        validate_channel_selection(Some(&staging_identity(None)), None)
+            .unwrap_err()
+            .contains("missing its channel")
+    );
+}
+
+fn staging_identity(channel: Option<&str>) -> ReleaseIdentity {
+    ReleaseIdentity {
+        schema_version: 1,
+        track: ReleaseTrack::Staging,
+        version: "0.3.9-pr.101.2".into(),
+        release_tag: "v0.3.9-pr.101.2".into(),
+        channel: channel.map(str::to_string),
+        source_commit: Some("0123456789abcdef0123456789abcdef01234567".into()),
+    }
+}

--- a/local/crates/fennara-cli/src/project_install_tests.rs
+++ b/local/crates/fennara-cli/src/project_install_tests.rs
@@ -13,6 +13,12 @@ fn validates_requested_staging_channel() {
 }
 
 #[test]
+fn existing_staging_channel_is_inherited_when_rerun_omits_channel() {
+    let identity = staging_identity(Some("pr-101"));
+    assert!(validate_channel_selection(Some(&identity), None).is_ok());
+}
+
+#[test]
 fn rejects_channels_for_stable_or_incomplete_staging_identity() {
     let stable = ReleaseIdentity {
         schema_version: 1,

--- a/local/crates/fennara-cli/src/release_channel.rs
+++ b/local/crates/fennara-cli/src/release_channel.rs
@@ -1,6 +1,6 @@
 use crate::release_client;
 use crate::release_identity::{
-    ReleaseIdentity, ReleaseSelector, ReleaseTrack, channel_pointer_asset_name,
+    ReleaseIdentity, ReleaseSelector, ReleaseTrack, channel_pointer_asset_name, channel_pointer_ref,
 };
 use crate::release_manifest::ReleaseManifest;
 use serde::{Deserialize, Serialize};
@@ -82,15 +82,9 @@ impl ChannelPointer {
 }
 
 pub(crate) fn fetch(channel: &str) -> Result<ChannelPointer, String> {
-    let selector = ReleaseSelector::staging(channel)?;
-    let release = release_client::fetch_release_for_selector(&selector)?;
+    ReleaseSelector::staging(channel)?;
     let asset_name = channel_pointer_asset_name(channel)?;
-    let asset = release.asset_by_name(&asset_name).ok_or_else(|| {
-        format!(
-            "staging channel release {} is missing {asset_name}",
-            release.tag
-        )
-    })?;
-    let bytes = release_client::download_github_api_asset(&asset, &asset_name)?;
+    let reference = channel_pointer_ref(channel)?;
+    let bytes = release_client::download_github_contents(&reference, &asset_name)?;
     ChannelPointer::parse(&bytes, channel)
 }

--- a/local/crates/fennara-cli/src/release_channel.rs
+++ b/local/crates/fennara-cli/src/release_channel.rs
@@ -1,0 +1,96 @@
+use crate::release_client;
+use crate::release_identity::{
+    ReleaseIdentity, ReleaseSelector, ReleaseTrack, channel_pointer_asset_name,
+};
+use crate::release_manifest::ReleaseManifest;
+use serde::{Deserialize, Serialize};
+
+const CHANNEL_POINTER_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct ChannelPointer {
+    pub schema_version: u64,
+    pub channel: String,
+    pub version: String,
+    pub release_tag: String,
+    pub source_commit: String,
+    pub release_manifest_sha256: String,
+}
+
+impl ChannelPointer {
+    pub(crate) fn parse(bytes: &[u8], expected_channel: &str) -> Result<Self, String> {
+        let pointer: Self = serde_json::from_slice(bytes)
+            .map_err(|error| format!("failed to parse staging channel pointer: {error}"))?;
+        pointer.validate(expected_channel)?;
+        Ok(pointer)
+    }
+
+    pub(crate) fn validate(&self, expected_channel: &str) -> Result<(), String> {
+        if self.schema_version != CHANNEL_POINTER_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported staging channel pointer schema {}",
+                self.schema_version
+            ));
+        }
+        if self.channel != expected_channel {
+            return Err(format!(
+                "staging channel pointer {:?} does not match requested channel {expected_channel:?}",
+                self.channel
+            ));
+        }
+        let identity = ReleaseIdentity {
+            schema_version: 1,
+            track: ReleaseTrack::Staging,
+            version: self.version.clone(),
+            release_tag: self.release_tag.clone(),
+            channel: Some(self.channel.clone()),
+            source_commit: Some(self.source_commit.clone()),
+        };
+        identity.validate(&self.version)?;
+        if self.release_manifest_sha256.len() != 64
+            || !self
+                .release_manifest_sha256
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        {
+            return Err("staging channel pointer has invalid release manifest SHA-256".into());
+        }
+        Ok(())
+    }
+
+    pub(crate) fn exact_selector(&self) -> Result<ReleaseSelector, String> {
+        ReleaseSelector::exact(&self.version)
+    }
+
+    pub(crate) fn validate_manifest_identity(
+        &self,
+        manifest: &ReleaseManifest,
+    ) -> Result<(), String> {
+        let identity = manifest.release_identity()?.ok_or_else(|| {
+            "staging release manifest is missing its release identity".to_string()
+        })?;
+        if identity.track != ReleaseTrack::Staging
+            || identity.version != self.version
+            || identity.release_tag != self.release_tag
+            || identity.channel.as_deref() != Some(self.channel.as_str())
+            || identity.source_commit.as_deref() != Some(self.source_commit.as_str())
+        {
+            return Err("staging release manifest identity does not match channel pointer".into());
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn fetch(channel: &str) -> Result<ChannelPointer, String> {
+    let selector = ReleaseSelector::staging(channel)?;
+    let release = release_client::fetch_release_for_selector(&selector)?;
+    let asset_name = channel_pointer_asset_name(channel)?;
+    let asset = release.asset_by_name(&asset_name).ok_or_else(|| {
+        format!(
+            "staging channel release {} is missing {asset_name}",
+            release.tag
+        )
+    })?;
+    let bytes = release_client::download_github_api_asset(&asset, &asset_name)?;
+    ChannelPointer::parse(&bytes, channel)
+}

--- a/local/crates/fennara-cli/src/release_channel_tests.rs
+++ b/local/crates/fennara-cli/src/release_channel_tests.rs
@@ -1,0 +1,36 @@
+use crate::release_channel::ChannelPointer;
+use crate::release_identity::ReleaseSelector;
+
+const SOURCE_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+
+#[test]
+fn accepts_an_exact_pointer_for_the_requested_channel() {
+    let pointer = ChannelPointer::parse(&pointer("pr-101", "0.3.9-pr.101.2"), "pr-101").unwrap();
+    assert_eq!(
+        pointer.exact_selector().unwrap(),
+        ReleaseSelector::ExactVersion("0.3.9-pr.101.2".into())
+    );
+}
+
+#[test]
+fn rejects_cross_channel_and_malformed_pointers() {
+    let error = ChannelPointer::parse(&pointer("pr-125", "0.3.9-pr.125.1"), "pr-101").unwrap_err();
+    assert!(error.contains("does not match requested channel"));
+
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&pointer("pr-101", "0.3.9-pr.101.1")).unwrap();
+    value["release_manifest_sha256"] = serde_json::json!("bad");
+    assert!(ChannelPointer::parse(&serde_json::to_vec(&value).unwrap(), "pr-101").is_err());
+}
+
+fn pointer(channel: &str, version: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "channel": channel,
+        "version": version,
+        "release_tag": format!("v{version}"),
+        "source_commit": SOURCE_COMMIT,
+        "release_manifest_sha256": "a".repeat(64),
+    }))
+    .unwrap()
+}

--- a/local/crates/fennara-cli/src/release_channel_tests.rs
+++ b/local/crates/fennara-cli/src/release_channel_tests.rs
@@ -23,6 +23,15 @@ fn rejects_cross_channel_and_malformed_pointers() {
     assert!(ChannelPointer::parse(&serde_json::to_vec(&value).unwrap(), "pr-101").is_err());
 }
 
+#[test]
+fn rejects_unsupported_schema_version() {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(&pointer("pr-101", "0.3.9-pr.101.1")).unwrap();
+    value["schema_version"] = serde_json::json!(2);
+    let error = ChannelPointer::parse(&serde_json::to_vec(&value).unwrap(), "pr-101").unwrap_err();
+    assert!(error.contains("unsupported staging channel pointer schema"));
+}
+
 fn pointer(channel: &str, version: &str) -> Vec<u8> {
     serde_json::to_vec(&serde_json::json!({
         "schema_version": 1,

--- a/local/crates/fennara-cli/src/release_client.rs
+++ b/local/crates/fennara-cli/src/release_client.rs
@@ -1,5 +1,8 @@
 use crate::app_layout::display_path;
 use crate::operation::{self, FailureClass, Phase};
+use crate::release_channel::ChannelPointer;
+use crate::release_identity::ReleaseSelector;
+use crate::release_manifest::ReleaseManifest;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 use std::env;
@@ -18,15 +21,21 @@ const HTTP_WRITE_TIMEOUT_SECS: u64 = 30;
 pub struct ReleaseAsset {
     pub name: String,
     pub url: String,
+    pub api_url: Option<String>,
     pub version: Option<String>,
 }
 
 pub struct Release {
     pub tag: String,
     pub assets: Value,
+    pub(crate) channel_pointer: Option<ChannelPointer>,
 }
 
 impl Release {
+    pub(crate) fn is_channel_release(&self) -> bool {
+        self.channel_pointer.is_some()
+    }
+
     pub fn asset(&self, prefix: &str) -> Option<ReleaseAsset> {
         self.asset_by_prefix_suffix(prefix, ".zip")
     }
@@ -45,6 +54,7 @@ impl Release {
             Some(ReleaseAsset {
                 name: name.to_string(),
                 url: url.to_string(),
+                api_url: asset.get("url").and_then(Value::as_str).map(str::to_string),
                 version: version_from_asset_name(name),
             })
         })
@@ -60,6 +70,7 @@ impl Release {
             Some(ReleaseAsset {
                 name: name.to_string(),
                 url: url.to_string(),
+                api_url: asset.get("url").and_then(Value::as_str).map(str::to_string),
                 version: version_from_asset_name(name),
             })
         })
@@ -73,11 +84,20 @@ pub struct DownloadAsset<'a> {
 }
 
 pub fn fetch_release(version: &str) -> Result<Release, String> {
-    let tag = if version == "latest" {
-        "latest".to_string()
-    } else {
-        format!("v{version}")
-    };
+    let selector = ReleaseSelector::from_version_request(version)?;
+    match &selector {
+        ReleaseSelector::StagingChannel(channel) => {
+            let pointer = crate::release_channel::fetch(channel)?;
+            let mut release = fetch_release_for_selector(&pointer.exact_selector()?)?;
+            release.channel_pointer = Some(pointer);
+            Ok(release)
+        }
+        _ => fetch_release_for_selector(&selector),
+    }
+}
+
+pub(crate) fn fetch_release_for_selector(selector: &ReleaseSelector) -> Result<Release, String> {
+    let tag = selector.github_tag();
     let url = format!("https://api.github.com/repos/{REPO}/releases/tags/{tag}");
     operation::phase(Phase::Checking, "Fetching release metadata")?;
     println!("release: fetching metadata from {url}");
@@ -105,10 +125,77 @@ pub fn fetch_release(version: &str) -> Result<Release, String> {
             .unwrap_or(&tag)
             .to_string(),
         assets: value.get("assets").cloned().unwrap_or(Value::Null),
+        channel_pointer: None,
     };
     println!("release: {}", release.tag);
     operation::set_component("release", release.tag.trim_start_matches('v'))?;
     Ok(release)
+}
+
+pub fn download_release_manifest(
+    release: &Release,
+    asset: &ReleaseAsset,
+) -> Result<ReleaseManifest, String> {
+    let (bytes, actual_sha256) = download_bytes_with_hash(&asset.url, &asset.name)?;
+    parse_release_manifest(release, &bytes, &actual_sha256, &asset.name)
+}
+
+pub(crate) fn parse_release_manifest(
+    release: &Release,
+    bytes: &[u8],
+    actual_sha256: &str,
+    label: &str,
+) -> Result<ReleaseManifest, String> {
+    if let Some(pointer) = release.channel_pointer.as_ref() {
+        verify_expected_hash(label, &pointer.release_manifest_sha256, actual_sha256)?;
+    }
+    let manifest = ReleaseManifest::parse(bytes)
+        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    manifest
+        .release_identity()
+        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    if let Some(pointer) = release.channel_pointer.as_ref() {
+        pointer
+            .validate_manifest_identity(&manifest)
+            .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    }
+    Ok(manifest)
+}
+
+pub(crate) fn download_github_api_asset(
+    asset: &ReleaseAsset,
+    label: &str,
+) -> Result<Vec<u8>, String> {
+    let api_url = asset.api_url.as_deref().ok_or_else(|| {
+        operation::failure(
+            FailureClass::ReleaseMetadataDownload,
+            format!("GitHub release asset {} is missing its API URL", asset.name),
+        )
+    })?;
+    operation::select_asset(label, None)?;
+    operation::phase(Phase::Downloading, &format!("Downloading {label}"))?;
+    let response = http_agent()
+        .get(api_url)
+        .set("Accept", "application/octet-stream")
+        .set("User-Agent", "fennara-cli")
+        .call()
+        .map_err(|error| {
+            operation::failure(
+                FailureClass::AssetDownload,
+                format!("failed to download {label} from GitHub asset API: {error}"),
+            )
+        })?;
+    let mut bytes = Vec::new();
+    response
+        .into_reader()
+        .read_to_end(&mut bytes)
+        .map_err(|error| {
+            operation::failure(
+                FailureClass::AssetDownload,
+                format!("failed to read {label} from GitHub asset API: {error}"),
+            )
+        })?;
+    Ok(bytes)
 }
 
 pub fn download_zip_to_dir(asset: &DownloadAsset<'_>, target: &Path) -> Result<(), String> {
@@ -146,22 +233,28 @@ pub(crate) fn verify_download_hash(
     actual_sha256: &str,
 ) -> Result<(), String> {
     if let Some(expected_sha256) = asset.expected_sha256 {
-        operation::phase(Phase::Verifying, &format!("Verifying {}", asset.label))?;
-        if !actual_sha256.eq_ignore_ascii_case(expected_sha256) {
-            operation::record_asset_hash(asset.label, actual_sha256, Some(false))?;
-            return Err(operation::failure(
-                FailureClass::HashMismatch,
-                format!(
-                    "{} sha256 mismatch: expected {expected_sha256}, got {actual_sha256}",
-                    asset.label
-                ),
-            ));
-        }
-        operation::record_asset_hash(asset.label, actual_sha256, Some(true))?;
-        println!("sha256: verified {}", asset.label);
+        verify_expected_hash(asset.label, expected_sha256, actual_sha256)?;
     } else {
         operation::record_asset_hash(asset.label, actual_sha256, None)?;
     }
+    Ok(())
+}
+
+fn verify_expected_hash(
+    label: &str,
+    expected_sha256: &str,
+    actual_sha256: &str,
+) -> Result<(), String> {
+    operation::phase(Phase::Verifying, &format!("Verifying {label}"))?;
+    if !actual_sha256.eq_ignore_ascii_case(expected_sha256) {
+        operation::record_asset_hash(label, actual_sha256, Some(false))?;
+        return Err(operation::failure(
+            FailureClass::HashMismatch,
+            format!("{label} sha256 mismatch: expected {expected_sha256}, got {actual_sha256}"),
+        ));
+    }
+    operation::record_asset_hash(label, actual_sha256, Some(true))?;
+    println!("sha256: verified {label}");
     Ok(())
 }
 
@@ -222,11 +315,9 @@ fn version_from_asset_name(name: &str) -> Option<String> {
     let marker = "-v";
     let start = name.rfind(marker)? + marker.len();
     let version = name.get(start..)?.strip_suffix(".zip")?;
-    if version.split('.').count() == 3 && version.chars().all(|c| c.is_ascii_digit() || c == '.') {
-        Some(version.to_string())
-    } else {
-        None
-    }
+    crate::release_version::parse_release_version(version)
+        .ok()
+        .map(|_| version.to_string())
 }
 
 fn http_agent() -> ureq::Agent {

--- a/local/crates/fennara-cli/src/release_client.rs
+++ b/local/crates/fennara-cli/src/release_client.rs
@@ -21,7 +21,6 @@ const HTTP_WRITE_TIMEOUT_SECS: u64 = 30;
 pub struct ReleaseAsset {
     pub name: String,
     pub url: String,
-    pub api_url: Option<String>,
     pub version: Option<String>,
 }
 
@@ -34,6 +33,8 @@ pub struct Release {
 impl Release {
     pub(crate) fn is_channel_release(&self) -> bool {
         self.channel_pointer.is_some()
+            || crate::release_version::parse_release_version(self.tag.trim_start_matches('v'))
+                .is_ok_and(|version| !version.pre.is_empty())
     }
 
     pub fn asset(&self, prefix: &str) -> Option<ReleaseAsset> {
@@ -54,7 +55,6 @@ impl Release {
             Some(ReleaseAsset {
                 name: name.to_string(),
                 url: url.to_string(),
-                api_url: asset.get("url").and_then(Value::as_str).map(str::to_string),
                 version: version_from_asset_name(name),
             })
         })
@@ -70,7 +70,6 @@ impl Release {
             Some(ReleaseAsset {
                 name: name.to_string(),
                 url: url.to_string(),
-                api_url: asset.get("url").and_then(Value::as_str).map(str::to_string),
                 version: version_from_asset_name(name),
             })
         })
@@ -162,27 +161,21 @@ pub(crate) fn parse_release_manifest(
     Ok(manifest)
 }
 
-pub(crate) fn download_github_api_asset(
-    asset: &ReleaseAsset,
-    label: &str,
-) -> Result<Vec<u8>, String> {
-    let api_url = asset.api_url.as_deref().ok_or_else(|| {
-        operation::failure(
-            FailureClass::ReleaseMetadataDownload,
-            format!("GitHub release asset {} is missing its API URL", asset.name),
-        )
-    })?;
+pub(crate) fn download_github_contents(reference: &str, label: &str) -> Result<Vec<u8>, String> {
+    let encoded_reference = reference.replace('/', "%2F");
+    let api_url =
+        format!("https://api.github.com/repos/{REPO}/contents/{label}?ref={encoded_reference}");
     operation::select_asset(label, None)?;
     operation::phase(Phase::Downloading, &format!("Downloading {label}"))?;
     let response = http_agent()
-        .get(api_url)
-        .set("Accept", "application/octet-stream")
+        .get(&api_url)
+        .set("Accept", "application/vnd.github.raw+json")
         .set("User-Agent", "fennara-cli")
         .call()
         .map_err(|error| {
             operation::failure(
                 FailureClass::AssetDownload,
-                format!("failed to download {label} from GitHub asset API: {error}"),
+                format!("failed to download {label} from staging channel {reference}: {error}"),
             )
         })?;
     let mut bytes = Vec::new();
@@ -192,7 +185,7 @@ pub(crate) fn download_github_api_asset(
         .map_err(|error| {
             operation::failure(
                 FailureClass::AssetDownload,
-                format!("failed to read {label} from GitHub asset API: {error}"),
+                format!("failed to read {label} from staging channel {reference}: {error}"),
             )
         })?;
     Ok(bytes)

--- a/local/crates/fennara-cli/src/release_client_tests.rs
+++ b/local/crates/fennara-cli/src/release_client_tests.rs
@@ -1,4 +1,7 @@
-use crate::release_client::{DownloadAsset, download_bytes, verify_download_hash};
+use crate::release_channel::ChannelPointer;
+use crate::release_client::{
+    DownloadAsset, Release, download_bytes, parse_release_manifest, verify_download_hash,
+};
 use sha2::{Digest, Sha256};
 use std::net::TcpListener;
 
@@ -29,4 +32,67 @@ fn download_connection_failure_is_actionable() {
         download_bytes(&format!("http://{address}/missing.zip"), "missing.zip").unwrap_err();
     assert!(error.contains("failed to download missing.zip"));
     assert!(error.contains("connect/read timeouts"));
+}
+
+#[test]
+fn staging_pointer_binds_manifest_hash_and_identity() {
+    let manifest = staging_manifest("0123456789abcdef0123456789abcdef01234567");
+    let bytes = serde_json::to_vec(&manifest).unwrap();
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let release = staging_release(&sha256);
+
+    assert!(parse_release_manifest(&release, &bytes, &sha256, "manifest.json").is_ok());
+
+    let mut tampered = bytes.clone();
+    tampered.push(b' ');
+    let tampered_sha256 = format!("{:x}", Sha256::digest(&tampered));
+    let error = parse_release_manifest(&release, &tampered, &tampered_sha256, "manifest.json")
+        .err()
+        .unwrap();
+    assert!(error.contains("sha256 mismatch"));
+}
+
+#[test]
+fn staging_pointer_rejects_manifest_from_another_source_commit() {
+    let manifest = staging_manifest("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let bytes = serde_json::to_vec(&manifest).unwrap();
+    let sha256 = format!("{:x}", Sha256::digest(&bytes));
+    let release = staging_release(&sha256);
+
+    let error = parse_release_manifest(&release, &bytes, &sha256, "manifest.json")
+        .err()
+        .unwrap();
+    assert!(error.contains("identity does not match channel pointer"));
+}
+
+fn staging_release(release_manifest_sha256: &str) -> Release {
+    Release {
+        tag: "v0.3.9-pr.101.2".into(),
+        assets: serde_json::Value::Null,
+        channel_pointer: Some(ChannelPointer {
+            schema_version: 1,
+            channel: "pr-101".into(),
+            version: "0.3.9-pr.101.2".into(),
+            release_tag: "v0.3.9-pr.101.2".into(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".into(),
+            release_manifest_sha256: release_manifest_sha256.into(),
+        }),
+    }
+}
+
+fn staging_manifest(source_commit: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": 1,
+        "version": "0.3.9-pr.101.2",
+        "release": {
+            "schema_version": 1,
+            "track": "staging",
+            "channel": "pr-101",
+            "version": "0.3.9-pr.101.2",
+            "release_tag": "v0.3.9-pr.101.2",
+            "source_commit": source_commit
+        },
+        "minimum_cli_version": "0.3.3",
+        "install_primitives": []
+    })
 }

--- a/local/crates/fennara-cli/src/release_identity.rs
+++ b/local/crates/fennara-cli/src/release_identity.rs
@@ -42,15 +42,18 @@ impl ReleaseIdentity {
 
     pub(crate) fn load(addon_dir: &Path, expected_version: &str) -> Result<Self, String> {
         let path = addon_dir.join(ADDON_IDENTITY_FILE);
-        if !path.is_file() {
-            return Self::legacy_stable(expected_version);
-        }
-        let bytes = fs::read(&path).map_err(|error| {
-            format!(
-                "failed to read addon release identity {}: {error}",
-                path.display()
-            )
-        })?;
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Self::legacy_stable(expected_version);
+            }
+            Err(error) => {
+                return Err(format!(
+                    "failed to read addon release identity {}: {error}",
+                    path.display()
+                ));
+            }
+        };
         Self::parse(&bytes, expected_version)
     }
 
@@ -185,6 +188,11 @@ pub(crate) fn pull_request_number(channel: &str) -> Result<u64, String> {
 pub(crate) fn channel_pointer_asset_name(channel: &str) -> Result<String, String> {
     pull_request_number(channel)?;
     Ok(format!("fennara-staging-channel-{channel}.json"))
+}
+
+pub(crate) fn channel_pointer_ref(channel: &str) -> Result<String, String> {
+    pull_request_number(channel)?;
+    Ok(format!("fennara-staging/{channel}"))
 }
 
 fn validate_source_commit(value: &str) -> Result<(), String> {

--- a/local/crates/fennara-cli/src/release_identity.rs
+++ b/local/crates/fennara-cli/src/release_identity.rs
@@ -1,0 +1,201 @@
+use crate::release_version::parse_release_version;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+pub(crate) const ADDON_IDENTITY_FILE: &str = "release.json";
+const IDENTITY_SCHEMA_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReleaseTrack {
+    Stable,
+    Staging,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct ReleaseIdentity {
+    pub schema_version: u64,
+    pub track: ReleaseTrack,
+    pub version: String,
+    pub release_tag: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub channel: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_commit: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ReleaseSelector {
+    StableLatest,
+    StagingChannel(String),
+    ExactVersion(String),
+}
+
+impl ReleaseIdentity {
+    pub(crate) fn parse(bytes: &[u8], expected_version: &str) -> Result<Self, String> {
+        let identity: Self = serde_json::from_slice(bytes)
+            .map_err(|error| format!("failed to parse addon release identity: {error}"))?;
+        identity.validate(expected_version)?;
+        Ok(identity)
+    }
+
+    pub(crate) fn load(addon_dir: &Path, expected_version: &str) -> Result<Self, String> {
+        let path = addon_dir.join(ADDON_IDENTITY_FILE);
+        if !path.is_file() {
+            return Self::legacy_stable(expected_version);
+        }
+        let bytes = fs::read(&path).map_err(|error| {
+            format!(
+                "failed to read addon release identity {}: {error}",
+                path.display()
+            )
+        })?;
+        Self::parse(&bytes, expected_version)
+    }
+
+    pub(crate) fn validate(&self, expected_version: &str) -> Result<(), String> {
+        if self.schema_version != IDENTITY_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported addon release identity schema {}",
+                self.schema_version
+            ));
+        }
+        let parsed = parse_release_version(&self.version)?;
+        if self.version != expected_version {
+            return Err(format!(
+                "addon release identity version {:?} does not match VERSION {:?}",
+                self.version, expected_version
+            ));
+        }
+        let expected_tag = format!("v{}", self.version);
+        if self.release_tag != expected_tag {
+            return Err(format!(
+                "addon release identity tag {:?} does not match {expected_tag:?}",
+                self.release_tag
+            ));
+        }
+
+        match self.track {
+            ReleaseTrack::Stable => {
+                if !parsed.pre.is_empty() {
+                    return Err(
+                        "stable addon release identity must not use a prerelease version".into(),
+                    );
+                }
+                if self.channel.is_some() {
+                    return Err("stable addon release identity must not include a channel".into());
+                }
+                if let Some(source_commit) = self.source_commit.as_deref() {
+                    validate_source_commit(source_commit)?;
+                }
+            }
+            ReleaseTrack::Staging => {
+                let channel = self.channel.as_deref().ok_or_else(|| {
+                    "staging addon release identity is missing channel".to_string()
+                })?;
+                let pull_request = pull_request_number(channel)?;
+                let expected_prefix = format!("pr.{pull_request}.");
+                let prerelease = parsed.pre.as_str();
+                let candidate = prerelease.strip_prefix(&expected_prefix).ok_or_else(|| {
+                    format!(
+                        "staging version {:?} does not belong to channel {channel:?}",
+                        self.version
+                    )
+                })?;
+                if candidate
+                    .parse::<u64>()
+                    .ok()
+                    .filter(|value| *value > 0)
+                    .is_none()
+                    || candidate.starts_with('0')
+                {
+                    return Err("staging candidate number must be a positive integer".into());
+                }
+                validate_source_commit(self.source_commit.as_deref().unwrap_or_default())?;
+            }
+        }
+        Ok(())
+    }
+
+    fn legacy_stable(version: &str) -> Result<Self, String> {
+        let parsed = parse_release_version(version)?;
+        if !parsed.pre.is_empty() {
+            return Err(format!(
+                "prerelease addon version {version:?} requires {ADDON_IDENTITY_FILE}"
+            ));
+        }
+        Ok(Self {
+            schema_version: IDENTITY_SCHEMA_VERSION,
+            track: ReleaseTrack::Stable,
+            version: version.to_string(),
+            release_tag: format!("v{version}"),
+            channel: None,
+            source_commit: None,
+        })
+    }
+}
+
+impl ReleaseSelector {
+    pub(crate) fn staging(channel: &str) -> Result<Self, String> {
+        pull_request_number(channel)?;
+        Ok(Self::StagingChannel(channel.to_string()))
+    }
+
+    pub(crate) fn exact(version: &str) -> Result<Self, String> {
+        parse_release_version(version)?;
+        Ok(Self::ExactVersion(version.to_string()))
+    }
+
+    pub(crate) fn from_version_request(value: &str) -> Result<Self, String> {
+        if value == "latest" {
+            Ok(Self::StableLatest)
+        } else if let Some(channel) = value.strip_prefix("channel:") {
+            Self::staging(channel)
+        } else {
+            Self::exact(value)
+        }
+    }
+
+    pub(crate) fn github_tag(&self) -> String {
+        match self {
+            Self::StableLatest => "latest".to_string(),
+            Self::StagingChannel(channel) => format!("staging-{channel}"),
+            Self::ExactVersion(version) => format!("v{version}"),
+        }
+    }
+}
+
+pub(crate) fn pull_request_number(channel: &str) -> Result<u64, String> {
+    let number = channel
+        .strip_prefix("pr-")
+        .ok_or_else(|| format!("staging channel {channel:?} must use pr-<number> format"))?;
+    if number.starts_with('0') {
+        return Err(format!(
+            "staging channel {channel:?} must use a positive pull-request number"
+        ));
+    }
+    number
+        .parse::<u64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or_else(|| format!("staging channel {channel:?} must use pr-<number> format"))
+}
+
+pub(crate) fn channel_pointer_asset_name(channel: &str) -> Result<String, String> {
+    pull_request_number(channel)?;
+    Ok(format!("fennara-staging-channel-{channel}.json"))
+}
+
+fn validate_source_commit(value: &str) -> Result<(), String> {
+    if value.len() != 40 || !value.chars().all(|character| character.is_ascii_hexdigit()) {
+        return Err("staging source commit must be a full 40-character Git SHA".into());
+    }
+    if value
+        .chars()
+        .any(|character| character.is_ascii_uppercase())
+    {
+        return Err("staging source commit must use lowercase hexadecimal".into());
+    }
+    Ok(())
+}

--- a/local/crates/fennara-cli/src/release_identity_tests.rs
+++ b/local/crates/fennara-cli/src/release_identity_tests.rs
@@ -1,0 +1,79 @@
+use crate::release_identity::{
+    ReleaseIdentity, ReleaseSelector, ReleaseTrack, channel_pointer_asset_name,
+};
+
+const SOURCE_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+
+#[test]
+fn validates_stable_and_pull_request_staging_identities() {
+    let stable = identity("stable", "0.3.9", None, None);
+    assert!(ReleaseIdentity::parse(&stable, "0.3.9").is_ok());
+
+    let staging = identity(
+        "staging",
+        "0.3.9-pr.101.2",
+        Some("pr-101"),
+        Some(SOURCE_COMMIT),
+    );
+    let parsed = ReleaseIdentity::parse(&staging, "0.3.9-pr.101.2").unwrap();
+    assert_eq!(parsed.track, ReleaseTrack::Staging);
+    assert_eq!(parsed.channel.as_deref(), Some("pr-101"));
+}
+
+#[test]
+fn rejects_cross_channel_or_unidentified_prerelease_identity() {
+    let wrong_channel = identity(
+        "staging",
+        "0.3.9-pr.125.1",
+        Some("pr-101"),
+        Some(SOURCE_COMMIT),
+    );
+    assert!(ReleaseIdentity::parse(&wrong_channel, "0.3.9-pr.125.1").is_err());
+
+    let legacy_error = ReleaseIdentity::load(
+        std::path::Path::new("path-that-does-not-exist"),
+        "0.3.9-pr.101.1",
+    )
+    .unwrap_err();
+    assert!(legacy_error.contains("requires release.json"));
+}
+
+#[test]
+fn maps_selectors_to_isolated_github_tags() {
+    assert_eq!(ReleaseSelector::StableLatest.github_tag(), "latest");
+    assert_eq!(
+        ReleaseSelector::staging("pr-101").unwrap().github_tag(),
+        "staging-pr-101"
+    );
+    assert_eq!(
+        ReleaseSelector::from_version_request("channel:pr-101").unwrap(),
+        ReleaseSelector::StagingChannel("pr-101".into())
+    );
+    assert_eq!(
+        ReleaseSelector::exact("0.3.9-pr.101.2")
+            .unwrap()
+            .github_tag(),
+        "v0.3.9-pr.101.2"
+    );
+    assert_eq!(
+        channel_pointer_asset_name("pr-101").unwrap(),
+        "fennara-staging-channel-pr-101.json"
+    );
+}
+
+fn identity(
+    track: &str,
+    version: &str,
+    channel: Option<&str>,
+    source_commit: Option<&str>,
+) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "schema_version": 1,
+        "track": track,
+        "version": version,
+        "release_tag": format!("v{version}"),
+        "channel": channel,
+        "source_commit": source_commit,
+    }))
+    .unwrap()
+}

--- a/local/crates/fennara-cli/src/release_identity_tests.rs
+++ b/local/crates/fennara-cli/src/release_identity_tests.rs
@@ -1,5 +1,5 @@
 use crate::release_identity::{
-    ReleaseIdentity, ReleaseSelector, ReleaseTrack, channel_pointer_asset_name,
+    ReleaseIdentity, ReleaseSelector, ReleaseTrack, channel_pointer_asset_name, channel_pointer_ref,
 };
 
 const SOURCE_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
@@ -39,6 +39,13 @@ fn rejects_cross_channel_or_unidentified_prerelease_identity() {
 }
 
 #[test]
+fn rejects_release_identity_versions_with_build_metadata() {
+    let release = identity("stable", "0.3.9+build", None, None);
+    let error = ReleaseIdentity::parse(&release, "0.3.9+build").unwrap_err();
+    assert!(error.contains("must not contain SemVer build metadata"));
+}
+
+#[test]
 fn maps_selectors_to_isolated_github_tags() {
     assert_eq!(ReleaseSelector::StableLatest.github_tag(), "latest");
     assert_eq!(
@@ -58,6 +65,10 @@ fn maps_selectors_to_isolated_github_tags() {
     assert_eq!(
         channel_pointer_asset_name("pr-101").unwrap(),
         "fennara-staging-channel-pr-101.json"
+    );
+    assert_eq!(
+        channel_pointer_ref("pr-101").unwrap(),
+        "fennara-staging/pr-101"
     );
 }
 

--- a/local/crates/fennara-cli/src/release_manifest.rs
+++ b/local/crates/fennara-cli/src/release_manifest.rs
@@ -1,5 +1,8 @@
 use crate::VERSION;
 use crate::app_layout::{arch_name, platform_name};
+use crate::release_identity::ReleaseIdentity;
+pub(crate) use crate::release_version::compare_versions;
+use crate::release_version::parse_release_version;
 use serde_json::Value;
 use std::cmp::Ordering;
 
@@ -38,6 +41,7 @@ impl ReleaseManifest {
 
     pub fn validate_for_install(&self) -> Result<(), String> {
         self.validate_schema()?;
+        self.validate_release_identity()?;
         self.validate_current_cli()?;
         self.validate_install_primitives()
     }
@@ -84,6 +88,26 @@ impl ReleaseManifest {
             ));
         }
         Ok(())
+    }
+
+    pub(crate) fn release_identity(&self) -> Result<Option<ReleaseIdentity>, String> {
+        let version = required_string(&self.value, "version")?;
+        let Some(identity) = self.value.get("release") else {
+            let parsed = parse_release_version(version)?;
+            if parsed.pre.is_empty() {
+                return Ok(None);
+            }
+            return Err(format!(
+                "prerelease manifest version {version:?} requires release identity"
+            ));
+        };
+        let bytes = serde_json::to_vec(identity)
+            .map_err(|error| format!("failed to read release manifest identity: {error}"))?;
+        ReleaseIdentity::parse(&bytes, version).map(Some)
+    }
+
+    fn validate_release_identity(&self) -> Result<(), String> {
+        self.release_identity().map(|_| ())
     }
 
     fn validate_minimum_cli_version(&self, running_cli_version: &str) -> Result<(), String> {
@@ -242,73 +266,10 @@ fn current_webview_platform_arch() -> &'static str {
     }
 }
 
-pub(crate) fn compare_versions(left: &str, right: &str) -> Option<Ordering> {
-    Some(parse_semver_core(left)?.cmp(&parse_semver_core(right)?))
-}
-
-fn parse_semver_core(value: &str) -> Option<[u64; 3]> {
-    let core = value.split_once('-').map(|(core, _)| core).unwrap_or(value);
-    let mut parts = core.split('.');
-    let major = parts.next()?.parse().ok()?;
-    let minor = parts.next()?.parse().ok()?;
-    let patch = parts.next()?.parse().ok()?;
-    if parts.next().is_some() {
-        return None;
-    }
-    Some([major, minor, patch])
-}
-
 fn update_cli_instruction() -> &'static str {
     if cfg!(target_os = "windows") {
         "Update the CLI first: irm https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.ps1 | iex"
     } else {
         "Update the CLI first: curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh"
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn compares_semver_core_versions() {
-        assert_eq!(compare_versions("0.3.0", "0.3.0"), Some(Ordering::Equal));
-        assert_eq!(compare_versions("0.3.1", "0.3.0"), Some(Ordering::Greater));
-        assert_eq!(compare_versions("0.2.9", "0.3.0"), Some(Ordering::Less));
-        assert_eq!(
-            compare_versions("0.3.0-beta.1", "0.3.0"),
-            Some(Ordering::Equal)
-        );
-        assert_eq!(compare_versions("0.3", "0.3.0"), None);
-    }
-
-    #[test]
-    fn selects_cli_asset_before_install_validation() {
-        let key = current_platform_key();
-        let mut cli_assets = serde_json::Map::new();
-        cli_assets.insert(
-            key,
-            serde_json::json!({
-                "name": "fennara-cli-current-platform-v9.0.0.zip",
-                "sha256": "a".repeat(64)
-            }),
-        );
-        let manifest = serde_json::json!({
-            "schema_version": 99,
-            "version": "9.0.0",
-            "minimum_cli_version": "9.0.0",
-            "install_primitives": ["future-primitive"],
-            "assets": {
-                "cli": cli_assets
-            }
-        });
-        let raw = serde_json::to_vec(&manifest).unwrap();
-
-        let parsed = ReleaseManifest::parse(&raw).unwrap();
-        let cli = parsed.select_cli_for_current_platform().unwrap();
-
-        assert_eq!(cli.version, "9.0.0");
-        assert_eq!(cli.cli.name, "fennara-cli-current-platform-v9.0.0.zip");
-        assert!(parsed.validate_for_install().is_err());
     }
 }

--- a/local/crates/fennara-cli/src/release_manifest_tests.rs
+++ b/local/crates/fennara-cli/src/release_manifest_tests.rs
@@ -1,0 +1,79 @@
+use crate::release_manifest::ReleaseManifest;
+use crate::{app_layout::arch_name, app_layout::platform_name};
+
+#[test]
+fn selects_cli_asset_before_install_validation() {
+    let key = format!("{}-{}", platform_name(), arch_name());
+    let mut cli_assets = serde_json::Map::new();
+    cli_assets.insert(
+        key,
+        serde_json::json!({
+            "name": "fennara-cli-current-platform-v9.0.0.zip",
+            "sha256": "a".repeat(64)
+        }),
+    );
+    let manifest = serde_json::json!({
+        "schema_version": 99,
+        "version": "9.0.0",
+        "minimum_cli_version": "9.0.0",
+        "install_primitives": ["future-primitive"],
+        "assets": {
+            "cli": cli_assets
+        }
+    });
+    let raw = serde_json::to_vec(&manifest).unwrap();
+
+    let parsed = ReleaseManifest::parse(&raw).unwrap();
+    let cli = parsed.select_cli_for_current_platform().unwrap();
+
+    assert_eq!(cli.version, "9.0.0");
+    assert_eq!(cli.cli.name, "fennara-cli-current-platform-v9.0.0.zip");
+    assert!(parsed.validate_for_install().is_err());
+}
+
+#[test]
+fn validates_optional_release_identity_against_manifest_version() {
+    let manifest = serde_json::json!({
+        "schema_version": 1,
+        "version": "0.3.9-pr.101.1",
+        "release": {
+            "schema_version": 1,
+            "track": "staging",
+            "channel": "pr-101",
+            "version": "0.3.9-pr.101.1",
+            "release_tag": "v0.3.9-pr.101.1",
+            "source_commit": "0123456789abcdef0123456789abcdef01234567"
+        },
+        "minimum_cli_version": "0.3.3",
+        "install_primitives": []
+    });
+    let parsed = ReleaseManifest::parse(&serde_json::to_vec(&manifest).unwrap()).unwrap();
+    assert!(parsed.validate_for_install().is_ok());
+
+    let mut mismatched = manifest;
+    mismatched["release"]["channel"] = serde_json::json!("pr-125");
+    let parsed = ReleaseManifest::parse(&serde_json::to_vec(&mismatched).unwrap()).unwrap();
+    assert!(parsed.validate_for_install().is_err());
+}
+
+#[test]
+fn permits_legacy_stable_identity_but_requires_it_for_prereleases() {
+    let stable = manifest_without_identity("0.3.8");
+    let parsed = ReleaseManifest::parse(&serde_json::to_vec(&stable).unwrap()).unwrap();
+    assert!(parsed.release_identity().unwrap().is_none());
+
+    let prerelease = manifest_without_identity("0.3.9-pr.101.1");
+    let parsed = ReleaseManifest::parse(&serde_json::to_vec(&prerelease).unwrap()).unwrap();
+    let error = parsed.release_identity().unwrap_err();
+    assert!(error.contains("prerelease manifest"));
+    assert!(error.contains("requires release identity"));
+}
+
+fn manifest_without_identity(version: &str) -> serde_json::Value {
+    serde_json::json!({
+        "schema_version": 1,
+        "version": version,
+        "minimum_cli_version": "0.3.3",
+        "install_primitives": []
+    })
+}

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -15,14 +15,33 @@ pub struct InstalledPackage {
     pub addon_dir: PathBuf,
 }
 
+pub(crate) struct ResolvedPackage {
+    release: Release,
+    manifest: Option<ReleaseManifest>,
+    version: String,
+    identity: Option<ReleaseIdentity>,
+}
+
+impl ResolvedPackage {
+    pub(crate) fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub(crate) fn identity(&self) -> Option<&ReleaseIdentity> {
+        self.identity.as_ref()
+    }
+}
+
 pub struct ActivationReceipt {
     previous_manifest: Option<Vec<u8>>,
 }
 
 pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String> {
-    let layout = AppLayout::detect()?;
-    layout.ensure_base_dirs()?;
+    let resolved = resolve_package(version_request)?;
+    ensure_resolved_package(resolved)
+}
 
+pub(crate) fn resolve_package(version_request: &str) -> Result<ResolvedPackage, String> {
     println!("package: resolving release {version_request}");
     let release = release_client::fetch_release(version_request)?;
     if let Some(manifest_asset) = release.manifest_asset() {
@@ -31,11 +50,81 @@ pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String>
         manifest
             .validate_for_install()
             .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
-        return ensure_manifest_package(&layout, &release, &manifest, None, true, true);
+        let selection = manifest
+            .select_for_current_platform()
+            .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+        let identity = manifest
+            .release_identity()
+            .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+        record_target_provenance(identity.as_ref())?;
+        return Ok(ResolvedPackage {
+            release,
+            manifest: Some(manifest),
+            version: selection.version,
+            identity,
+        });
     }
 
     validate_legacy_fallback_allowed(&release)?;
-    ensure_legacy_package(&layout, &release)
+    record_target_provenance(None)?;
+    let version = legacy_version(&release)?;
+    Ok(ResolvedPackage {
+        release,
+        manifest: None,
+        version,
+        identity: None,
+    })
+}
+
+fn record_target_provenance(identity: Option<&ReleaseIdentity>) -> Result<(), String> {
+    let (track, channel, source_commit) = release_provenance(identity);
+    operation::set_component("release_track", track)?;
+    if let Some(channel) = channel {
+        operation::set_component("release_channel", channel)?;
+    }
+    if let Some(source_commit) = source_commit {
+        operation::set_component("source_commit", source_commit)?;
+    }
+    Ok(())
+}
+
+fn record_manifest_target_provenance(manifest: &ReleaseManifest) -> Result<(), String> {
+    let identity = manifest
+        .release_identity()
+        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    record_target_provenance(identity.as_ref())
+}
+
+pub(crate) fn release_provenance(
+    identity: Option<&ReleaseIdentity>,
+) -> (&'static str, Option<&str>, Option<&str>) {
+    match identity {
+        Some(identity) if identity.track == ReleaseTrack::Staging => (
+            "staging",
+            identity.channel.as_deref(),
+            identity.source_commit.as_deref(),
+        ),
+        Some(_) | None => ("stable", None, None),
+    }
+}
+
+pub(crate) fn ensure_resolved_package(
+    resolved: ResolvedPackage,
+) -> Result<InstalledPackage, String> {
+    let layout = AppLayout::detect()?;
+    layout.ensure_base_dirs()?;
+
+    if let Some(manifest) = resolved.manifest {
+        return ensure_manifest_package(
+            &layout,
+            &resolved.release,
+            &manifest,
+            Some(&resolved.version),
+            true,
+            true,
+        );
+    }
+    ensure_legacy_package(&layout, &resolved.release)
 }
 
 pub(crate) fn validate_legacy_fallback_allowed(release: &Release) -> Result<(), String> {
@@ -71,6 +160,7 @@ pub fn stage_exact_package(version: &str) -> Result<InstalledPackage, String> {
     manifest
         .validate_for_install()
         .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    record_manifest_target_provenance(&manifest)?;
     ensure_manifest_package(&layout, &release, &manifest, Some(version), false, true)
 }
 
@@ -94,6 +184,7 @@ pub fn prepare_package(version_request: &str) -> Result<InstalledPackage, String
     manifest
         .validate_for_install()
         .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    record_manifest_target_provenance(&manifest)?;
     ensure_manifest_package(&layout, &release, &manifest, None, false, false)
 }
 
@@ -216,10 +307,7 @@ fn ensure_legacy_package(
     let addon_asset = release
         .asset(&addon_prefix)
         .ok_or_else(|| format!("release {} is missing {addon_prefix}*.zip", release.tag))?;
-    let version = local_asset
-        .version
-        .clone()
-        .ok_or_else(|| format!("could not parse version from {}", local_asset.name))?;
+    let version = legacy_version(release)?;
 
     let installed = ensure_selected_package(
         layout,
@@ -245,6 +333,16 @@ fn ensure_legacy_package(
     }
 
     Ok(installed)
+}
+
+fn legacy_version(release: &Release) -> Result<String, String> {
+    let local_prefix = format!("fennara-local-{}-{}-v", platform_name(), arch_name());
+    let local_asset = release
+        .asset(&local_prefix)
+        .ok_or_else(|| format!("release {} is missing {local_prefix}*.zip", release.tag))?;
+    local_asset
+        .version
+        .ok_or_else(|| format!("could not parse version from {}", local_asset.name))
 }
 
 fn ensure_selected_package(

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -26,16 +26,28 @@ pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String>
     let release = release_client::fetch_release(version_request)?;
     if let Some(manifest_asset) = release.manifest_asset() {
         println!("manifest: {}", manifest_asset.name);
-        let bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
-        let manifest = ReleaseManifest::parse(&bytes)
-            .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+        let manifest = release_client::download_release_manifest(&release, &manifest_asset)?;
         manifest
             .validate_for_install()
             .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
         return ensure_manifest_package(&layout, &release, &manifest, None, true, true);
     }
 
+    validate_legacy_fallback_allowed(&release)?;
     ensure_legacy_package(&layout, &release)
+}
+
+pub(crate) fn validate_legacy_fallback_allowed(release: &Release) -> Result<(), String> {
+    if release.is_channel_release() {
+        return Err(operation::failure(
+            FailureClass::ManifestInvalid,
+            format!(
+                "staging channel release {} has no release manifest; refusing unverified legacy installation",
+                release.tag
+            ),
+        ));
+    }
+    Ok(())
 }
 
 pub fn stage_exact_package(version: &str) -> Result<InstalledPackage, String> {
@@ -54,9 +66,7 @@ pub fn stage_exact_package(version: &str) -> Result<InstalledPackage, String> {
         )
     })?;
     println!("manifest: {}", manifest_asset.name);
-    let bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
-    let manifest = ReleaseManifest::parse(&bytes)
-        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    let manifest = release_client::download_release_manifest(&release, &manifest_asset)?;
     manifest
         .validate_for_install()
         .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
@@ -79,9 +89,7 @@ pub fn prepare_package(version_request: &str) -> Result<InstalledPackage, String
         )
     })?;
     println!("manifest: {}", manifest_asset.name);
-    let bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
-    let manifest = ReleaseManifest::parse(&bytes)
-        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    let manifest = release_client::download_release_manifest(&release, &manifest_asset)?;
     manifest
         .validate_for_install()
         .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -3,6 +3,7 @@ use crate::operation::{self, FailureClass};
 use crate::release_client::{self, DownloadAsset, Release, ReleaseAsset};
 use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
 use crate::release_manifest::ReleaseManifest;
+use crate::release_version::parse_release_version;
 use crate::webview_runtime;
 use std::fs::{self, File};
 use std::io::Write;
@@ -19,6 +20,7 @@ pub(crate) struct ResolvedPackage {
     release: Release,
     manifest: Option<ReleaseManifest>,
     version: String,
+    expected_version: Option<String>,
     identity: Option<ReleaseIdentity>,
 }
 
@@ -44,6 +46,7 @@ pub fn ensure_package(version_request: &str) -> Result<InstalledPackage, String>
 pub(crate) fn resolve_package(version_request: &str) -> Result<ResolvedPackage, String> {
     println!("package: resolving release {version_request}");
     let release = release_client::fetch_release(version_request)?;
+    let expected_version = expected_manifest_version(version_request, &release.tag);
     if let Some(manifest_asset) = release.manifest_asset() {
         println!("manifest: {}", manifest_asset.name);
         let manifest = release_client::download_release_manifest(&release, &manifest_asset)?;
@@ -61,6 +64,7 @@ pub(crate) fn resolve_package(version_request: &str) -> Result<ResolvedPackage, 
             release,
             manifest: Some(manifest),
             version: selection.version,
+            expected_version,
             identity,
         });
     }
@@ -72,6 +76,7 @@ pub(crate) fn resolve_package(version_request: &str) -> Result<ResolvedPackage, 
         release,
         manifest: None,
         version,
+        expected_version,
         identity: None,
     })
 }
@@ -119,7 +124,7 @@ pub(crate) fn ensure_resolved_package(
             &layout,
             &resolved.release,
             &manifest,
-            Some(&resolved.version),
+            resolved.expected_version.as_deref(),
             true,
             true,
         );
@@ -287,11 +292,21 @@ pub(crate) fn validate_expected_version(
         return Err(operation::failure(
             FailureClass::ManifestInvalid,
             format!(
-                "release {release_tag} declares version {selected_version}, but the existing addon requires {expected}"
+                "release {release_tag} declares version {selected_version}, but the resolved request expected {expected}"
             ),
         ));
     }
     Ok(())
+}
+
+pub(crate) fn expected_manifest_version(
+    version_request: &str,
+    release_tag: &str,
+) -> Option<String> {
+    [version_request, release_tag.trim_start_matches('v')]
+        .into_iter()
+        .find(|candidate| parse_release_version(candidate).is_ok())
+        .map(str::to_string)
 }
 
 fn ensure_legacy_package(

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -1,6 +1,6 @@
 use crate::app_layout::{AppLayout, arch_name, binary_name, display_path, platform_name};
 use crate::operation::{self, FailureClass};
-use crate::release_client::{self, DownloadAsset, Release};
+use crate::release_client::{self, DownloadAsset, Release, ReleaseAsset};
 use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
 use crate::release_manifest::ReleaseManifest;
 use crate::webview_runtime;
@@ -299,11 +299,8 @@ fn ensure_legacy_package(
     release: &Release,
 ) -> Result<InstalledPackage, String> {
     println!("package: using legacy release assets");
-    let local_prefix = format!("fennara-local-{}-{}-v", platform_name(), arch_name());
     let addon_prefix = "fennara-addon-v".to_string();
-    let local_asset = release
-        .asset(&local_prefix)
-        .ok_or_else(|| format!("release {} is missing {local_prefix}*.zip", release.tag))?;
+    let local_asset = legacy_local_asset(release)?;
     let addon_asset = release
         .asset(&addon_prefix)
         .ok_or_else(|| format!("release {} is missing {addon_prefix}*.zip", release.tag))?;
@@ -336,13 +333,17 @@ fn ensure_legacy_package(
 }
 
 fn legacy_version(release: &Release) -> Result<String, String> {
-    let local_prefix = format!("fennara-local-{}-{}-v", platform_name(), arch_name());
-    let local_asset = release
-        .asset(&local_prefix)
-        .ok_or_else(|| format!("release {} is missing {local_prefix}*.zip", release.tag))?;
+    let local_asset = legacy_local_asset(release)?;
     local_asset
         .version
         .ok_or_else(|| format!("could not parse version from {}", local_asset.name))
+}
+
+fn legacy_local_asset(release: &Release) -> Result<ReleaseAsset, String> {
+    let local_prefix = format!("fennara-local-{}-{}-v", platform_name(), arch_name());
+    release
+        .asset(&local_prefix)
+        .ok_or_else(|| format!("release {} is missing {local_prefix}*.zip", release.tag))
 }
 
 fn ensure_selected_package(

--- a/local/crates/fennara-cli/src/release_package.rs
+++ b/local/crates/fennara-cli/src/release_package.rs
@@ -1,6 +1,7 @@
 use crate::app_layout::{AppLayout, arch_name, binary_name, display_path, platform_name};
 use crate::operation::{self, FailureClass};
 use crate::release_client::{self, DownloadAsset, Release};
+use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
 use crate::release_manifest::ReleaseManifest;
 use crate::webview_runtime;
 use std::fs::{self, File};
@@ -512,8 +513,23 @@ fn write_manifest(layout: &AppLayout, version: &str) -> Result<(), String> {
         "current manifest: writing {}",
         display_path(&layout.current_manifest_path)
     );
+    let addon_dir = layout
+        .versions_dir
+        .join(version)
+        .join("addon")
+        .join("addons")
+        .join("fennara");
+    let identity = ReleaseIdentity::load(&addon_dir, version)?;
+    let track = match identity.track {
+        ReleaseTrack::Stable => "stable",
+        ReleaseTrack::Staging => "staging",
+    };
     let manifest = serde_json::json!({
         "version": version,
+        "release_track": track,
+        "release_channel": identity.channel,
+        "release_tag": identity.release_tag,
+        "source_commit": identity.source_commit,
         "mcp_runtime": format!("versions/{version}/{}", binary_name("fennara-mcp-runtime")),
         "daemon_runtime": format!("versions/{version}/{}", binary_name("fennara-daemon-runtime")),
         "addon": format!("versions/{version}/addon/addons/fennara"),

--- a/local/crates/fennara-cli/src/release_package_tests.rs
+++ b/local/crates/fennara-cli/src/release_package_tests.rs
@@ -1,7 +1,9 @@
 use crate::app_layout::{AppLayout, binary_name};
+use crate::release_channel::ChannelPointer;
+use crate::release_client::Release;
 use crate::release_package::{
     activate_package_at, package_complete, restore_activation_at, shared_runtime_component_key,
-    validate_expected_version,
+    validate_expected_version, validate_legacy_fallback_allowed,
 };
 use std::fs;
 use std::ops::Deref;
@@ -77,6 +79,26 @@ fn shared_runtime_component_uses_manifest_identifier() {
         shared_runtime_component_key(&runtime).as_deref(),
         Some("shared_runtime_linux_cef")
     );
+}
+
+#[test]
+fn channel_release_cannot_use_legacy_installation_without_a_manifest() {
+    let release = Release {
+        tag: "v0.3.9-pr.101.2".into(),
+        assets: serde_json::Value::Array(Vec::new()),
+        channel_pointer: Some(ChannelPointer {
+            schema_version: 1,
+            channel: "pr-101".into(),
+            version: "0.3.9-pr.101.2".into(),
+            release_tag: "v0.3.9-pr.101.2".into(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".into(),
+            release_manifest_sha256: "a".repeat(64),
+        }),
+    };
+
+    let error = validate_legacy_fallback_allowed(&release).unwrap_err();
+    assert!(error.contains("has no release manifest"));
+    assert!(error.contains("refusing unverified legacy installation"));
 }
 
 fn write_complete_package(layout: &AppLayout, version: &str) {

--- a/local/crates/fennara-cli/src/release_package_tests.rs
+++ b/local/crates/fennara-cli/src/release_package_tests.rs
@@ -62,6 +62,34 @@ fn activation_restore_removes_manifest_when_none_existed() {
 }
 
 #[test]
+fn activation_records_staging_identity_for_self_update() {
+    let layout = test_layout("staging-identity");
+    let version = "1.2.3-pr.101.2";
+    write_complete_package(&layout, version);
+    fs::write(
+        layout
+            .versions_dir
+            .join(version)
+            .join("addon/addons/fennara/release.json"),
+        format!(
+            r#"{{"schema_version":1,"track":"staging","version":"{version}","release_tag":"v{version}","channel":"pr-101","source_commit":"0123456789abcdef0123456789abcdef01234567"}}"#
+        ),
+    )
+    .unwrap();
+
+    activate_package_at(&layout, version).unwrap();
+    let active: serde_json::Value =
+        serde_json::from_slice(&fs::read(&layout.current_manifest_path).unwrap()).unwrap();
+    assert_eq!(active["release_track"], "staging");
+    assert_eq!(active["release_channel"], "pr-101");
+    assert_eq!(active["release_tag"], format!("v{version}"));
+    assert_eq!(
+        active["source_commit"],
+        "0123456789abcdef0123456789abcdef01234567"
+    );
+}
+
+#[test]
 fn exact_install_rejects_mismatched_manifest_before_asset_installation() {
     let error = validate_expected_version("v1.2.3", "1.2.4", Some("1.2.3")).unwrap_err();
     assert!(error.contains("release v1.2.3 declares version 1.2.4"));
@@ -94,6 +122,19 @@ fn channel_release_cannot_use_legacy_installation_without_a_manifest() {
             source_commit: "0123456789abcdef0123456789abcdef01234567".into(),
             release_manifest_sha256: "a".repeat(64),
         }),
+    };
+
+    let error = validate_legacy_fallback_allowed(&release).unwrap_err();
+    assert!(error.contains("has no release manifest"));
+    assert!(error.contains("refusing unverified legacy installation"));
+}
+
+#[test]
+fn exact_prerelease_cannot_use_legacy_installation_without_a_manifest() {
+    let release = Release {
+        tag: "v0.3.9-pr.101.2".into(),
+        assets: serde_json::Value::Array(Vec::new()),
+        channel_pointer: None,
     };
 
     let error = validate_legacy_fallback_allowed(&release).unwrap_err();

--- a/local/crates/fennara-cli/src/release_package_tests.rs
+++ b/local/crates/fennara-cli/src/release_package_tests.rs
@@ -1,9 +1,10 @@
 use crate::app_layout::{AppLayout, binary_name};
 use crate::release_channel::ChannelPointer;
 use crate::release_client::Release;
+use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
 use crate::release_package::{
-    activate_package_at, package_complete, restore_activation_at, shared_runtime_component_key,
-    validate_expected_version, validate_legacy_fallback_allowed,
+    activate_package_at, package_complete, release_provenance, restore_activation_at,
+    shared_runtime_component_key, validate_expected_version, validate_legacy_fallback_allowed,
 };
 use std::fs;
 use std::ops::Deref;
@@ -14,6 +15,25 @@ fn complete_package_requires_launchers_runtimes_and_cached_addon() {
     let layout = test_layout("complete");
     write_complete_package(&layout, "1.2.3");
     assert!(package_complete(&layout, "1.2.3"));
+}
+
+#[test]
+fn resolved_manifest_identity_describes_target_provenance() {
+    let source_commit = "0123456789abcdef0123456789abcdef01234567";
+    let identity = ReleaseIdentity {
+        schema_version: 1,
+        track: ReleaseTrack::Staging,
+        version: "1.2.3-pr.101.2".into(),
+        release_tag: "v1.2.3-pr.101.2".into(),
+        channel: Some("pr-101".into()),
+        source_commit: Some(source_commit.into()),
+    };
+
+    assert_eq!(
+        release_provenance(Some(&identity)),
+        ("staging", Some("pr-101"), Some(source_commit))
+    );
+    assert_eq!(release_provenance(None), ("stable", None, None));
 }
 
 #[test]

--- a/local/crates/fennara-cli/src/release_package_tests.rs
+++ b/local/crates/fennara-cli/src/release_package_tests.rs
@@ -3,8 +3,9 @@ use crate::release_channel::ChannelPointer;
 use crate::release_client::Release;
 use crate::release_identity::{ReleaseIdentity, ReleaseTrack};
 use crate::release_package::{
-    activate_package_at, package_complete, release_provenance, restore_activation_at,
-    shared_runtime_component_key, validate_expected_version, validate_legacy_fallback_allowed,
+    activate_package_at, expected_manifest_version, package_complete, release_provenance,
+    restore_activation_at, shared_runtime_component_key, validate_expected_version,
+    validate_legacy_fallback_allowed,
 };
 use std::fs;
 use std::ops::Deref;
@@ -113,7 +114,20 @@ fn activation_records_staging_identity_for_self_update() {
 fn exact_install_rejects_mismatched_manifest_before_asset_installation() {
     let error = validate_expected_version("v1.2.3", "1.2.4", Some("1.2.3")).unwrap_err();
     assert!(error.contains("release v1.2.3 declares version 1.2.4"));
-    assert!(error.contains("addon requires 1.2.3"));
+    assert!(error.contains("expected 1.2.3"));
+}
+
+#[test]
+fn manifest_version_expectation_is_independent_from_manifest_selection() {
+    assert_eq!(
+        expected_manifest_version("1.2.3", "v1.2.3"),
+        Some("1.2.3".into())
+    );
+    assert_eq!(
+        expected_manifest_version("channel:pr-101", "v1.2.3-pr.101.2"),
+        Some("1.2.3-pr.101.2".into())
+    );
+    assert_eq!(expected_manifest_version("latest", "latest"), None);
 }
 
 #[test]

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -1,8 +1,11 @@
 use crate::app_layout::display_path;
+use crate::daemon_setup;
 use crate::operation::{self, FailureClass, Phase};
 use crate::project_addon;
 use crate::project_guidance;
 use crate::project_install;
+use crate::release_client;
+use crate::release_identity::{ReleaseIdentity, ReleaseSelector, ReleaseTrack};
 use crate::release_package;
 use crate::self_update::{self, StartResult};
 use crate::update_stage;
@@ -12,14 +15,13 @@ use sysinfo::{Pid, System};
 
 pub fn run(args: Vec<&str>) -> Result<(), String> {
     operation::phase(Phase::Checking, "Validating project update request")?;
-    let options = UpdateOptions::parse(args)?;
+    let mut options = UpdateOptions::parse(args)?;
     let project_dir = project_install::resolve_project_dir(options.project_dir.clone())
         .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?;
     project_install::ensure_godot_project(&project_dir)
         .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?;
     println!("Updating Fennara");
     println!("project: {}", display_path(&project_dir));
-    println!("requested version: {}", options.version);
 
     if !project_install::has_fennara_addon(&project_dir) {
         return Err(operation::failure(
@@ -30,21 +32,59 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             ),
         ));
     }
-    let project_version = if options.prepare {
-        Some(
-            project_addon::inspect(&project_dir)
-                .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?
-                .ok_or_else(|| {
+    let existing = project_addon::inspect(&project_dir)
+        .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?
+        .ok_or_else(|| {
+            operation::failure(
+                FailureClass::ProjectInvalid,
+                "The project does not contain a complete Fennara addon to update.",
+            )
+        })?;
+    let project_version = Some(existing.version.clone());
+    let identity = ReleaseIdentity::load(
+        &project_install::project_addon_dir(&project_dir),
+        &existing.version,
+    )
+    .map_err(|error| operation::failure(FailureClass::ProjectInvalid, error))?;
+    if options.version.is_empty() {
+        options.version = match identity.track {
+            ReleaseTrack::Stable => "latest".to_string(),
+            ReleaseTrack::Staging => format!(
+                "channel:{}",
+                identity.channel.as_deref().ok_or_else(|| {
                     operation::failure(
                         FailureClass::ProjectInvalid,
-                        "The project does not contain a complete Fennara addon to update.",
+                        "the staging addon is missing its release channel",
                     )
                 })?
-                .version,
+            ),
+        };
+    }
+    options.version = resolve_exact_target(&options.version)?;
+    if options.version != existing.version {
+        let layout = crate::app_layout::AppLayout::detect()?;
+        daemon_setup::ensure_switch_available(
+            &layout,
+            options.prepare.then_some(project_dir.as_path()),
         )
-    } else {
-        project_install::project_addon_version(&project_dir)
-    };
+        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+    }
+    operation::set_requested_version(&options.version)?;
+    println!("requested version: {}", options.version);
+    operation::set_component(
+        "release_track",
+        match identity.track {
+            ReleaseTrack::Stable => "stable",
+            ReleaseTrack::Staging => "staging",
+        },
+    )?;
+    operation::set_component("activation_reason", "project_update")?;
+    if let Some(channel) = identity.channel.as_deref() {
+        operation::set_component("release_channel", channel)?;
+    }
+    if let Some(source_commit) = identity.source_commit.as_deref() {
+        operation::set_component("source_commit", source_commit)?;
+    }
 
     if !options.no_self_update {
         println!("self-update: checking installed CLI");
@@ -125,6 +165,48 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     Ok(())
 }
 
+fn resolve_exact_target(request: &str) -> Result<String, String> {
+    if matches!(
+        ReleaseSelector::from_version_request(request)?,
+        ReleaseSelector::ExactVersion(_)
+    ) {
+        return Ok(request.to_string());
+    }
+    let release = release_client::fetch_release(request)?;
+    if let Some(pointer) = release.channel_pointer.as_ref() {
+        operation::set_component("release_channel", &pointer.channel)?;
+        operation::set_component("source_commit", &pointer.source_commit)?;
+        return Ok(pointer.version.clone());
+    }
+    exact_version_from_stable_release(&release)
+}
+
+fn exact_version_from_stable_release(release: &release_client::Release) -> Result<String, String> {
+    let manifest = release.manifest_asset().ok_or_else(|| {
+        operation::failure(
+            FailureClass::ManifestInvalid,
+            format!(
+                "release {} does not contain a versioned release manifest",
+                release.tag
+            ),
+        )
+    })?;
+    let exact = manifest
+        .name
+        .strip_prefix("fennara-release-manifest-v")
+        .and_then(|value| value.strip_suffix(".json"))
+        .ok_or_else(|| {
+            operation::failure(
+                FailureClass::ManifestInvalid,
+                "stable latest contains an invalid release manifest asset name",
+            )
+        })?;
+    match ReleaseSelector::exact(exact)? {
+        ReleaseSelector::ExactVersion(version) => Ok(version),
+        _ => unreachable!(),
+    }
+}
+
 struct UpdateOptions {
     version: String,
     project_dir: Option<PathBuf>,
@@ -136,7 +218,7 @@ struct UpdateOptions {
 
 impl UpdateOptions {
     fn parse(args: Vec<&str>) -> Result<Self, String> {
-        let mut version = "latest".to_string();
+        let mut version = String::new();
         let mut project_dir = None;
         let mut no_self_update = false;
         let mut prepare = false;
@@ -300,6 +382,7 @@ Usage:
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn continuation_args_resume_without_self_update() {
@@ -359,5 +442,21 @@ mod tests {
                 .unwrap();
 
         assert!(options.prepare);
+    }
+
+    #[test]
+    fn stable_latest_version_comes_from_the_versioned_manifest_asset() {
+        let release = release_client::Release {
+            tag: "latest".to_string(),
+            assets: json!([{
+                "name": "fennara-release-manifest-v0.3.9.json",
+                "browser_download_url": "https://example.invalid/manifest"
+            }]),
+            channel_pointer: None,
+        };
+        assert_eq!(
+            exact_version_from_stable_release(&release).unwrap(),
+            "0.3.9"
+        );
     }
 }

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -170,13 +170,21 @@ fn resolve_exact_target(request: &str) -> Result<String, String> {
         return Ok(request.to_string());
     }
     let release = release_client::fetch_release(request)?;
+    operation::set_component("release_track", resolved_release_track(&release))?;
     if let Some(pointer) = release.channel_pointer.as_ref() {
-        operation::set_component("release_track", "staging")?;
         operation::set_component("release_channel", &pointer.channel)?;
         operation::set_component("source_commit", &pointer.source_commit)?;
         return Ok(pointer.version.clone());
     }
     exact_version_from_stable_release(&release)
+}
+
+pub(crate) fn resolved_release_track(release: &release_client::Release) -> &'static str {
+    if release.channel_pointer.is_some() {
+        "staging"
+    } else {
+        "stable"
+    }
 }
 
 fn exact_version_from_stable_release(release: &release_client::Release) -> Result<String, String> {

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -40,7 +40,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
                 "The project does not contain a complete Fennara addon to update.",
             )
         })?;
-    let project_version = Some(existing.version.clone());
+    let project_version = existing.version.clone();
     let identity = ReleaseIdentity::load(
         &project_install::project_addon_dir(&project_dir),
         &existing.version,
@@ -60,6 +60,20 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             ),
         };
     }
+    operation::set_component(
+        "installed_release_track",
+        match identity.track {
+            ReleaseTrack::Stable => "stable",
+            ReleaseTrack::Staging => "staging",
+        },
+    )?;
+    operation::set_component("activation_reason", "project_update")?;
+    if let Some(channel) = identity.channel.as_deref() {
+        operation::set_component("installed_release_channel", channel)?;
+    }
+    if let Some(source_commit) = identity.source_commit.as_deref() {
+        operation::set_component("installed_source_commit", source_commit)?;
+    }
     options.version = resolve_exact_target(&options.version)?;
     if options.version != existing.version {
         let layout = crate::app_layout::AppLayout::detect()?;
@@ -71,20 +85,6 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     }
     operation::set_requested_version(&options.version)?;
     println!("requested version: {}", options.version);
-    operation::set_component(
-        "release_track",
-        match identity.track {
-            ReleaseTrack::Stable => "stable",
-            ReleaseTrack::Staging => "staging",
-        },
-    )?;
-    operation::set_component("activation_reason", "project_update")?;
-    if let Some(channel) = identity.channel.as_deref() {
-        operation::set_component("release_channel", channel)?;
-    }
-    if let Some(source_commit) = identity.source_commit.as_deref() {
-        operation::set_component("source_commit", source_commit)?;
-    }
 
     if !options.no_self_update {
         println!("self-update: checking installed CLI");
@@ -103,7 +103,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     } else {
         release_package::ensure_package(&options.version)?
     };
-    if project_version.as_deref() == Some(package.version.as_str()) {
+    if project_version == package.version {
         if !options.prepare {
             println!("guidance: refreshing AGENTS.md and addons/fennara/ai/guidelines.md");
             project_guidance::write(&project_dir)?;
@@ -127,7 +127,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             .ok_or_else(|| "update staging requires an operation ID".to_string())?;
         let staged = update_stage::prepare(
             &project_dir,
-            project_version.as_deref().unwrap_or("unknown"),
+            &project_version,
             &package,
             &operation_id,
             observed_godot_process(options.godot_pid, options.godot_executable.as_deref())?,
@@ -154,10 +154,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
         .map_err(|error| operation::failure(FailureClass::StageFilesystem, error))?;
     operation::phase(Phase::Validating, "Checking the updated installation")?;
     println!("Updated Fennara");
-    println!(
-        "from: {}",
-        project_version.unwrap_or_else(|| "unknown".to_string())
-    );
+    println!("from: {project_version}");
     println!("to: {}", package.version);
     println!("project: {}", display_path(&project_dir));
     println!("guidance: refreshed AGENTS.md and addons/fennara/ai/guidelines.md");
@@ -174,6 +171,7 @@ fn resolve_exact_target(request: &str) -> Result<String, String> {
     }
     let release = release_client::fetch_release(request)?;
     if let Some(pointer) = release.channel_pointer.as_ref() {
+        operation::set_component("release_track", "staging")?;
         operation::set_component("release_channel", &pointer.channel)?;
         operation::set_component("source_commit", &pointer.source_commit)?;
         return Ok(pointer.version.clone());

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -77,11 +77,8 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
     options.version = resolve_exact_target(&options.version)?;
     if options.version != existing.version {
         let layout = crate::app_layout::AppLayout::detect()?;
-        daemon_setup::ensure_switch_available(
-            &layout,
-            options.prepare.then_some(project_dir.as_path()),
-        )
-        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+        daemon_setup::ensure_switch_available(&layout, Some(project_dir.as_path()))
+            .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
     }
     operation::set_requested_version(&options.version)?;
     println!("requested version: {}", options.version);

--- a/local/crates/fennara-cli/src/release_update_tests.rs
+++ b/local/crates/fennara-cli/src/release_update_tests.rs
@@ -1,0 +1,27 @@
+use crate::release_channel::ChannelPointer;
+use crate::release_client::Release;
+use crate::release_update::resolved_release_track;
+
+#[test]
+fn identifies_stable_and_staging_release_targets_before_handoff() {
+    let stable = Release {
+        tag: "latest".into(),
+        assets: serde_json::json!([]),
+        channel_pointer: None,
+    };
+    assert_eq!(resolved_release_track(&stable), "stable");
+
+    let staging = Release {
+        tag: "staging-pr-101".into(),
+        assets: serde_json::json!([]),
+        channel_pointer: Some(ChannelPointer {
+            schema_version: 1,
+            channel: "pr-101".into(),
+            version: "0.3.9-pr.101.2".into(),
+            release_tag: "v0.3.9-pr.101.2".into(),
+            source_commit: "0123456789abcdef0123456789abcdef01234567".into(),
+            release_manifest_sha256: "1".repeat(64),
+        }),
+    };
+    assert_eq!(resolved_release_track(&staging), "staging");
+}

--- a/local/crates/fennara-cli/src/release_version.rs
+++ b/local/crates/fennara-cli/src/release_version.rs
@@ -1,0 +1,21 @@
+use semver::Version;
+use std::cmp::Ordering;
+
+pub(crate) fn parse_release_version(value: &str) -> Result<Version, String> {
+    let version = Version::parse(value)
+        .map_err(|error| format!("invalid release version {value:?}: {error}"))?;
+    if !version.build.is_empty() {
+        return Err(format!(
+            "release version {value:?} must not contain SemVer build metadata"
+        ));
+    }
+    Ok(version)
+}
+
+pub(crate) fn compare_versions(left: &str, right: &str) -> Option<Ordering> {
+    Some(
+        parse_release_version(left)
+            .ok()?
+            .cmp(&parse_release_version(right).ok()?),
+    )
+}

--- a/local/crates/fennara-cli/src/release_version_tests.rs
+++ b/local/crates/fennara-cli/src/release_version_tests.rs
@@ -1,0 +1,22 @@
+use crate::release_version::{compare_versions, parse_release_version};
+use std::cmp::Ordering;
+
+#[test]
+fn compares_stable_and_prerelease_versions_with_semver_precedence() {
+    assert_eq!(compare_versions("0.3.9", "0.3.9"), Some(Ordering::Equal));
+    assert_eq!(
+        compare_versions("0.3.9-pr.101.2", "0.3.9-pr.101.1"),
+        Some(Ordering::Greater)
+    );
+    assert_eq!(
+        compare_versions("0.3.9-pr.101.2", "0.3.9"),
+        Some(Ordering::Less)
+    );
+    assert_eq!(compare_versions("0.3", "0.3.0"), None);
+}
+
+#[test]
+fn rejects_build_metadata_and_invalid_numeric_prerelease_identifiers() {
+    assert!(parse_release_version("0.3.9+build.1").is_err());
+    assert!(parse_release_version("0.3.9-pr.0101.1").is_err());
+}

--- a/local/crates/fennara-cli/src/self_update.rs
+++ b/local/crates/fennara-cli/src/self_update.rs
@@ -1,7 +1,8 @@
 use crate::VERSION;
-use crate::app_layout::{AppLayout, binary_name, display_path};
+use crate::app_layout::{AppLayout, binary_name, display_path, read_current_manifest};
 use crate::operation::{self, FailureClass, Phase};
 use crate::release_client::{self, DownloadAsset};
+use crate::release_identity::ReleaseSelector;
 use crate::release_manifest::compare_versions;
 use std::cmp::Ordering;
 use std::env;
@@ -26,7 +27,13 @@ pub enum StartResult {
 
 pub fn run(args: Vec<&str>) -> Result<(), String> {
     let options = SelfUpdateOptions::parse(args)?;
-    match start(&options.version, Vec::new())? {
+    let layout = AppLayout::detect()?;
+    let version = if options.version.is_empty() {
+        active_release_request(&layout)?
+    } else {
+        options.version
+    };
+    match start(&version, Vec::new())? {
         StartResult::Started => Ok(()),
         StartResult::AlreadyCurrent => {
             println!("Fennara CLI is already up to date.");
@@ -34,6 +41,32 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             Ok(())
         }
         StartResult::Skipped(reason) => Err(reason),
+    }
+}
+
+pub(crate) fn active_release_request(layout: &AppLayout) -> Result<String, String> {
+    let Some(manifest) = read_current_manifest(&layout.current_manifest_path)? else {
+        return Ok("latest".to_string());
+    };
+    match manifest
+        .get("release_track")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("stable")
+    {
+        "stable" => Ok("latest".to_string()),
+        "staging" => {
+            let channel = manifest
+                .get("release_channel")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| {
+                    "active staging installation is missing its release channel".to_string()
+                })?;
+            ReleaseSelector::staging(channel)?;
+            Ok(format!("channel:{channel}"))
+        }
+        other => Err(format!(
+            "active installation has unknown release track {other:?}"
+        )),
     }
 }
 
@@ -485,7 +518,7 @@ struct SelfUpdateOptions {
 
 impl SelfUpdateOptions {
     fn parse(args: Vec<&str>) -> Result<Self, String> {
-        let mut version = "latest".to_string();
+        let mut version = String::new();
         let mut index = 0;
 
         while index < args.len() {

--- a/local/crates/fennara-cli/src/self_update.rs
+++ b/local/crates/fennara-cli/src/self_update.rs
@@ -2,7 +2,7 @@ use crate::VERSION;
 use crate::app_layout::{AppLayout, binary_name, display_path};
 use crate::operation::{self, FailureClass, Phase};
 use crate::release_client::{self, DownloadAsset};
-use crate::release_manifest::{ReleaseManifest, compare_versions};
+use crate::release_manifest::compare_versions;
 use std::cmp::Ordering;
 use std::env;
 use std::fs::{self, File, OpenOptions};
@@ -50,9 +50,7 @@ pub fn start(version_request: &str, continuation_args: Vec<String>) -> Result<St
             release.tag
         )));
     };
-    let manifest_bytes = release_client::download_bytes(&manifest_asset.url, &manifest_asset.name)?;
-    let manifest = ReleaseManifest::parse(&manifest_bytes)
-        .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;
+    let manifest = release_client::download_release_manifest(&release, &manifest_asset)?;
     let selection = manifest
         .select_cli_for_current_platform()
         .map_err(|error| operation::failure(FailureClass::ManifestInvalid, error))?;

--- a/local/crates/fennara-cli/src/self_update_tests.rs
+++ b/local/crates/fennara-cli/src/self_update_tests.rs
@@ -1,0 +1,80 @@
+use crate::app_layout::AppLayout;
+use crate::self_update::active_release_request;
+use std::fs;
+use std::ops::Deref;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn defaults_to_stable_latest_without_active_identity() {
+    let layout = test_layout("stable-default");
+    assert_eq!(active_release_request(&layout).unwrap(), "latest");
+}
+
+#[test]
+fn preserves_the_active_staging_channel() {
+    let layout = test_layout("staging-channel");
+    fs::create_dir_all(&layout.app_dir).unwrap();
+    fs::write(
+        &layout.current_manifest_path,
+        r#"{"version":"0.3.9-pr.101.2","release_track":"staging","release_channel":"pr-101"}"#,
+    )
+    .unwrap();
+
+    assert_eq!(active_release_request(&layout).unwrap(), "channel:pr-101");
+}
+
+#[test]
+fn rejects_malformed_staging_channel_state() {
+    let layout = test_layout("invalid-channel");
+    fs::create_dir_all(&layout.app_dir).unwrap();
+    fs::write(
+        &layout.current_manifest_path,
+        r#"{"version":"0.3.9-pr.101.2","release_track":"staging","release_channel":"../latest"}"#,
+    )
+    .unwrap();
+
+    assert!(
+        active_release_request(&layout)
+            .unwrap_err()
+            .contains("pr-<number>")
+    );
+}
+
+fn test_layout(name: &str) -> TempLayout {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let app_dir = std::env::temp_dir().join(format!(
+        "fennara-self-update-test-{name}-{}-{nonce}",
+        std::process::id()
+    ));
+    TempLayout(AppLayout {
+        bin_dir: app_dir.join("bin"),
+        versions_dir: app_dir.join("versions"),
+        cache_dir: app_dir.join("cache"),
+        logs_dir: app_dir.join("logs"),
+        operation_logs_dir: app_dir.join("logs/operations"),
+        operations_dir: app_dir.join("operations"),
+        tools_dir: app_dir.join("tools"),
+        webview_dir: app_dir.join("webview"),
+        current_manifest_path: app_dir.join("current.json"),
+        app_dir,
+    })
+}
+
+struct TempLayout(AppLayout);
+
+impl Deref for TempLayout {
+    type Target = AppLayout;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for TempLayout {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.app_dir);
+    }
+}

--- a/local/crates/fennara-cli/src/update_apply/transaction.rs
+++ b/local/crates/fennara-cli/src/update_apply/transaction.rs
@@ -25,8 +25,11 @@ pub(super) fn apply_after_exit(
     )?;
     set_state(receipt_path, receipt, "applying")?;
     let layout = AppLayout::detect()?;
-    daemon_setup::shutdown_if_running(&layout)
-        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
+    if let Err(error) = daemon_setup::shutdown_if_running(&layout)
+        .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))
+    {
+        return rollback_before_reopen(options, root, receipt_path, receipt, error);
+    }
     update_stage::verify_staged_addon(root, receipt)
         .map_err(|error| operation::failure(FailureClass::ValidationFailed, error))?;
     launchers::snapshot(&layout, root)

--- a/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
@@ -1,5 +1,7 @@
 use axum::{
-    Extension, Json, Router, middleware,
+    Extension, Json, Router,
+    http::StatusCode,
+    middleware,
     routing::{get, post},
 };
 use serde_json::{Value, json};
@@ -15,6 +17,8 @@ pub(crate) mod process_helpers;
 pub(crate) mod runtime_log;
 pub(crate) mod runtime_sessions;
 pub(crate) mod scene_runner;
+#[cfg(test)]
+mod shutdown_tests;
 pub(crate) mod state;
 pub(crate) mod util;
 
@@ -104,21 +108,43 @@ async fn health() -> Json<Value> {
     }))
 }
 
-async fn shutdown(axum::extract::State(state): axum::extract::State<AppState>) -> Json<Value> {
+async fn shutdown(
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> (StatusCode, Json<Value>) {
+    let connected_projects = state.projects.read().await.len();
+    if let Some(error) = connected_shutdown_error(connected_projects) {
+        return (StatusCode::CONFLICT, Json(error));
+    }
     if let Some(sender) = state.shutdown_sender.lock().await.take() {
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let _ = sender.send(());
         });
 
-        Json(json!({
-            "ok": true,
-            "message": "daemon shutdown requested"
-        }))
+        (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "message": "daemon shutdown requested"
+            })),
+        )
     } else {
-        Json(json!({
-            "ok": true,
-            "message": "daemon shutdown already requested"
-        }))
+        (
+            StatusCode::OK,
+            Json(json!({
+                "ok": true,
+                "message": "daemon shutdown already requested"
+            })),
+        )
     }
+}
+
+fn connected_shutdown_error(connected_projects: usize) -> Option<Value> {
+    (connected_projects > 0).then(|| {
+        json!({
+            "ok": false,
+            "error": "connected_godot_projects",
+            "connected_project_count": connected_projects
+        })
+    })
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
@@ -116,9 +116,9 @@ async fn shutdown(
         return (StatusCode::CONFLICT, Json(error));
     }
     if let Some(sender) = state.shutdown_sender.lock().await.take() {
+        let shutdown_state = state.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            let _ = sender.send(());
+            finish_deferred_shutdown(shutdown_state, sender, Duration::from_millis(100)).await;
         });
 
         (
@@ -136,6 +136,20 @@ async fn shutdown(
                 "message": "daemon shutdown already requested"
             })),
         )
+    }
+}
+
+async fn finish_deferred_shutdown(state: AppState, sender: oneshot::Sender<()>, delay: Duration) {
+    tokio::time::sleep(delay).await;
+    let projects = state.projects.read().await;
+    if connected_shutdown_error(projects.len()).is_none() {
+        let _ = sender.send(());
+        return;
+    }
+    drop(projects);
+    let mut shutdown_sender = state.shutdown_sender.lock().await;
+    if shutdown_sender.is_none() {
+        *shutdown_sender = Some(sender);
     }
 }
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/shutdown_tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/shutdown_tests.rs
@@ -1,0 +1,13 @@
+use super::connected_shutdown_error;
+
+#[test]
+fn shutdown_is_allowed_without_connected_godot_projects() {
+    assert!(connected_shutdown_error(0).is_none());
+}
+
+#[test]
+fn shutdown_reports_connected_project_count() {
+    let error = connected_shutdown_error(2).unwrap();
+    assert_eq!(error["error"], "connected_godot_projects");
+    assert_eq!(error["connected_project_count"], 2);
+}

--- a/local/crates/fennara-daemon/src/runtime_daemon/shutdown_tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/shutdown_tests.rs
@@ -1,7 +1,7 @@
 use super::{connected_shutdown_error, finish_deferred_shutdown};
 use crate::runtime_daemon::state::{AppState, GodotProjectStatus};
 use std::time::Duration;
-use tokio::sync::oneshot;
+use tokio::sync::oneshot::{self, error::TryRecvError};
 
 #[test]
 fn shutdown_is_allowed_without_connected_godot_projects() {
@@ -44,7 +44,7 @@ async fn deferred_shutdown_is_cancelled_and_rearmed_when_a_project_connects() {
 
     shutdown.await.unwrap();
 
-    assert!(receiver.try_recv().is_err());
+    assert_eq!(receiver.try_recv(), Err(TryRecvError::Empty));
     assert!(state.shutdown_sender.lock().await.is_some());
 }
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/shutdown_tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/shutdown_tests.rs
@@ -1,4 +1,7 @@
-use super::connected_shutdown_error;
+use super::{connected_shutdown_error, finish_deferred_shutdown};
+use crate::runtime_daemon::state::{AppState, GodotProjectStatus};
+use std::time::Duration;
+use tokio::sync::oneshot;
 
 #[test]
 fn shutdown_is_allowed_without_connected_godot_projects() {
@@ -10,4 +13,49 @@ fn shutdown_reports_connected_project_count() {
     let error = connected_shutdown_error(2).unwrap();
     assert_eq!(error["error"], "connected_godot_projects");
     assert_eq!(error["connected_project_count"], 2);
+}
+
+#[tokio::test]
+async fn deferred_shutdown_is_cancelled_and_rearmed_when_a_project_connects() {
+    let (sender, mut receiver) = oneshot::channel();
+    let state = AppState::new(sender);
+    let deferred = state.shutdown_sender.lock().await.take().unwrap();
+    let mut projects = state.projects.write().await;
+    let shutdown_state = state.clone();
+    let shutdown = tokio::spawn(async move {
+        finish_deferred_shutdown(shutdown_state, deferred, Duration::ZERO).await;
+    });
+    tokio::task::yield_now().await;
+    projects.insert(
+        "project".into(),
+        GodotProjectStatus {
+            session_id: "session".into(),
+            project_name: Some("Project".into()),
+            project_path: Some("/project".into()),
+            godot_executable_path: None,
+            godot_version: None,
+            plugin_version: None,
+            rendering_context: None,
+            chat_token: None,
+            tools: Vec::new(),
+        },
+    );
+    drop(projects);
+
+    shutdown.await.unwrap();
+
+    assert!(receiver.try_recv().is_err());
+    assert!(state.shutdown_sender.lock().await.is_some());
+}
+
+#[tokio::test]
+async fn deferred_shutdown_fires_when_no_project_connects() {
+    let (sender, receiver) = oneshot::channel();
+    let state = AppState::new(sender);
+    let deferred = state.shutdown_sender.lock().await.take().unwrap();
+
+    finish_deferred_shutdown(state.clone(), deferred, Duration::ZERO).await;
+
+    receiver.await.unwrap();
+    assert!(state.shutdown_sender.lock().await.is_none());
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,6 +21,18 @@ Both scripts use `.package-preview/` as temporary staging and write zip outputs 
 
 Packaging scripts must keep the addon payload small. In particular, Linux CEF runtime files such as `libcef.so` and `fennara_cef_helper` must not be bundled inside `fennara-addon-*`; CEF is installed once into the user's shared Fennara app-data directory.
 
+## Staging Release Scripts
+
+- `write-staging-candidate.mjs`: creates the exact prerelease identity for one pull request and frozen source commit.
+- `validate-staging-build.mjs`: checks addon parts, platform archives, the assembled addon, the release manifest, and Linux CEF before publication.
+- `smoke-public-release.mjs`: downloads every published candidate through its unauthenticated browser URL and verifies the trusted asset and manifest hashes before channel advancement.
+- `write-staging-pointer.mjs`: writes the small per-PR pointer after hashing the exact release manifest.
+- `check-staging-channel-advance.mjs`: rejects backward or conflicting channel movement.
+- `validate-staging-publish-bundle.mjs`: revalidates the final artifact bundle without executing candidate code.
+- `verify-published-assets.mjs`: compares the expected and downloaded GitHub Release asset names and SHA-256 values.
+
+These scripts support `.github/workflows/staging-release.yml`. Candidate build jobs run without release credentials. Only the trusted final job can publish, and it advances the per-channel Git ref after the immutable release has been downloaded and verified.
+
 ## Linux CEF Scripts
 
 - `prepare-linux-cef-sdk.mjs`: downloads/extracts the pinned official Linux x64 CEF SDK used to build the Linux CEF bridge.

--- a/scripts/check-staging-channel-advance.mjs
+++ b/scripts/check-staging-channel-advance.mjs
@@ -1,8 +1,9 @@
 import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { decideChannelAdvance } from "./staging-candidate.mjs";
+import { parseArgs } from "./staging-validation-files.mjs";
 
-const args = parseArgs(process.argv.slice(2));
+const args = parseArgs(process.argv.slice(2), ["next", "current", "github-output"]);
 const next = readJson(requiredArg("next"));
 const currentPath = args.current ? path.resolve(args.current) : undefined;
 const current = currentPath && existsSync(currentPath) ? readJson(currentPath) : undefined;
@@ -15,19 +16,6 @@ console.log(action);
 
 function readJson(file) {
   return JSON.parse(readFileSync(path.resolve(file), "utf8"));
-}
-
-function parseArgs(rawArgs) {
-  const parsed = {};
-  for (let index = 0; index < rawArgs.length; index += 2) {
-    const option = rawArgs[index];
-    const value = rawArgs[index + 1];
-    if (!option?.startsWith("--") || value === undefined) {
-      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
-    }
-    parsed[option.slice(2)] = value;
-  }
-  return parsed;
 }
 
 function requiredArg(name) {

--- a/scripts/check-staging-channel-advance.mjs
+++ b/scripts/check-staging-channel-advance.mjs
@@ -1,0 +1,38 @@
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { decideChannelAdvance } from "./staging-candidate.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const next = readJson(requiredArg("next"));
+const currentPath = args.current ? path.resolve(args.current) : undefined;
+const current = currentPath && existsSync(currentPath) ? readJson(currentPath) : undefined;
+const action = decideChannelAdvance(current, next);
+
+if (args["github-output"]) {
+  appendFileSync(path.resolve(args["github-output"]), `action=${action}\n`);
+}
+console.log(action);
+
+function readJson(file) {
+  return JSON.parse(readFileSync(path.resolve(file), "utf8"));
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    parsed[option.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  if (!args[name]) {
+    throw new Error(`Missing --${name}`);
+  }
+  return args[name];
+}

--- a/scripts/check-version.mjs
+++ b/scripts/check-version.mjs
@@ -1,13 +1,28 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseReleaseVersion, validateReleaseIdentity } from "./release-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const version = read("VERSION").trim();
 const failures = [];
 
-if (!/^\d+\.\d+\.\d+$/.test(version)) {
-  failures.push(`VERSION must use x.y.z format, got "${version}"`);
+try {
+  const parsed = parseReleaseVersion(version, "VERSION");
+  if (parsed.build) {
+    failures.push("VERSION must not contain SemVer build metadata");
+  }
+} catch (error) {
+  failures.push(error.message);
+}
+
+try {
+  validateReleaseIdentity(
+    JSON.parse(read("godot_demo/addons/fennara/release.json")),
+    version,
+  );
+} catch (error) {
+  failures.push(`godot_demo/addons/fennara/release.json: ${error.message}`);
 }
 
 expect(

--- a/scripts/package-addon-all.mjs
+++ b/scripts/package-addon-all.mjs
@@ -1,5 +1,6 @@
 import {
   copyFileSync,
+  chmodSync,
   mkdirSync,
   readFileSync,
   readdirSync,
@@ -10,10 +11,15 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { copyFile } from "./package-text-assets.mjs";
+import { parseReleaseVersion } from "./release-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const args = parseArgs(process.argv.slice(2));
-const version = readVersion();
+const version = args.version ?? readVersion();
+const parsedVersion = parseReleaseVersion(version, "addon package version");
+if (parsedVersion.build) {
+  throw new Error("addon package version must not contain SemVer build metadata");
+}
 const partsDir = path.resolve(root, args["parts-dir"] ?? "dist");
 const distDir = path.join(root, "dist");
 const stageDir = path.join(root, ".package-preview", "addon-all");
@@ -33,6 +39,7 @@ for (const partRoot of partRoots) {
 }
 assertNoBundledCef(path.join(stageDir, "addons", "fennara"));
 assertBundledRipgrep(path.join(stageDir, "addons", "fennara"));
+restoreUnixExecutableModes(path.join(stageDir, "addons", "fennara"));
 
 zipDirectory(stageDir, archive);
 copyFileSync(archive, latestArchive);
@@ -168,5 +175,20 @@ function assertBundledRipgrep(addonRoot) {
     if (!exists(filePath)) {
       throw new Error(`Missing bundled ripgrep binary in addon archive: ${relative}`);
     }
+  }
+}
+
+function restoreUnixExecutableModes(addonRoot) {
+  const executableFiles = [
+    "bin/rg-linux-x86_64",
+    "bin/rg-macos-arm64",
+    "bin/libfennara.macos.editor.framework/libfennara.macos.editor",
+  ];
+  for (const relative of executableFiles) {
+    const filePath = path.join(addonRoot, ...relative.split("/"));
+    if (!exists(filePath)) {
+      throw new Error(`Missing executable addon file: ${relative}`);
+    }
+    chmodSync(filePath, 0o755);
   }
 }

--- a/scripts/release-identity.mjs
+++ b/scripts/release-identity.mjs
@@ -128,9 +128,45 @@ export function createChannelPointer(identity, releaseManifestSha256) {
   };
 }
 
-export function channelReleaseTag(channel) {
+export function validateChannelPointer(value, expectedChannel) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("staging channel pointer must be a JSON object");
+  }
+  if (value.schema_version !== 1) {
+    throw new Error(`unsupported staging channel pointer schema ${JSON.stringify(value.schema_version)}`);
+  }
+  const channel = requiredString(value, "channel");
   validatePullRequestChannel(channel);
-  return `staging-${channel}`;
+  if (expectedChannel !== undefined && channel !== expectedChannel) {
+    throw new Error(
+      `staging channel pointer ${JSON.stringify(channel)} does not match ${JSON.stringify(expectedChannel)}`,
+    );
+  }
+  const identity = validateReleaseIdentity({
+    schema_version: 1,
+    track: "staging",
+    channel,
+    version: requiredString(value, "version"),
+    release_tag: requiredString(value, "release_tag"),
+    source_commit: requiredString(value, "source_commit"),
+  });
+  const releaseManifestSha256 = requiredString(value, "release_manifest_sha256");
+  if (!/^[0-9a-f]{64}$/i.test(releaseManifestSha256)) {
+    throw new Error("release manifest SHA-256 must contain exactly 64 hexadecimal characters");
+  }
+  return {
+    schema_version: 1,
+    channel: identity.channel,
+    version: identity.version,
+    release_tag: identity.release_tag,
+    source_commit: identity.source_commit,
+    release_manifest_sha256: releaseManifestSha256.toLowerCase(),
+  };
+}
+
+export function channelPointerRef(channel) {
+  validatePullRequestChannel(channel);
+  return `fennara-staging/${channel}`;
 }
 
 export function channelPointerAssetName(channel) {

--- a/scripts/release-identity.mjs
+++ b/scripts/release-identity.mjs
@@ -1,0 +1,164 @@
+const SEMVER_PATTERN =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const PULL_REQUEST_CHANNEL_PATTERN = /^pr-([1-9]\d*)$/;
+const FULL_GITHUB_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+export function parseReleaseVersion(value, label = "version") {
+  const match = SEMVER_PATTERN.exec(value);
+  if (!match) {
+    throw new Error(`${label} must be a valid SemVer value, got ${JSON.stringify(value)}`);
+  }
+  return {
+    value,
+    prerelease: match[4] ?? "",
+    build: match[5] ?? "",
+  };
+}
+
+export function validatePullRequestChannel(channel) {
+  const match = PULL_REQUEST_CHANNEL_PATTERN.exec(channel);
+  if (!match) {
+    throw new Error(
+      `staging channel must use pr-<number> format, got ${JSON.stringify(channel)}`,
+    );
+  }
+  const pullRequest = Number(match[1]);
+  if (!Number.isSafeInteger(pullRequest)) {
+    throw new Error(`staging channel number is too large: ${JSON.stringify(channel)}`);
+  }
+  return pullRequest;
+}
+
+export function createReleaseIdentity({
+  version,
+  track = "stable",
+  channel,
+  sourceCommit,
+}) {
+  const parsed = parseReleaseVersion(version);
+  if (parsed.build) {
+    throw new Error("release versions must not contain SemVer build metadata");
+  }
+
+  const identity = {
+    schema_version: 1,
+    track,
+    version,
+    release_tag: `v${version}`,
+  };
+
+  if (track === "stable") {
+    if (parsed.prerelease) {
+      throw new Error("stable release versions must not contain a prerelease suffix");
+    }
+    if (channel !== undefined) {
+      throw new Error("stable release identity must not include a staging channel");
+    }
+    if (sourceCommit !== undefined) {
+      assertFullGitHubSha(sourceCommit);
+      identity.source_commit = sourceCommit;
+    }
+    return identity;
+  }
+
+  if (track !== "staging") {
+    throw new Error(`release track must be stable or staging, got ${JSON.stringify(track)}`);
+  }
+
+  const pullRequest = validatePullRequestChannel(channel ?? "");
+  const prereleaseParts = parsed.prerelease.split(".");
+  if (
+    prereleaseParts.length !== 3 ||
+    prereleaseParts[0] !== "pr" ||
+    prereleaseParts[1] !== String(pullRequest) ||
+    !/^[1-9]\d*$/.test(prereleaseParts[2])
+  ) {
+    throw new Error(
+      `staging version for ${channel} must end with -pr.${pullRequest}.<candidate-number>`,
+    );
+  }
+  assertFullGitHubSha(sourceCommit);
+  identity.channel = channel;
+  identity.source_commit = sourceCommit;
+  return identity;
+}
+
+export function validateReleaseIdentity(value, expectedVersion) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("release identity must be a JSON object");
+  }
+  if (value.schema_version !== 1) {
+    throw new Error(`unsupported release identity schema ${JSON.stringify(value.schema_version)}`);
+  }
+
+  const identity = createReleaseIdentity({
+    version: requiredString(value, "version"),
+    track: requiredString(value, "track"),
+    channel: optionalString(value, "channel"),
+    sourceCommit: optionalString(value, "source_commit"),
+  });
+  if (value.release_tag !== identity.release_tag) {
+    throw new Error(
+      `release identity tag must be ${identity.release_tag}, got ${JSON.stringify(value.release_tag)}`,
+    );
+  }
+  if (expectedVersion !== undefined && identity.version !== expectedVersion) {
+    throw new Error(
+      `release identity version ${identity.version} does not match VERSION ${expectedVersion}`,
+    );
+  }
+  return identity;
+}
+
+export function createChannelPointer(identity, releaseManifestSha256) {
+  const validated = validateReleaseIdentity(identity);
+  if (validated.track !== "staging") {
+    throw new Error("only staging identities can create channel pointers");
+  }
+  if (!/^[0-9a-f]{64}$/i.test(releaseManifestSha256)) {
+    throw new Error("release manifest SHA-256 must contain exactly 64 hexadecimal characters");
+  }
+  return {
+    schema_version: 1,
+    channel: validated.channel,
+    version: validated.version,
+    release_tag: validated.release_tag,
+    source_commit: validated.source_commit,
+    release_manifest_sha256: releaseManifestSha256.toLowerCase(),
+  };
+}
+
+export function channelReleaseTag(channel) {
+  validatePullRequestChannel(channel);
+  return `staging-${channel}`;
+}
+
+export function channelPointerAssetName(channel) {
+  validatePullRequestChannel(channel);
+  return `fennara-staging-channel-${channel}.json`;
+}
+
+function assertFullGitHubSha(value) {
+  if (!FULL_GITHUB_SHA_PATTERN.test(value ?? "")) {
+    throw new Error("staging source commit must be a full 40-character lowercase Git SHA");
+  }
+}
+
+function requiredString(value, field) {
+  const fieldValue = value[field];
+  if (typeof fieldValue !== "string" || fieldValue.length === 0) {
+    throw new Error(`release identity is missing ${field}`);
+  }
+  return fieldValue;
+}
+
+function optionalString(value, field) {
+  const fieldValue = value[field];
+  if (fieldValue === undefined) {
+    return undefined;
+  }
+  if (typeof fieldValue !== "string" || fieldValue.length === 0) {
+    throw new Error(`release identity ${field} must be a non-empty string when present`);
+  }
+  return fieldValue;
+}

--- a/scripts/release-targets.mjs
+++ b/scripts/release-targets.mjs
@@ -1,0 +1,5 @@
+export const RELEASE_TARGETS = Object.freeze([
+  Object.freeze({ key: "windows-x86_64", platform: "windows", arch: "x86_64" }),
+  Object.freeze({ key: "linux-x86_64", platform: "linux", arch: "x86_64" }),
+  Object.freeze({ key: "macos-arm64", platform: "macos", arch: "arm64" }),
+]);

--- a/scripts/set-version.mjs
+++ b/scripts/set-version.mjs
@@ -2,17 +2,50 @@ import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { createReleaseIdentity, parseReleaseVersion } from "./release-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const version = process.argv[2];
+let args;
+try {
+  args = parseArgs(process.argv.slice(3));
+} catch (error) {
+  console.error(error.message);
+  printUsage();
+  process.exit(1);
+}
 
-if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
-  console.error("Usage: node scripts/set-version.mjs <x.y.z>");
+try {
+  const parsed = parseReleaseVersion(version ?? "");
+  if (parsed.build) {
+    throw new Error("release versions must not contain SemVer build metadata");
+  }
+} catch (error) {
+  console.error(error.message);
+  printUsage();
+  process.exit(1);
+}
+
+let identity;
+try {
+  identity = createReleaseIdentity({
+    version,
+    track: args.track ?? "stable",
+    channel: args.channel,
+    sourceCommit: args["source-commit"],
+  });
+} catch (error) {
+  console.error(error.message);
+  printUsage();
   process.exit(1);
 }
 
 write("VERSION", `${version}\n`);
 write("godot_demo/addons/fennara/VERSION", `${version}\n`);
+write(
+  "godot_demo/addons/fennara/release.json",
+  `${JSON.stringify(identity, null, 2)}\n`,
+);
 
 update("local/Cargo.toml", (text) => {
   if (/\[workspace\.package\][\s\S]*?version\s*=/.test(text)) {
@@ -74,4 +107,31 @@ function run(command, args) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1);
   }
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  const allowed = new Set(["track", "channel", "source-commit"]);
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+    if (!arg.startsWith("--") || !rawArgs[index + 1]?.length) {
+      throw new Error(`Invalid set-version argument: ${arg}`);
+    }
+    const name = arg.slice(2);
+    if (!allowed.has(name)) {
+      throw new Error(`Unknown set-version option: ${arg}`);
+    }
+    if (parsed[name] !== undefined) {
+      throw new Error(`Duplicate set-version option: ${arg}`);
+    }
+    parsed[name] = rawArgs[index + 1];
+    index += 1;
+  }
+  return parsed;
+}
+
+function printUsage() {
+  console.error(
+    "Usage: node scripts/set-version.mjs <semver> [--track staging --channel pr-<number> --source-commit <full-sha>]",
+  );
 }

--- a/scripts/smoke-public-release.mjs
+++ b/scripts/smoke-public-release.mjs
@@ -1,12 +1,17 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { requireDescendantPath } from "./staging-validation-files.mjs";
 
 const args = parseArgs(process.argv.slice(2));
 const repository = requiredArg("repository");
 const releaseTag = requiredArg("release-tag");
 const expectedDir = path.resolve(requiredArg("expected-dir"));
-const downloadDir = path.resolve(requiredArg("download-dir"));
+const downloadDir = requireDescendantPath(
+  process.env.RUNNER_TEMP,
+  requiredArg("download-dir"),
+  "--download-dir",
+);
 const METADATA_TIMEOUT_MS = 30_000;
 const ASSET_TIMEOUT_MS = 60_000;
 

--- a/scripts/smoke-public-release.mjs
+++ b/scripts/smoke-public-release.mjs
@@ -7,12 +7,14 @@ const repository = requiredArg("repository");
 const releaseTag = requiredArg("release-tag");
 const expectedDir = path.resolve(requiredArg("expected-dir"));
 const downloadDir = path.resolve(requiredArg("download-dir"));
+const METADATA_TIMEOUT_MS = 30_000;
+const ASSET_TIMEOUT_MS = 60_000;
 
 if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
   throw new Error("repository must use owner/name format");
 }
 
-const response = await fetch(
+const metadata = await fetchJson(
   `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(releaseTag)}`,
   {
     headers: {
@@ -21,11 +23,13 @@ const response = await fetch(
       "X-GitHub-Api-Version": "2026-03-10",
     },
   },
+  METADATA_TIMEOUT_MS,
+  "public release metadata",
 );
-if (!response.ok) {
-  throw new Error(`public release metadata returned HTTP ${response.status}`);
+if (!metadata.response.ok) {
+  throw new Error(`public release metadata returned HTTP ${metadata.response.status}`);
 }
-const release = await response.json();
+const release = metadata.body;
 if (release.draft || !release.prerelease || release.tag_name !== releaseTag) {
   throw new Error("public release metadata does not describe the expected published prerelease");
 }
@@ -43,14 +47,19 @@ for (const [name, expectedHash] of expectedManifest) {
   if (typeof url !== "string" || !url.startsWith("https://github.com/")) {
     throw new Error(`release asset ${name} has no public GitHub browser download URL`);
   }
-  const assetResponse = await fetch(url, {
-    headers: { "User-Agent": "fennara-staging-public-smoke" },
-    redirect: "follow",
-  });
-  if (!assetResponse.ok) {
-    throw new Error(`public download for ${name} returned HTTP ${assetResponse.status}`);
+  const download = await fetchBytes(
+    url,
+    {
+      headers: { "User-Agent": "fennara-staging-public-smoke" },
+      redirect: "follow",
+    },
+    ASSET_TIMEOUT_MS,
+    `public download for ${name}`,
+  );
+  if (!download.response.ok) {
+    throw new Error(`public download for ${name} returned HTTP ${download.response.status}`);
   }
-  const bytes = Buffer.from(await assetResponse.arrayBuffer());
+  const bytes = download.body;
   const actualHash = createHash("sha256").update(bytes).digest("hex");
   if (actualHash !== expectedHash) {
     throw new Error(`public download hash mismatch for ${name}`);
@@ -137,4 +146,31 @@ function requiredArg(name) {
     throw new Error(`missing --${name}`);
   }
   return args[name];
+}
+
+async function fetchJson(url, options, timeoutMs, label) {
+  return fetchBody(url, options, timeoutMs, label, async (response) =>
+    response.ok ? response.json() : undefined,
+  );
+}
+
+async function fetchBytes(url, options, timeoutMs, label) {
+  return fetchBody(url, options, timeoutMs, label, async (response) =>
+    response.ok ? Buffer.from(await response.arrayBuffer()) : undefined,
+  );
+}
+
+async function fetchBody(url, options, timeoutMs, label, readBody) {
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { response, body: await readBody(response) };
+  } catch (error) {
+    if (error?.name === "TimeoutError") {
+      throw new Error(`${label} timed out after ${timeoutMs} ms`, { cause: error });
+    }
+    throw new Error(`${label} failed: ${error?.message ?? error}`, { cause: error });
+  }
 }

--- a/scripts/smoke-public-release.mjs
+++ b/scripts/smoke-public-release.mjs
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const repository = requiredArg("repository");
+const releaseTag = requiredArg("release-tag");
+const expectedDir = path.resolve(requiredArg("expected-dir"));
+const downloadDir = path.resolve(requiredArg("download-dir"));
+
+if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repository)) {
+  throw new Error("repository must use owner/name format");
+}
+
+const response = await fetch(
+  `https://api.github.com/repos/${repository}/releases/tags/${encodeURIComponent(releaseTag)}`,
+  {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "fennara-staging-public-smoke",
+      "X-GitHub-Api-Version": "2026-03-10",
+    },
+  },
+);
+if (!response.ok) {
+  throw new Error(`public release metadata returned HTTP ${response.status}`);
+}
+const release = await response.json();
+if (release.draft || !release.prerelease || release.tag_name !== releaseTag) {
+  throw new Error("public release metadata does not describe the expected published prerelease");
+}
+
+const expectedManifest = expectedAssetManifest(expectedDir);
+const published = new Map(
+  (release.assets ?? []).map((asset) => [asset.name, asset.browser_download_url]),
+);
+assertExactNames([...expectedManifest.keys()], [...published.keys()]);
+
+rmSync(downloadDir, { recursive: true, force: true });
+mkdirSync(downloadDir, { recursive: true });
+for (const [name, expectedHash] of expectedManifest) {
+  const url = published.get(name);
+  if (typeof url !== "string" || !url.startsWith("https://github.com/")) {
+    throw new Error(`release asset ${name} has no public GitHub browser download URL`);
+  }
+  const assetResponse = await fetch(url, {
+    headers: { "User-Agent": "fennara-staging-public-smoke" },
+    redirect: "follow",
+  });
+  if (!assetResponse.ok) {
+    throw new Error(`public download for ${name} returned HTTP ${assetResponse.status}`);
+  }
+  const bytes = Buffer.from(await assetResponse.arrayBuffer());
+  const actualHash = createHash("sha256").update(bytes).digest("hex");
+  if (actualHash !== expectedHash) {
+    throw new Error(`public download hash mismatch for ${name}`);
+  }
+  writeFileSync(path.join(downloadDir, name), bytes);
+}
+
+const manifestName = [...expectedManifest.keys()].find(
+  (name) => name.startsWith("fennara-release-manifest-v") && name.endsWith(".json"),
+);
+if (!manifestName) {
+  throw new Error("published assets do not contain a versioned release manifest");
+}
+const manifest = JSON.parse(readFileSync(path.join(downloadDir, manifestName), "utf8"));
+for (const asset of manifestAssets(manifest)) {
+  if (!expectedManifest.has(asset.name)) {
+    throw new Error(`release manifest references unpublished asset ${asset.name}`);
+  }
+  if (expectedManifest.get(asset.name) !== asset.sha256) {
+    throw new Error(`release manifest hash does not match public asset ${asset.name}`);
+  }
+}
+
+console.log(`Verified ${expectedManifest.size} assets through public browser download URLs`);
+
+function expectedAssetManifest(directory) {
+  return new Map(
+    readdirSync(directory)
+      .sort()
+      .map((name) => {
+        const file = path.join(directory, name);
+        if (!statSync(file).isFile()) {
+          throw new Error(`unexpected directory in expected release assets: ${file}`);
+        }
+        return [name, createHash("sha256").update(readFileSync(file)).digest("hex")];
+      }),
+  );
+}
+
+function manifestAssets(manifest) {
+  const records = [
+    ...Object.values(manifest.assets?.cli ?? {}),
+    ...Object.values(manifest.assets?.local ?? {}),
+    manifest.assets?.addon,
+    ...(manifest.shared_runtimes ?? []).map((runtime) => runtime.archive),
+  ].filter(Boolean);
+  for (const record of records) {
+    if (
+      typeof record.name !== "string" ||
+      typeof record.sha256 !== "string" ||
+      !/^[0-9a-f]{64}$/.test(record.sha256)
+    ) {
+      throw new Error("release manifest contains an invalid asset record");
+    }
+  }
+  return records;
+}
+
+function assertExactNames(expected, actual) {
+  const left = [...expected].sort();
+  const right = [...actual].sort();
+  if (JSON.stringify(left) !== JSON.stringify(right)) {
+    throw new Error(
+      `public release assets differ from validated assets\nexpected: ${JSON.stringify(left)}\nactual: ${JSON.stringify(right)}`,
+    );
+  }
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`invalid argument ${JSON.stringify(option)}`);
+    }
+    parsed[option.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  if (!args[name]) {
+    throw new Error(`missing --${name}`);
+  }
+  return args[name];
+}

--- a/scripts/smoke-public-release.mjs
+++ b/scripts/smoke-public-release.mjs
@@ -1,15 +1,24 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { requireDescendantPath } from "./staging-validation-files.mjs";
+import {
+  parseArgs,
+  requireDescendantPath,
+  requiredArg,
+} from "./staging-validation-files.mjs";
 
-const args = parseArgs(process.argv.slice(2));
-const repository = requiredArg("repository");
-const releaseTag = requiredArg("release-tag");
-const expectedDir = path.resolve(requiredArg("expected-dir"));
+const args = parseArgs(process.argv.slice(2), [
+  "repository",
+  "release-tag",
+  "expected-dir",
+  "download-dir",
+]);
+const repository = requiredArg(args, "repository");
+const releaseTag = requiredArg(args, "release-tag");
+const expectedDir = path.resolve(requiredArg(args, "expected-dir"));
 const downloadDir = requireDescendantPath(
   process.env.RUNNER_TEMP,
-  requiredArg("download-dir"),
+  requiredArg(args, "download-dir"),
   "--download-dir",
 );
 const METADATA_TIMEOUT_MS = 30_000;
@@ -133,25 +142,6 @@ function assertExactNames(expected, actual) {
   }
 }
 
-function parseArgs(rawArgs) {
-  const parsed = {};
-  for (let index = 0; index < rawArgs.length; index += 2) {
-    const option = rawArgs[index];
-    const value = rawArgs[index + 1];
-    if (!option?.startsWith("--") || value === undefined) {
-      throw new Error(`invalid argument ${JSON.stringify(option)}`);
-    }
-    parsed[option.slice(2)] = value;
-  }
-  return parsed;
-}
-
-function requiredArg(name) {
-  if (!args[name]) {
-    throw new Error(`missing --${name}`);
-  }
-  return args[name];
-}
 
 async function fetchJson(url, options, timeoutMs, label) {
   return fetchBody(url, options, timeoutMs, label, async (response) =>

--- a/scripts/staging-addon-validation.mjs
+++ b/scripts/staging-addon-validation.mjs
@@ -5,6 +5,8 @@ import { RELEASE_TARGETS } from "./release-targets.mjs";
 import {
   assertDirectory,
   assertPath,
+  assertSafeZipMembers,
+  assertSameNames,
   assertZipExecutable,
   assertVersion,
   inspectZip,
@@ -41,6 +43,8 @@ export function validateAddonArchive(candidate, addonFile) {
     "addons/fennara/VERSION",
     "addons/fennara/release.json",
   );
+  const validatedNames = assertSafeZipMembers(addon.members);
+  assertSameNames(validatedNames, addon.names, `${path.basename(addonFile)} ZIP members`);
   assertVersion(addon.version, candidate.version, path.basename(addonFile));
   const addonIdentity = validateReleaseIdentity(JSON.parse(addon.release), candidate.version);
   const candidateIdentity = validateReleaseIdentity(candidate, candidate.version);

--- a/scripts/staging-addon-validation.mjs
+++ b/scripts/staging-addon-validation.mjs
@@ -1,0 +1,89 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { validateReleaseIdentity } from "./release-identity.mjs";
+import { RELEASE_TARGETS } from "./release-targets.mjs";
+import {
+  assertDirectory,
+  assertPath,
+  assertZipExecutable,
+  assertVersion,
+  inspectZip,
+  readJson,
+  treeHashes,
+} from "./staging-validation-files.mjs";
+
+export function validateAddonParts(candidate, addonPartsDir) {
+  let commonFiles;
+  for (const target of RELEASE_TARGETS) {
+    const addonRoot = path.join(
+      addonPartsDir,
+      `fennara-addon-part-${target.platform}-${target.arch}`,
+      "addons",
+      "fennara",
+    );
+    assertDirectory(addonRoot, `addon part ${target.key}`);
+    assertAddonIdentity(addonRoot, candidate);
+    for (const relative of addonBinaryRequirements(target)) {
+      assertPath(path.join(addonRoot, ...relative.split("/")), `${target.key} addon file ${relative}`);
+    }
+    const currentCommonFiles = treeHashes(addonRoot, "bin");
+    if (commonFiles === undefined) {
+      commonFiles = currentCommonFiles;
+    } else if (JSON.stringify(commonFiles) !== JSON.stringify(currentCommonFiles)) {
+      throw new Error(`non-binary addon files differ in ${target.key}`);
+    }
+  }
+}
+
+export function validateAddonArchive(candidate, addonFile) {
+  const addon = inspectZip(
+    addonFile,
+    "addons/fennara/VERSION",
+    "addons/fennara/release.json",
+  );
+  assertVersion(addon.version, candidate.version, path.basename(addonFile));
+  const addonIdentity = validateReleaseIdentity(JSON.parse(addon.release), candidate.version);
+  const candidateIdentity = validateReleaseIdentity(candidate, candidate.version);
+  if (JSON.stringify(addonIdentity) !== JSON.stringify(candidateIdentity)) {
+    throw new Error("all-platform addon identity does not match staging candidate");
+  }
+  for (const target of RELEASE_TARGETS) {
+    for (const relative of addonBinaryRequirements(target)) {
+      const entry = `addons/fennara/${relative}`;
+      if (!addon.names.includes(entry) && !addon.names.some((name) => name.startsWith(`${entry}/`))) {
+        throw new Error(`${path.basename(addonFile)} is missing ${entry}`);
+      }
+    }
+  }
+  for (const relative of [
+    "bin/rg-linux-x86_64",
+    "bin/rg-macos-arm64",
+    "bin/libfennara.macos.editor.framework/libfennara.macos.editor",
+  ]) {
+    assertZipExecutable(addon, `addons/fennara/${relative}`);
+  }
+}
+
+function assertAddonIdentity(addonRoot, candidate) {
+  const version = readFileSync(path.join(addonRoot, "VERSION"), "utf8").trim();
+  assertVersion(version, candidate.version, addonRoot);
+  const identity = validateReleaseIdentity(readJson(path.join(addonRoot, "release.json")), version);
+  const expected = validateReleaseIdentity(candidate, candidate.version);
+  if (JSON.stringify(identity) !== JSON.stringify(expected)) {
+    throw new Error(`addon part identity does not match staging candidate: ${addonRoot}`);
+  }
+}
+
+function addonBinaryRequirements(target) {
+  if (target.platform === "windows") {
+    return ["bin/libfennara.windows.editor.x86_64.dll", "bin/rg-windows-x86_64.exe"];
+  }
+  if (target.platform === "linux") {
+    return [
+      "bin/libfennara.linux.editor.x86_64.so",
+      "bin/libfennara_linux_cef_bridge.so",
+      "bin/rg-linux-x86_64",
+    ];
+  }
+  return ["bin/libfennara.macos.editor.framework", "bin/rg-macos-arm64"];
+}

--- a/scripts/staging-build-validation.mjs
+++ b/scripts/staging-build-validation.mjs
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { validateAddonArchive, validateAddonParts } from "./staging-addon-validation.mjs";
+import {
+  validateLinuxCefArchive,
+  validatePlatformArchives,
+  validateReleaseManifest,
+} from "./staging-release-validation.mjs";
+import { readJson } from "./staging-validation-files.mjs";
+import { validateStagingCandidate } from "./staging-candidate.mjs";
+
+export function validateStagingBuild({
+  candidatePath,
+  assetsDir,
+  addonPartsDir,
+  releaseManifestPath,
+  linuxCefManifestPath,
+}) {
+  const candidate = validateStagingCandidate(readJson(candidatePath));
+  const linuxCef = readJson(linuxCefManifestPath);
+  const manifest = readJson(releaseManifestPath);
+
+  validateAddonParts(candidate, addonPartsDir);
+  validateReleaseManifest(candidate, manifest, assetsDir, linuxCef);
+  validatePlatformArchives(candidate, assetsDir);
+  validateAddonArchive(
+    candidate,
+    path.join(assetsDir, `fennara-release-addon-v${candidate.version}.zip`),
+  );
+  validateLinuxCefArchive(assetsDir, linuxCef);
+  return candidate;
+}

--- a/scripts/staging-candidate.mjs
+++ b/scripts/staging-candidate.mjs
@@ -1,0 +1,135 @@
+import {
+  createReleaseIdentity,
+  parseReleaseVersion,
+  validateChannelPointer,
+  validateReleaseIdentity,
+} from "./release-identity.mjs";
+
+const SOURCE_REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+export function createStagingCandidate({
+  baseVersion,
+  pullRequest,
+  candidateNumber,
+  sourceCommit,
+  sourceRepository,
+}) {
+  const base = parseReleaseVersion(baseVersion, "base version");
+  if (base.prerelease || base.build) {
+    throw new Error("base version must be a stable SemVer value without prerelease or build metadata");
+  }
+
+  const pullRequestNumber = positiveInteger(pullRequest, "pull request");
+  const sequence = positiveInteger(candidateNumber, "candidate number");
+  validateSourceRepository(sourceRepository);
+
+  const channel = `pr-${pullRequestNumber}`;
+  const version = `${baseVersion}-pr.${pullRequestNumber}.${sequence}`;
+  const identity = createReleaseIdentity({
+    version,
+    track: "staging",
+    channel,
+    sourceCommit,
+  });
+
+  return {
+    ...identity,
+    base_version: baseVersion,
+    pull_request: pullRequestNumber,
+    candidate_number: sequence,
+    source_repository: sourceRepository,
+  };
+}
+
+export function validateStagingCandidate(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("staging candidate must be a JSON object");
+  }
+  const identity = validateReleaseIdentity(value, requiredString(value, "version"));
+  if (identity.track !== "staging") {
+    throw new Error("staging candidate release identity must use the staging track");
+  }
+
+  const expected = createStagingCandidate({
+    baseVersion: requiredString(value, "base_version"),
+    pullRequest: value.pull_request,
+    candidateNumber: value.candidate_number,
+    sourceCommit: requiredString(value, "source_commit"),
+    sourceRepository: requiredString(value, "source_repository"),
+  });
+  for (const [field, expectedValue] of Object.entries(expected)) {
+    if (value[field] !== expectedValue) {
+      throw new Error(
+        `staging candidate ${field} must be ${JSON.stringify(expectedValue)}, got ${JSON.stringify(value[field])}`,
+      );
+    }
+  }
+  return expected;
+}
+
+export function decideChannelAdvance(currentValue, nextValue) {
+  const next = validateChannelPointer(nextValue);
+  if (currentValue === undefined || currentValue === null) {
+    return "create";
+  }
+  const current = validateChannelPointer(currentValue, next.channel);
+  const currentSequence = candidateSequence(current.version, current.channel);
+  const nextSequence = candidateSequence(next.version, next.channel);
+  if (nextSequence < currentSequence) {
+    throw new Error(
+      `refusing to move ${next.channel} backward from ${current.version} to ${next.version}`,
+    );
+  }
+  if (nextSequence === currentSequence) {
+    if (JSON.stringify(current) === JSON.stringify(next)) {
+      return "noop";
+    }
+    throw new Error(
+      `channel ${next.channel} candidate ${next.version} already exists with different provenance`,
+    );
+  }
+  return "advance";
+}
+
+function positiveInteger(value, label) {
+  const text = String(value ?? "");
+  if (!/^[1-9]\d*$/.test(text)) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  const parsed = Number(text);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${label} is too large`);
+  }
+  return parsed;
+}
+
+function validateSourceRepository(value) {
+  const [owner, repository] = String(value ?? "").split("/");
+  if (
+    !SOURCE_REPOSITORY_PATTERN.test(value ?? "") ||
+    owner === "." ||
+    owner === ".." ||
+    repository === "." ||
+    repository === ".."
+  ) {
+    throw new Error("source repository must use owner/name format");
+  }
+}
+
+function candidateSequence(version, channel) {
+  const pullRequest = channel.slice("pr-".length);
+  const parsed = parseReleaseVersion(version);
+  const match = new RegExp(`^pr\\.${pullRequest}\\.([1-9]\\d*)$`).exec(parsed.prerelease);
+  if (!match) {
+    throw new Error(`staging version ${version} does not belong to ${channel}`);
+  }
+  return positiveInteger(match[1], "candidate number");
+}
+
+function requiredString(value, field) {
+  const fieldValue = value[field];
+  if (typeof fieldValue !== "string" || fieldValue.length === 0) {
+    throw new Error(`staging candidate is missing ${field}`);
+  }
+  return fieldValue;
+}

--- a/scripts/staging-release-validation.mjs
+++ b/scripts/staging-release-validation.mjs
@@ -7,6 +7,7 @@ import {
   assertSameNames,
   assertVersion,
   inspectZip,
+  requiredSafeFileName,
   requiredSha256,
   requiredString,
   sha256File,
@@ -38,10 +39,11 @@ export function validateReleaseManifest(candidate, manifest, assetsDir, linuxCef
     "release manifest assets",
   );
   for (const asset of manifestAssets) {
-    const file = path.join(assetsDir, asset.name);
-    assertFile(file, `release asset ${asset.name}`);
-    if (sha256File(file) !== requiredSha256(asset.sha256, `manifest hash for ${asset.name}`)) {
-      throw new Error(`release manifest hash mismatch for ${asset.name}`);
+    const name = requiredSafeFileName(asset.name, "release manifest asset name");
+    const file = path.join(assetsDir, name);
+    assertFile(file, `release asset ${name}`);
+    if (sha256File(file) !== requiredSha256(asset.sha256, `manifest hash for ${name}`)) {
+      throw new Error(`release manifest hash mismatch for ${name}`);
     }
   }
 
@@ -79,8 +81,9 @@ export function validatePlatformArchives(candidate, assetsDir) {
 }
 
 export function validateLinuxCefArchive(assetsDir, linuxCef) {
-  const name = requiredString(linuxCef.archive?.name, "Linux CEF archive name");
+  const name = requiredSafeFileName(linuxCef.archive?.name, "Linux CEF archive name");
   const file = path.join(assetsDir, name);
+  assertFile(file, `Linux CEF archive ${name}`);
   if (sha256File(file) !== requiredSha256(linuxCef.archive?.sha256, "Linux CEF hash")) {
     throw new Error(`Linux CEF archive hash mismatch for ${name}`);
   }
@@ -95,7 +98,7 @@ function expectedArchiveNames(candidate, linuxCef) {
       ({ platform, arch }) => `fennara-release-local-${platform}-${arch}-v${candidate.version}.zip`,
     ),
     `fennara-release-addon-v${candidate.version}.zip`,
-    requiredString(linuxCef.archive?.name, "Linux CEF archive name"),
+    requiredSafeFileName(linuxCef.archive?.name, "Linux CEF archive name"),
   ]);
 }
 

--- a/scripts/staging-release-validation.mjs
+++ b/scripts/staging-release-validation.mjs
@@ -1,0 +1,109 @@
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { validateReleaseIdentity } from "./release-identity.mjs";
+import { RELEASE_TARGETS } from "./release-targets.mjs";
+import {
+  assertFile,
+  assertSameNames,
+  assertVersion,
+  inspectZip,
+  requiredSha256,
+  requiredString,
+  sha256File,
+} from "./staging-validation-files.mjs";
+
+const LOCAL_BINARIES = [
+  "fennara",
+  "fennara-daemon",
+  "fennara-daemon-runtime",
+  "fennara-mcp",
+  "fennara-mcp-runtime",
+];
+
+export function validateReleaseManifest(candidate, manifest, assetsDir, linuxCef) {
+  if (manifest.version !== candidate.version) {
+    throw new Error(`release manifest version does not match ${candidate.version}`);
+  }
+  const manifestIdentity = validateReleaseIdentity(manifest.release, candidate.version);
+  const candidateIdentity = validateReleaseIdentity(candidate, candidate.version);
+  if (JSON.stringify(manifestIdentity) !== JSON.stringify(candidateIdentity)) {
+    throw new Error("release manifest identity does not match staging candidate");
+  }
+
+  const expectedArchives = expectedArchiveNames(candidate, linuxCef);
+  const manifestAssets = manifestAssetRecords(manifest);
+  assertSameNames(
+    new Set(manifestAssets.map((asset) => asset.name)),
+    expectedArchives,
+    "release manifest assets",
+  );
+  for (const asset of manifestAssets) {
+    const file = path.join(assetsDir, asset.name);
+    assertFile(file, `release asset ${asset.name}`);
+    if (sha256File(file) !== requiredSha256(asset.sha256, `manifest hash for ${asset.name}`)) {
+      throw new Error(`release manifest hash mismatch for ${asset.name}`);
+    }
+  }
+
+  const expectedFiles = new Set([
+    ...expectedArchives,
+    `fennara-release-manifest-v${candidate.version}.json`,
+  ]);
+  const actualFiles = new Set(
+    readdirSync(assetsDir).filter((entry) => statSync(path.join(assetsDir, entry)).isFile()),
+  );
+  assertSameNames(actualFiles, expectedFiles, "assembled release files");
+}
+
+export function validatePlatformArchives(candidate, assetsDir) {
+  for (const target of RELEASE_TARGETS) {
+    const extension = target.platform === "windows" ? ".exe" : "";
+    const cliName = `fennara-cli-${target.platform}-${target.arch}-v${candidate.version}.zip`;
+    const cli = inspectZip(path.join(assetsDir, cliName), "VERSION", undefined);
+    assertSameNames(
+      new Set(cli.names),
+      new Set(["VERSION", `bin/fennara${extension}`]),
+      cliName,
+    );
+    assertVersion(cli.version, candidate.version, cliName);
+
+    const localName = `fennara-release-local-${target.platform}-${target.arch}-v${candidate.version}.zip`;
+    const local = inspectZip(path.join(assetsDir, localName), "VERSION", undefined);
+    assertSameNames(
+      new Set(local.names),
+      new Set(["VERSION", ...LOCAL_BINARIES.map((binary) => `bin/${binary}${extension}`)]),
+      localName,
+    );
+    assertVersion(local.version, candidate.version, localName);
+  }
+}
+
+export function validateLinuxCefArchive(assetsDir, linuxCef) {
+  const name = requiredString(linuxCef.archive?.name, "Linux CEF archive name");
+  const file = path.join(assetsDir, name);
+  if (sha256File(file) !== requiredSha256(linuxCef.archive?.sha256, "Linux CEF hash")) {
+    throw new Error(`Linux CEF archive hash mismatch for ${name}`);
+  }
+}
+
+function expectedArchiveNames(candidate, linuxCef) {
+  return new Set([
+    ...RELEASE_TARGETS.map(
+      ({ platform, arch }) => `fennara-cli-${platform}-${arch}-v${candidate.version}.zip`,
+    ),
+    ...RELEASE_TARGETS.map(
+      ({ platform, arch }) => `fennara-release-local-${platform}-${arch}-v${candidate.version}.zip`,
+    ),
+    `fennara-release-addon-v${candidate.version}.zip`,
+    requiredString(linuxCef.archive?.name, "Linux CEF archive name"),
+  ]);
+}
+
+function manifestAssetRecords(manifest) {
+  return [
+    ...Object.values(manifest.assets?.cli ?? {}),
+    ...Object.values(manifest.assets?.local ?? {}),
+    manifest.assets?.addon,
+    ...(manifest.shared_runtimes ?? []).map((runtime) => runtime.archive),
+  ].filter(Boolean);
+}

--- a/scripts/staging-validation-files.mjs
+++ b/scripts/staging-validation-files.mjs
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+export function inspectZip(file, versionEntry, releaseEntry) {
+  assertFile(file, "release archive");
+  const script = [
+    "import json, sys, zipfile",
+    "archive, version_entry, release_entry = sys.argv[1:4]",
+    "with zipfile.ZipFile(archive, 'r') as zf:",
+    "    names = sorted(name.rstrip('/') for name in zf.namelist() if not name.endswith('/'))",
+    "    modes = {info.filename.rstrip('/'): (info.external_attr >> 16) & 0o777 for info in zf.infolist() if not info.is_dir()}",
+    "    result = {'names': names, 'modes': modes, 'version': zf.read(version_entry).decode('utf-8').strip()}",
+    "    if release_entry:",
+    "        result['release'] = zf.read(release_entry).decode('utf-8')",
+    "    print(json.dumps(result))",
+  ].join("\n");
+  const result = spawnSync("python", ["-c", script, file, versionEntry, releaseEntry ?? ""], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`failed to inspect ${file}: ${result.stderr.trim()}`);
+  }
+  return JSON.parse(result.stdout);
+}
+
+export function treeHashes(root, excludedTopLevel) {
+  const records = {};
+  visit(root, "");
+  return records;
+
+  function visit(directory, relativeDirectory) {
+    for (const entry of readdirSync(directory).sort()) {
+      if (!relativeDirectory && entry === excludedTopLevel) {
+        continue;
+      }
+      const file = path.join(directory, entry);
+      const relative = path.posix.join(relativeDirectory, entry);
+      if (statSync(file).isDirectory()) {
+        visit(file, relative);
+      } else {
+        records[relative] = sha256File(file);
+      }
+    }
+  }
+}
+
+export function assertSameNames(actual, expected, label) {
+  const left = [...actual].sort();
+  const right = [...expected].sort();
+  if (JSON.stringify(left) !== JSON.stringify(right)) {
+    throw new Error(`${label} mismatch\nexpected: ${JSON.stringify(right)}\nactual: ${JSON.stringify(left)}`);
+  }
+}
+
+export function assertVersion(actual, expected, label) {
+  if (actual !== expected) {
+    throw new Error(`${label} version ${JSON.stringify(actual)} does not match ${expected}`);
+  }
+}
+
+export function assertPath(file, label) {
+  if (!exists(file)) {
+    throw new Error(`Missing ${label}: ${file}`);
+  }
+}
+
+export function assertZipExecutable(archive, entry) {
+  const mode = archive.modes?.[entry] ?? 0;
+  if ((mode & 0o111) === 0) {
+    throw new Error(`${entry} is not executable in the release archive (mode ${mode.toString(8)})`);
+  }
+}
+
+export function assertFile(file, label) {
+  if (!exists(file) || !statSync(file).isFile()) {
+    throw new Error(`Missing ${label}: ${file}`);
+  }
+}
+
+export function assertDirectory(directory, label) {
+  if (!exists(directory) || !statSync(directory).isDirectory()) {
+    throw new Error(`Missing ${label}: ${directory}`);
+  }
+}
+
+export function sha256File(file) {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+export function requiredString(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is required`);
+  }
+  return value;
+}
+
+export function requiredSha256(value, label) {
+  if (typeof value !== "string" || !/^[0-9a-f]{64}$/i.test(value)) {
+    throw new Error(`${label} must be a SHA-256 value`);
+  }
+  return value.toLowerCase();
+}
+
+export function readJson(file) {
+  return JSON.parse(readFileSync(file, "utf8"));
+}
+
+function exists(file) {
+  try {
+    statSync(file);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/staging-validation-files.mjs
+++ b/scripts/staging-validation-files.mjs
@@ -3,8 +3,11 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
+let cachedPython;
+
 export function inspectZip(file, versionEntry, releaseEntry) {
   assertFile(file, "release archive");
+  const python = resolvePython();
   const script = [
     "import json, sys, zipfile",
     "archive, version_entry, release_entry = sys.argv[1:4]",
@@ -16,9 +19,11 @@ export function inspectZip(file, versionEntry, releaseEntry) {
     "        result['release'] = zf.read(release_entry).decode('utf-8')",
     "    print(json.dumps(result))",
   ].join("\n");
-  const result = spawnSync("python", ["-c", script, file, versionEntry, releaseEntry ?? ""], {
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    python.command,
+    [...python.prefixArgs, "-c", script, file, versionEntry, releaseEntry ?? ""],
+    { encoding: "utf8", windowsHide: true },
+  );
   if (result.status !== 0) {
     throw new Error(`failed to inspect ${file}: ${result.stderr.trim()}`);
   }
@@ -96,6 +101,21 @@ export function requiredString(value, label) {
   return value;
 }
 
+export function requiredSafeFileName(value, label) {
+  const name = requiredString(value, label);
+  if (
+    name === "." ||
+    name === ".." ||
+    path.isAbsolute(name) ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    path.basename(name) !== name
+  ) {
+    throw new Error(`${label} must be a plain file name`);
+  }
+  return name;
+}
+
 export function requiredSha256(value, label) {
   if (typeof value !== "string" || !/^[0-9a-f]{64}$/i.test(value)) {
     throw new Error(`${label} must be a SHA-256 value`);
@@ -114,4 +134,33 @@ function exists(file) {
   } catch {
     return false;
   }
+}
+
+function resolvePython() {
+  if (cachedPython) {
+    return cachedPython;
+  }
+  const candidates =
+    process.platform === "win32"
+      ? [
+          { command: "py", prefixArgs: ["-3"] },
+          { command: "python3", prefixArgs: [] },
+          { command: "python", prefixArgs: [] },
+        ]
+      : [
+          { command: "python3", prefixArgs: [] },
+          { command: "python", prefixArgs: [] },
+        ];
+  for (const candidate of candidates) {
+    const result = spawnSync(
+      candidate.command,
+      [...candidate.prefixArgs, "--version"],
+      { encoding: "utf8", windowsHide: true },
+    );
+    if (!result.error && result.status === 0) {
+      cachedPython = candidate;
+      return cachedPython;
+    }
+  }
+  throw new Error("Python 3 is required to inspect release archives");
 }

--- a/scripts/staging-validation-files.mjs
+++ b/scripts/staging-validation-files.mjs
@@ -5,6 +5,42 @@ import { spawnSync } from "node:child_process";
 
 let cachedPython;
 
+export function parseArgs(rawArgs, allowedOptions) {
+  const allowed = new Set(allowedOptions);
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    const name = option.slice(2);
+    if (!allowed.has(name)) {
+      throw new Error(`Unknown option ${option}`);
+    }
+    if (parsed[name] !== undefined) {
+      throw new Error(`Duplicate option ${option}`);
+    }
+    parsed[name] = value;
+  }
+  return parsed;
+}
+
+export function requireDescendantPath(root, candidate, label) {
+  const resolvedRoot = path.resolve(requiredString(root, "RUNNER_TEMP"));
+  const resolvedCandidate = path.resolve(requiredString(candidate, label));
+  const relative = path.relative(resolvedRoot, resolvedCandidate);
+  if (
+    !relative ||
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(`${label} must be inside RUNNER_TEMP without naming RUNNER_TEMP itself`);
+  }
+  return resolvedCandidate;
+}
+
 export function inspectZip(file, versionEntry, releaseEntry) {
   assertFile(file, "release archive");
   const python = resolvePython();

--- a/scripts/staging-validation-files.mjs
+++ b/scripts/staging-validation-files.mjs
@@ -26,6 +26,14 @@ export function parseArgs(rawArgs, allowedOptions) {
   return parsed;
 }
 
+export function requiredArg(args, name) {
+  const value = args[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing --${name}`);
+  }
+  return value;
+}
+
 export function requireDescendantPath(root, candidate, label) {
   const resolvedRoot = path.resolve(requiredString(root, "RUNNER_TEMP"));
   const resolvedCandidate = path.resolve(requiredString(candidate, label));
@@ -48,9 +56,10 @@ export function inspectZip(file, versionEntry, releaseEntry) {
     "import json, sys, zipfile",
     "archive, version_entry, release_entry = sys.argv[1:4]",
     "with zipfile.ZipFile(archive, 'r') as zf:",
-    "    names = sorted(name.rstrip('/') for name in zf.namelist() if not name.endswith('/'))",
-    "    modes = {info.filename.rstrip('/'): (info.external_attr >> 16) & 0o777 for info in zf.infolist() if not info.is_dir()}",
-    "    result = {'names': names, 'modes': modes, 'version': zf.read(version_entry).decode('utf-8').strip()}",
+    "    members = [{'name': info.filename, 'mode': (info.external_attr >> 16) & 0xffff, 'create_system': info.create_system, 'is_dir': info.is_dir()} for info in zf.infolist()]",
+    "    names = sorted(member['name'] for member in members if not member['is_dir'])",
+    "    modes = {member['name']: member['mode'] & 0o777 for member in members if not member['is_dir']}",
+    "    result = {'members': members, 'names': names, 'modes': modes, 'version': zf.read(version_entry).decode('utf-8').strip()}",
     "    if release_entry:",
     "        result['release'] = zf.read(release_entry).decode('utf-8')",
     "    print(json.dumps(result))",
@@ -64,6 +73,38 @@ export function inspectZip(file, versionEntry, releaseEntry) {
     throw new Error(`failed to inspect ${file}: ${result.stderr.trim()}`);
   }
   return JSON.parse(result.stdout);
+}
+
+export function assertSafeZipMembers(members) {
+  if (!Array.isArray(members)) {
+    throw new Error("release archive member metadata is missing");
+  }
+  const names = [];
+  const seen = new Set();
+  for (const member of members) {
+    const name = member?.name;
+    if (typeof name !== "string" || name.length === 0) {
+      throw new Error("release archive contains a member without a valid name");
+    }
+    if (
+      name.includes("\\") ||
+      name.startsWith("/") ||
+      /^[A-Za-z]:/.test(name) ||
+      name.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+    ) {
+      throw new Error(`release archive contains unsafe member path ${JSON.stringify(name)}`);
+    }
+    if (seen.has(name)) {
+      throw new Error(`release archive contains duplicate member ${JSON.stringify(name)}`);
+    }
+    seen.add(name);
+    const fileType = Number(member.mode) & 0o170000;
+    if (member.is_dir || member.create_system !== 3 || fileType !== 0o100000) {
+      throw new Error(`release archive member ${JSON.stringify(name)} is not a regular Unix file`);
+    }
+    names.push(name);
+  }
+  return names.sort();
 }
 
 export function treeHashes(root, excludedTopLevel) {

--- a/scripts/tests/native-release-validation.test.mjs
+++ b/scripts/tests/native-release-validation.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const discovery = read("../../fennara-cpp/src/release/discovery.cpp");
+const identity = read("../../fennara-cpp/src/release/identity.cpp");
+const version = read("../../fennara-cpp/src/release/version.cpp");
+
+test("native release discovery uses a bare TLS host and requires a complete body", () => {
+  assert.match(discovery, /connect_to_host\("api\.github\.com", 443,/);
+  assert.doesNotMatch(discovery, /connect_to_host\("https:\/\//);
+  assert.match(discovery, /bool response_complete = false;/);
+  assert.match(discovery, /if \(!response_complete\)/);
+  assert.match(discovery, /Timed out reading the GitHub response/);
+});
+
+test("native manifest versions are strict after explicit boundary normalization", () => {
+  const parser = /std::optional<Version> parse\(godot::String input\) \{([\s\S]*?)\n\}/.exec(version);
+  assert.ok(parser, "missing native release version parser");
+  assert.doesNotMatch(parser[1], /normalize\(/);
+  assert.match(discovery, /release_version::normalize\(godot::String\(release\.get\("tag_name"/);
+});
+
+test("native identity schema rejects string and boolean coercion", () => {
+  assert.match(identity, /schema_type != godot::Variant::INT/);
+  assert.match(identity, /schema_type != godot::Variant::FLOAT/);
+  assert.match(identity, /\(double\)schema_version != 1\.0/);
+});
+
+function read(relativePath) {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}

--- a/scripts/tests/native-update-safety.test.mjs
+++ b/scripts/tests/native-update-safety.test.mjs
@@ -6,12 +6,17 @@ const discoveryHeader = read("../../fennara-cpp/include/fennara/release/discover
 const pluginSource = read("../../fennara-cpp/src/ui/fennara_plugin.cpp");
 const updateNoticeSource = read("../../fennara-cpp/src/update_notice.cpp");
 
-test("native update discovery cancellation returns the global check to idle", () => {
+test("native update discovery cancellation returns the shared check to idle", () => {
   assert.match(discoveryHeader, /bool cancelled = false;/);
   assert.match(
     updateNoticeSource,
-    /if \(result\.cancelled\) \{\s*g_check_started = false;\s*g_checked = false;\s*return;/,
+    /if \(result\.cancelled\) \{\s*current\.check_started = false;\s*current\.checked = false;\s*return;/,
   );
+});
+
+test("native update state is initialized lazily after the extension loads", () => {
+  assert.match(updateNoticeSource, /State &state\(\) \{\s*static State instance;/);
+  assert.doesNotMatch(updateNoticeSource, /release_discovery::Result g_[a-z_]+;/);
 });
 
 test("plugin teardown signals cancellation before joining discovery", () => {

--- a/scripts/tests/native-update-safety.test.mjs
+++ b/scripts/tests/native-update-safety.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const discoveryHeader = read("../../fennara-cpp/include/fennara/release/discovery.hpp");
+const pluginSource = read("../../fennara-cpp/src/ui/fennara_plugin.cpp");
+const updateNoticeSource = read("../../fennara-cpp/src/update_notice.cpp");
+
+test("native update discovery cancellation returns the global check to idle", () => {
+  assert.match(discoveryHeader, /bool cancelled = false;/);
+  assert.match(
+    updateNoticeSource,
+    /if \(result\.cancelled\) \{\s*g_check_started = false;\s*g_checked = false;\s*return;/,
+  );
+});
+
+test("plugin teardown signals cancellation before joining discovery", () => {
+  const stop = /void FennaraPlugin::_stop_update_check\(\) \{([\s\S]*?)\n\}/.exec(pluginSource);
+  assert.ok(stop, "missing update-check teardown helper");
+  const cancel = stop[1].indexOf("update_check_cancelled.store(true");
+  const join = stop[1].indexOf("update_check_thread.join()");
+  assert.ok(cancel >= 0 && cancel < join, "teardown must cancel before joining the worker");
+});
+
+function read(relativePath) {
+  return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+}

--- a/scripts/tests/release-identity.test.mjs
+++ b/scripts/tests/release-identity.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  channelPointerAssetName,
+  channelReleaseTag,
+  createChannelPointer,
+  createReleaseIdentity,
+  parseReleaseVersion,
+  validateReleaseIdentity,
+} from "../release-identity.mjs";
+
+const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+test("accepts stable and pull-request staging identities", () => {
+  assert.deepEqual(createReleaseIdentity({ version: "0.3.9" }), {
+    schema_version: 1,
+    track: "stable",
+    version: "0.3.9",
+    release_tag: "v0.3.9",
+  });
+  assert.deepEqual(
+    createReleaseIdentity({
+      version: "0.3.9-pr.101.2",
+      track: "staging",
+      channel: "pr-101",
+      sourceCommit: SOURCE_COMMIT,
+    }),
+    {
+      schema_version: 1,
+      track: "staging",
+      version: "0.3.9-pr.101.2",
+      release_tag: "v0.3.9-pr.101.2",
+      channel: "pr-101",
+      source_commit: SOURCE_COMMIT,
+    },
+  );
+});
+
+test("rejects ambiguous or mismatched staging identity", () => {
+  assert.throws(
+    () => createReleaseIdentity({
+      version: "0.3.9-pr.125.1",
+      track: "staging",
+      channel: "pr-101",
+      sourceCommit: SOURCE_COMMIT,
+    }),
+    /must end with -pr\.101/,
+  );
+  assert.throws(
+    () => createReleaseIdentity({ version: "0.3.9-rc.1" }),
+    /stable release versions/,
+  );
+});
+
+test("validates identity tag and VERSION agreement", () => {
+  const identity = createReleaseIdentity({ version: "0.3.9" });
+  assert.deepEqual(validateReleaseIdentity(identity, "0.3.9"), identity);
+  assert.throws(
+    () => validateReleaseIdentity({ ...identity, release_tag: "v0.4.0" }),
+    /tag must be v0\.3\.9/,
+  );
+  assert.throws(() => validateReleaseIdentity(identity, "0.4.0"), /does not match VERSION/);
+});
+
+test("creates an isolated pointer name and record per pull request", () => {
+  const identity = createReleaseIdentity({
+    version: "0.3.9-pr.101.2",
+    track: "staging",
+    channel: "pr-101",
+    sourceCommit: SOURCE_COMMIT,
+  });
+  assert.equal(channelReleaseTag("pr-101"), "staging-pr-101");
+  assert.equal(channelPointerAssetName("pr-101"), "fennara-staging-channel-pr-101.json");
+  assert.deepEqual(createChannelPointer(identity, "a".repeat(64)), {
+    schema_version: 1,
+    channel: "pr-101",
+    version: "0.3.9-pr.101.2",
+    release_tag: "v0.3.9-pr.101.2",
+    source_commit: SOURCE_COMMIT,
+    release_manifest_sha256: "a".repeat(64),
+  });
+});
+
+test("accepts SemVer prereleases and rejects invalid numeric identifiers", () => {
+  assert.equal(parseReleaseVersion("0.3.9-pr.101.2").prerelease, "pr.101.2");
+  assert.throws(() => parseReleaseVersion("0.3.9-pr.0101.2"), /valid SemVer/);
+  assert.throws(() => parseReleaseVersion("0.3"), /valid SemVer/);
+});

--- a/scripts/tests/release-identity.test.mjs
+++ b/scripts/tests/release-identity.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -49,9 +50,27 @@ test("rejects ambiguous or mismatched staging identity", () => {
     /must end with -pr\.101/,
   );
   assert.throws(
+    () => createReleaseIdentity({
+      version: "0.3.9-preview-pr.101.2",
+      track: "staging",
+      channel: "pr-101",
+      sourceCommit: SOURCE_COMMIT,
+    }),
+    /must end with -pr\.101/,
+  );
+  assert.throws(
     () => createReleaseIdentity({ version: "0.3.9-rc.1" }),
     /stable release versions/,
   );
+});
+
+test("native identity validation anchors the PR marker to the prerelease start", () => {
+  const source = readFileSync(
+    new URL("../../fennara-cpp/src/release/identity.cpp", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /prerelease\.begins_with\(prefix\)/);
+  assert.doesNotMatch(source, /identity\.version\.find\(prefix\)/);
 });
 
 test("validates identity tag and VERSION agreement", () => {

--- a/scripts/tests/release-identity.test.mjs
+++ b/scripts/tests/release-identity.test.mjs
@@ -3,10 +3,11 @@ import test from "node:test";
 
 import {
   channelPointerAssetName,
-  channelReleaseTag,
+  channelPointerRef,
   createChannelPointer,
   createReleaseIdentity,
   parseReleaseVersion,
+  validateChannelPointer,
   validateReleaseIdentity,
 } from "../release-identity.mjs";
 
@@ -70,9 +71,10 @@ test("creates an isolated pointer name and record per pull request", () => {
     channel: "pr-101",
     sourceCommit: SOURCE_COMMIT,
   });
-  assert.equal(channelReleaseTag("pr-101"), "staging-pr-101");
+  assert.equal(channelPointerRef("pr-101"), "fennara-staging/pr-101");
   assert.equal(channelPointerAssetName("pr-101"), "fennara-staging-channel-pr-101.json");
-  assert.deepEqual(createChannelPointer(identity, "a".repeat(64)), {
+  const pointer = createChannelPointer(identity, "a".repeat(64));
+  assert.deepEqual(pointer, {
     schema_version: 1,
     channel: "pr-101",
     version: "0.3.9-pr.101.2",
@@ -80,6 +82,7 @@ test("creates an isolated pointer name and record per pull request", () => {
     source_commit: SOURCE_COMMIT,
     release_manifest_sha256: "a".repeat(64),
   });
+  assert.deepEqual(validateChannelPointer(pointer, "pr-101"), pointer);
 });
 
 test("accepts SemVer prereleases and rejects invalid numeric identifiers", () => {

--- a/scripts/tests/stable-release-workflow.test.mjs
+++ b/scripts/tests/stable-release-workflow.test.mjs
@@ -8,10 +8,11 @@ const workflow = readFileSync(
 );
 
 test("stable publication reconciles matching drafts before immutable promotion", () => {
-  assert.match(workflow, /reconcile_draft=false/);
-  assert.match(workflow, /Resuming matching draft release/);
+  const publishStep = namedStep(jobBlock(workflow, "publish"), "Publish release");
+  assert.match(publishStep, /reconcile_draft=false/);
+  assert.match(publishStep, /Resuming matching draft release/);
   assert.match(
-    workflow,
+    publishStep,
     /verify-published-assets\.mjs[\s\S]*?--actual-dir "\$\{exact_assets_dir\}"[\s\S]*?--draft=false/,
   );
 });
@@ -25,3 +26,16 @@ test("latest promotion verifies exact bytes and moves the tag last", () => {
     latestUpload > 0 && latestUpload < latestVerify && latestVerify < latestEdit && latestEdit < tagPush,
   );
 });
+
+function jobBlock(source, jobName) {
+  const match = new RegExp(`^  ${jobName}:\\r?\\n([\\s\\S]*?)(?=^  [a-zA-Z0-9_-]+:|(?![\\s\\S]))`, "m").exec(source);
+  assert.ok(match, `missing ${jobName} job`);
+  return match[0];
+}
+
+function namedStep(job, stepName) {
+  const escaped = stepName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`^      - name: ${escaped}\\r?\\n([\\s\\S]*?)(?=^      - name:|(?![\\s\\S]))`, "m").exec(job);
+  assert.ok(match, `missing ${stepName} step`);
+  return match[0];
+}

--- a/scripts/tests/stable-release-workflow.test.mjs
+++ b/scripts/tests/stable-release-workflow.test.mjs
@@ -18,13 +18,20 @@ test("stable publication reconciles matching drafts before immutable promotion",
 });
 
 test("latest promotion verifies exact bytes and moves the tag last", () => {
-  const latestUpload = workflow.indexOf('gh release upload latest "${promotion_assets[@]}"');
-  const latestVerify = workflow.indexOf('--actual-dir "${latest_assets_dir}"');
-  const latestEdit = workflow.indexOf("gh release edit latest");
-  const tagPush = workflow.indexOf("git push --force origin refs/tags/latest");
+  const publishStep = namedStep(jobBlock(workflow, "publish"), "Publish release");
+  const latestUpload = publishStep.indexOf('gh release upload latest "${promotion_assets[@]}"');
+  const latestVerify = publishStep.indexOf('--actual-dir "${latest_assets_dir}"');
+  const latestEdit = publishStep.indexOf("gh release edit latest");
+  const tagPush = publishStep.indexOf("git push --force origin refs/tags/latest");
   assert.ok(
     latestUpload > 0 && latestUpload < latestVerify && latestVerify < latestEdit && latestEdit < tagPush,
   );
+});
+
+test("immutable-release preflight uses an administration token", () => {
+  const preflight = namedStep(jobBlock(workflow, "publish"), "Require immutable GitHub releases");
+  assert.match(preflight, /GH_TOKEN: \$\{\{ secrets\.RELEASE_ADMIN_TOKEN \}\}/);
+  assert.match(preflight, /RELEASE_ADMIN_TOKEN must provide repository Administration read access/);
 });
 
 function jobBlock(source, jobName) {

--- a/scripts/tests/stable-release-workflow.test.mjs
+++ b/scripts/tests/stable-release-workflow.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(
+  new URL("../../.github/workflows/release.yml", import.meta.url),
+  "utf8",
+);
+
+test("stable publication reconciles matching drafts before immutable promotion", () => {
+  assert.match(workflow, /reconcile_draft=false/);
+  assert.match(workflow, /Resuming matching draft release/);
+  assert.match(
+    workflow,
+    /verify-published-assets\.mjs[\s\S]*?--actual-dir "\$\{exact_assets_dir\}"[\s\S]*?--draft=false/,
+  );
+});
+
+test("latest promotion verifies exact bytes and moves the tag last", () => {
+  const latestUpload = workflow.indexOf('gh release upload latest "${promotion_assets[@]}"');
+  const latestVerify = workflow.indexOf('--actual-dir "${latest_assets_dir}"');
+  const latestEdit = workflow.indexOf("gh release edit latest");
+  const tagPush = workflow.indexOf("git push --force origin refs/tags/latest");
+  assert.ok(
+    latestUpload > 0 && latestUpload < latestVerify && latestVerify < latestEdit && latestEdit < tagPush,
+  );
+});

--- a/scripts/tests/staging-candidate.test.mjs
+++ b/scripts/tests/staging-candidate.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createStagingCandidate,
+  decideChannelAdvance,
+  validateStagingCandidate,
+} from "../staging-candidate.mjs";
+import { createChannelPointer } from "../release-identity.mjs";
+
+const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
+
+test("creates an exact pull-request staging candidate", () => {
+  const candidate = createStagingCandidate({
+    baseVersion: "0.3.9",
+    pullRequest: "101",
+    candidateNumber: "2",
+    sourceCommit: SOURCE_COMMIT,
+    sourceRepository: "fennaraOfficial/fennara-godot-ai",
+  });
+
+  assert.deepEqual(candidate, {
+    schema_version: 1,
+    track: "staging",
+    version: "0.3.9-pr.101.2",
+    release_tag: "v0.3.9-pr.101.2",
+    channel: "pr-101",
+    source_commit: SOURCE_COMMIT,
+    base_version: "0.3.9",
+    pull_request: 101,
+    candidate_number: 2,
+    source_repository: "fennaraOfficial/fennara-godot-ai",
+  });
+  assert.deepEqual(validateStagingCandidate(candidate), candidate);
+});
+
+test("rejects invalid base versions and channel numbers", () => {
+  const common = {
+    pullRequest: "101",
+    candidateNumber: "1",
+    sourceCommit: SOURCE_COMMIT,
+    sourceRepository: "fennaraOfficial/fennara-godot-ai",
+  };
+  assert.throws(
+    () => createStagingCandidate({ ...common, baseVersion: "0.3.9-rc.1" }),
+    /base version must be a stable SemVer/,
+  );
+  assert.throws(
+    () => createStagingCandidate({ ...common, baseVersion: "0.3.9", pullRequest: "01" }),
+    /pull request must be a positive integer/,
+  );
+  assert.throws(
+    () => createStagingCandidate({ ...common, baseVersion: "0.3.9", candidateNumber: "0" }),
+    /candidate number must be a positive integer/,
+  );
+});
+
+test("rejects malformed source repository provenance", () => {
+  const candidate = createStagingCandidate({
+    baseVersion: "0.3.9",
+    pullRequest: "101",
+    candidateNumber: "1",
+    sourceCommit: SOURCE_COMMIT,
+    sourceRepository: "fennaraOfficial/fennara-godot-ai",
+  });
+  assert.throws(
+    () => validateStagingCandidate({ ...candidate, source_repository: "../repository" }),
+    /source repository must use owner\/name format/,
+  );
+});
+
+test("advances a channel monotonically and makes exact retries idempotent", () => {
+  const first = createStagingCandidate({
+    baseVersion: "0.3.9",
+    pullRequest: "101",
+    candidateNumber: "1",
+    sourceCommit: SOURCE_COMMIT,
+    sourceRepository: "fennaraOfficial/fennara-godot-ai",
+  });
+  const second = createStagingCandidate({
+    ...first,
+    baseVersion: "0.3.9",
+    pullRequest: "101",
+    candidateNumber: "2",
+    sourceCommit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    sourceRepository: "fennaraOfficial/fennara-godot-ai",
+  });
+  const firstPointer = createChannelPointer(first, "1".repeat(64));
+  const secondPointer = createChannelPointer(second, "2".repeat(64));
+
+  assert.equal(decideChannelAdvance(undefined, firstPointer), "create");
+  assert.equal(decideChannelAdvance(firstPointer, firstPointer), "noop");
+  assert.equal(decideChannelAdvance(firstPointer, secondPointer), "advance");
+  assert.throws(
+    () => decideChannelAdvance(secondPointer, firstPointer),
+    /refusing to move pr-101 backward/,
+  );
+});

--- a/scripts/tests/staging-candidate.test.mjs
+++ b/scripts/tests/staging-candidate.test.mjs
@@ -96,3 +96,19 @@ test("advances a channel monotonically and makes exact retries idempotent", () =
     /refusing to move pr-101 backward/,
   );
 });
+
+test("rejects same-sequence channel pointers with different provenance", () => {
+  const candidate = createStagingCandidate({
+    baseVersion: "0.3.9",
+    pullRequest: "101",
+    candidateNumber: "1",
+    sourceCommit: SOURCE_COMMIT,
+    sourceRepository: "fennaraOfficial/fennara-godot-ai",
+  });
+  const current = createChannelPointer(candidate, "1".repeat(64));
+  const conflicting = createChannelPointer(candidate, "2".repeat(64));
+  assert.throws(
+    () => decideChannelAdvance(current, conflicting),
+    /already exists with different provenance/,
+  );
+});

--- a/scripts/tests/staging-validation-files.test.mjs
+++ b/scripts/tests/staging-validation-files.test.mjs
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { createStagingCandidate } from "../staging-candidate.mjs";
 import {
+  assertSafeZipMembers,
   parseArgs,
   requireDescendantPath,
+  requiredArg,
   requiredSafeFileName,
 } from "../staging-validation-files.mjs";
+
+const SOURCE_COMMIT = "0123456789abcdef0123456789abcdef01234567";
 
 test("release validation accepts only plain asset file names", () => {
   assert.equal(requiredSafeFileName("fennara-release.zip", "asset"), "fennara-release.zip");
@@ -42,6 +49,92 @@ test("shared staging argument parsing rejects unknown and duplicate options", ()
     () => parseArgs(["--bundle", "one", "--bundle", "two"], ["bundle"]),
     /Duplicate option/,
   );
+  assert.equal(requiredArg({ bundle: "candidate" }, "bundle"), "candidate");
+  assert.throws(() => requiredArg({}, "bundle"), /Missing --bundle/);
+});
+
+test("addon archive validation rejects unsafe and non-regular members", () => {
+  const regular = 0o100644;
+  assert.deepEqual(
+    assertSafeZipMembers([
+      { name: "addons/fennara/VERSION", mode: regular, create_system: 3, is_dir: false },
+      { name: "addons/fennara/bin/tool", mode: 0o100755, create_system: 3, is_dir: false },
+    ]),
+    ["addons/fennara/VERSION", "addons/fennara/bin/tool"],
+  );
+
+  for (const name of [
+    "/absolute",
+    "C:/absolute",
+    "../outside",
+    "addons/../outside",
+    "addons\\outside",
+    "addons//outside",
+  ]) {
+    assert.throws(
+      () => assertSafeZipMembers([{ name, mode: regular, create_system: 3, is_dir: false }]),
+      /unsafe member path/,
+    );
+  }
+  assert.throws(
+    () => assertSafeZipMembers([
+      { name: "duplicate", mode: regular, create_system: 3, is_dir: false },
+      { name: "duplicate", mode: regular, create_system: 3, is_dir: false },
+    ]),
+    /duplicate member/,
+  );
+  for (const member of [
+    { name: "directory", mode: 0o040755, create_system: 3, is_dir: true },
+    { name: "symlink", mode: 0o120777, create_system: 3, is_dir: false },
+    { name: "unknown", mode: 0, create_system: 0, is_dir: false },
+  ]) {
+    assert.throws(() => assertSafeZipMembers([member]), /not a regular Unix file/);
+  }
+});
+
+test("staging pointer writer rejects same-version manifest provenance mismatches", () => {
+  const tempParent = fileURLToPath(new URL("../../temp/", import.meta.url));
+  mkdirSync(tempParent, { recursive: true });
+  const directory = mkdtempSync(path.join(tempParent, "staging-pointer-provenance-"));
+  try {
+    const candidate = createStagingCandidate({
+      baseVersion: "0.3.9",
+      pullRequest: "101",
+      candidateNumber: "2",
+      sourceCommit: SOURCE_COMMIT,
+      sourceRepository: "fennaraOfficial/fennara-godot-ai",
+    });
+    const candidatePath = path.join(directory, "candidate.json");
+    const manifestPath = path.join(directory, "manifest.json");
+    const pointerPath = path.join(directory, "pointer.json");
+    writeFileSync(candidatePath, JSON.stringify(candidate));
+    writeFileSync(
+      manifestPath,
+      JSON.stringify({
+        version: candidate.version,
+        release: { ...candidate, source_commit: "f".repeat(40) },
+      }),
+    );
+
+    const script = fileURLToPath(new URL("../write-staging-pointer.mjs", import.meta.url));
+    const result = spawnSync(
+      process.execPath,
+      [
+        script,
+        "--candidate",
+        candidatePath,
+        "--manifest",
+        manifestPath,
+        "--out",
+        pointerPath,
+      ],
+      { encoding: "utf8" },
+    );
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /identity does not match staging candidate/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("recursive release smoke output must stay below RUNNER_TEMP", () => {

--- a/scripts/tests/staging-validation-files.test.mjs
+++ b/scripts/tests/staging-validation-files.test.mjs
@@ -3,7 +3,11 @@ import { spawnSync } from "node:child_process";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { requiredSafeFileName } from "../staging-validation-files.mjs";
+import {
+  parseArgs,
+  requireDescendantPath,
+  requiredSafeFileName,
+} from "../staging-validation-files.mjs";
 
 test("release validation accepts only plain asset file names", () => {
   assert.equal(requiredSafeFileName("fennara-release.zip", "asset"), "fennara-release.zip");
@@ -27,4 +31,28 @@ test("staging pointer writer rejects unknown and duplicate options", () => {
   );
   assert.notEqual(duplicate.status, 0);
   assert.match(duplicate.stderr, /Duplicate option --candidate/);
+});
+
+test("shared staging argument parsing rejects unknown and duplicate options", () => {
+  assert.deepEqual(parseArgs(["--bundle", "candidate"], ["bundle"]), {
+    bundle: "candidate",
+  });
+  assert.throws(() => parseArgs(["--unknown", "value"], ["bundle"]), /Unknown option/);
+  assert.throws(
+    () => parseArgs(["--bundle", "one", "--bundle", "two"], ["bundle"]),
+    /Duplicate option/,
+  );
+});
+
+test("recursive release smoke output must stay below RUNNER_TEMP", () => {
+  const root = fileURLToPath(new URL("../../temp/smoke-root/", import.meta.url));
+  assert.equal(
+    requireDescendantPath(root, `${root}/candidate`, "--download-dir"),
+    fileURLToPath(new URL("../../temp/smoke-root/candidate", import.meta.url)),
+  );
+  assert.throws(() => requireDescendantPath(root, root, "--download-dir"), /inside RUNNER_TEMP/);
+  assert.throws(
+    () => requireDescendantPath(root, `${root}/../outside`, "--download-dir"),
+    /inside RUNNER_TEMP/,
+  );
 });

--- a/scripts/tests/staging-validation-files.test.mjs
+++ b/scripts/tests/staging-validation-files.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { requiredSafeFileName } from "../staging-validation-files.mjs";
+
+test("release validation accepts only plain asset file names", () => {
+  assert.equal(requiredSafeFileName("fennara-release.zip", "asset"), "fennara-release.zip");
+  for (const name of ["../secret", "..\\secret", "/tmp/secret", "C:\\temp\\secret", ".", ".."]) {
+    assert.throws(() => requiredSafeFileName(name, "asset"), /plain file name/);
+  }
+});
+
+test("staging pointer writer rejects unknown and duplicate options", () => {
+  const script = fileURLToPath(new URL("../write-staging-pointer.mjs", import.meta.url));
+  const unknown = spawnSync(process.execPath, [script, "--unknown", "value"], {
+    encoding: "utf8",
+  });
+  assert.notEqual(unknown.status, 0);
+  assert.match(unknown.stderr, /Unknown option --unknown/);
+
+  const duplicate = spawnSync(
+    process.execPath,
+    [script, "--candidate", "one", "--candidate", "two"],
+    { encoding: "utf8" },
+  );
+  assert.notEqual(duplicate.status, 0);
+  assert.match(duplicate.stderr, /Duplicate option --candidate/);
+});

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const workflow = readFileSync(new URL("../../.github/workflows/staging-release.yml", import.meta.url), "utf8");
+
+test("dry runs cannot enter the publication job", () => {
+  assert.match(workflow, /^  publish:\r?\n[\s\S]*?^    if: inputs\.publish$/m);
+  assert.match(workflow, /publish:\r?\n[\s\S]*?default: false[\s\S]*?type: boolean/);
+  assert.doesNotMatch(workflow, /pull_request_target|workflow_run/);
+});
+
+test("candidate builds are pinned and isolated per pull request", () => {
+  assert.match(workflow, /group: staging-release-pr-\$\{\{ inputs\.pull_request \}\}/);
+  assert.match(workflow, /cancel-in-progress: true/);
+  assert.ok(
+    (workflow.match(/ref: \$\{\{ needs\.resolve\.outputs\.source_commit \}\}/g) ?? []).length >= 2,
+    "candidate source checkouts must use the frozen pull-request head",
+  );
+  assert.match(workflow, /test "\$\(git rev-parse HEAD\)" = "\$\{EXPECTED_SOURCE_COMMIT\}"/);
+});
+
+test("write credentials are confined to trusted publication", () => {
+  const publishIndex = workflow.indexOf("\n  publish:");
+  assert.ok(publishIndex > 0);
+  assert.doesNotMatch(workflow.slice(0, publishIndex), /contents: write/);
+  assert.match(workflow.slice(publishIndex), /contents: write/);
+  assert.match(workflow.slice(publishIndex), /ref: \$\{\{ github\.sha \}\}/);
+});
+
+test("public smoke validation precedes monotonic pointer advancement", () => {
+  const publicSmoke = workflow.indexOf("name: Smoke test public release downloads");
+  const monotonicCheck = workflow.indexOf("name: Check monotonic channel advancement");
+  const pointerAdvance = workflow.indexOf("name: Advance the per-PR staging pointer last");
+  assert.ok(publicSmoke > 0 && publicSmoke < monotonicCheck && monotonicCheck < pointerAdvance);
+  assert.doesNotMatch(workflow, /gh release (create|edit|upload) latest/);
+});

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -46,9 +46,11 @@ test("write credentials are confined to trusted publication", () => {
 });
 
 test("public smoke validation precedes monotonic pointer advancement", () => {
-  const publicSmoke = workflow.indexOf("name: Smoke test public release downloads");
-  const monotonicCheck = workflow.indexOf("name: Check monotonic channel advancement");
-  const pointerAdvance = workflow.indexOf("name: Advance the per-PR staging pointer last");
+  const publish = jobBlocks(workflow).get("publish");
+  assert.ok(publish, "workflow must contain the publish job");
+  const publicSmoke = publish.indexOf("name: Smoke test public release downloads");
+  const monotonicCheck = publish.indexOf("name: Check monotonic channel advancement");
+  const pointerAdvance = publish.indexOf("name: Advance the per-PR staging pointer last");
   assert.ok(publicSmoke > 0 && publicSmoke < monotonicCheck && monotonicCheck < pointerAdvance);
   assert.doesNotMatch(workflow, /gh release (create|edit|upload) latest/);
 });
@@ -60,8 +62,10 @@ test("shell commands do not interpolate resolve outputs directly", () => {
 });
 
 test("immutable-release preflight uses an administration token", () => {
+  const publish = jobBlocks(workflow).get("publish");
+  assert.ok(publish, "workflow must contain the publish job");
   assert.match(
-    workflow,
+    publish,
     /name: Require immutable GitHub releases[\s\S]*?GH_TOKEN: \$\{\{ secrets\.RELEASE_ADMIN_TOKEN \}\}/,
   );
 });

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -6,26 +6,43 @@ const workflow = readFileSync(new URL("../../.github/workflows/staging-release.y
 
 test("dry runs cannot enter the publication job", () => {
   assert.match(workflow, /^  publish:\r?\n[\s\S]*?^    if: inputs\.publish$/m);
-  assert.match(workflow, /publish:\r?\n[\s\S]*?default: false[\s\S]*?type: boolean/);
+  assert.match(
+    workflow,
+    /^      publish:\r?\n        description: [^\r\n]+\r?\n        required: true\r?\n        default: false\r?\n        type: boolean$/m,
+  );
   assert.doesNotMatch(workflow, /pull_request_target|workflow_run/);
 });
 
 test("candidate builds are pinned and isolated per pull request", () => {
   assert.match(workflow, /group: staging-release-pr-\$\{\{ inputs\.pull_request \}\}/);
   assert.match(workflow, /cancel-in-progress: true/);
-  assert.ok(
-    (workflow.match(/ref: \$\{\{ needs\.resolve\.outputs\.source_commit \}\}/g) ?? []).length >= 2,
-    "candidate source checkouts must use the frozen pull-request head",
-  );
+  const checkouts = checkoutSteps(workflow);
+  assert.ok(checkouts.length >= 2, "workflow must contain trusted and candidate checkouts");
+  for (const checkout of checkouts) {
+    if (/name: Checkout trusted /.test(checkout)) {
+      assert.match(checkout, /ref: \$\{\{ github\.sha \}\}/);
+    } else {
+      assert.match(checkout, /ref: \$\{\{ needs\.resolve\.outputs\.source_commit \}\}/);
+    }
+  }
   assert.match(workflow, /test "\$\(git rev-parse HEAD\)" = "\$\{EXPECTED_SOURCE_COMMIT\}"/);
 });
 
 test("write credentials are confined to trusted publication", () => {
-  const publishIndex = workflow.indexOf("\n  publish:");
-  assert.ok(publishIndex > 0);
-  assert.doesNotMatch(workflow.slice(0, publishIndex), /contents: write/);
-  assert.match(workflow.slice(publishIndex), /contents: write/);
-  assert.match(workflow.slice(publishIndex), /ref: \$\{\{ github\.sha \}\}/);
+  assert.equal(
+    (workflow.match(/^\s+contents: write$/gm) ?? []).length,
+    1,
+    "only the publish job may request contents write access",
+  );
+  const jobs = jobBlocks(workflow);
+  for (const [name, block] of jobs) {
+    if (name === "publish") {
+      assert.match(block, /^    permissions:\r?\n(?:      [^\r\n]+\r?\n)*?      contents: write$/m);
+      assert.match(block, /ref: \$\{\{ github\.sha \}\}/);
+    } else {
+      assert.doesNotMatch(block, /contents: write/);
+    }
+  }
 });
 
 test("public smoke validation precedes monotonic pointer advancement", () => {
@@ -36,14 +53,47 @@ test("public smoke validation precedes monotonic pointer advancement", () => {
   assert.doesNotMatch(workflow, /gh release (create|edit|upload) latest/);
 });
 
-test("write-capable publication scripts do not interpolate resolve outputs directly", () => {
-  const publish = workflow.slice(workflow.indexOf("\n  publish:"));
-  assert.doesNotMatch(
-    publish,
-    /--download-dir[^\n]*\$\{\{ needs\.resolve\.outputs\./,
-  );
-  assert.doesNotMatch(
-    publish,
-    /--current[^\n]*\$\{\{ needs\.resolve\.outputs\./,
-  );
+test("shell commands do not interpolate resolve outputs directly", () => {
+  for (const block of runBlocks(workflow)) {
+    assert.doesNotMatch(block, /\$\{\{ needs\.resolve\.outputs\./);
+  }
 });
+
+function runBlocks(source) {
+  const lines = source.split(/\r?\n/);
+  const blocks = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = /^(\s*)run:\s*(.*)$/.exec(lines[index]);
+    if (!match) {
+      continue;
+    }
+    const indent = match[1].length;
+    const block = [match[2]];
+    while (index + 1 < lines.length) {
+      const next = lines[index + 1];
+      if (next.trim() && next.match(/^\s*/)[0].length <= indent) {
+        break;
+      }
+      block.push(next);
+      index += 1;
+    }
+    blocks.push(block.join("\n"));
+  }
+  return blocks;
+}
+
+function checkoutSteps(source) {
+  return source
+    .split(/(?=^      - name:)/m)
+    .filter((block) => /uses: actions\/checkout@/.test(block));
+}
+
+function jobBlocks(source) {
+  const jobsSource = source.split(/^jobs:\r?\n/m)[1];
+  assert.ok(jobsSource, "workflow must contain jobs");
+  const blocks = new Map();
+  for (const match of jobsSource.matchAll(/^  ([a-zA-Z0-9_-]+):\r?\n([\s\S]*?)(?=^  [a-zA-Z0-9_-]+:|(?![\s\S]))/gm)) {
+    blocks.set(match[1], match[0]);
+  }
+  return blocks;
+}

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -35,3 +35,15 @@ test("public smoke validation precedes monotonic pointer advancement", () => {
   assert.ok(publicSmoke > 0 && publicSmoke < monotonicCheck && monotonicCheck < pointerAdvance);
   assert.doesNotMatch(workflow, /gh release (create|edit|upload) latest/);
 });
+
+test("write-capable publication scripts do not interpolate resolve outputs directly", () => {
+  const publish = workflow.slice(workflow.indexOf("\n  publish:"));
+  assert.doesNotMatch(
+    publish,
+    /--download-dir[^\n]*\$\{\{ needs\.resolve\.outputs\./,
+  );
+  assert.doesNotMatch(
+    publish,
+    /--current[^\n]*\$\{\{ needs\.resolve\.outputs\./,
+  );
+});

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -15,7 +15,7 @@ test("dry runs cannot enter the publication job", () => {
 
 test("candidate builds are pinned and isolated per pull request", () => {
   assert.match(workflow, /group: staging-release-pr-\$\{\{ inputs\.pull_request \}\}/);
-  assert.match(workflow, /cancel-in-progress: true/);
+  assert.match(workflow, /cancel-in-progress: false/);
   const checkouts = checkoutSteps(workflow);
   assert.ok(checkouts.length >= 2, "workflow must contain trusted and candidate checkouts");
   for (const checkout of checkouts) {
@@ -59,6 +59,13 @@ test("shell commands do not interpolate resolve outputs directly", () => {
   }
 });
 
+test("immutable-release preflight uses an administration token", () => {
+  assert.match(
+    workflow,
+    /name: Require immutable GitHub releases[\s\S]*?GH_TOKEN: \$\{\{ secrets\.RELEASE_ADMIN_TOKEN \}\}/,
+  );
+});
+
 function runBlocks(source) {
   const lines = source.split(/\r?\n/);
   const blocks = [];
@@ -84,7 +91,7 @@ function runBlocks(source) {
 
 function checkoutSteps(source) {
   return source
-    .split(/(?=^      - name:)/m)
+    .split(/(?=^      - )/m)
     .filter((block) => /uses: actions\/checkout@/.test(block));
 }
 

--- a/scripts/validate-staging-build.mjs
+++ b/scripts/validate-staging-build.mjs
@@ -1,7 +1,14 @@
 import path from "node:path";
 import { validateStagingBuild } from "./staging-build-validation.mjs";
+import { parseArgs } from "./staging-validation-files.mjs";
 
-const args = parseArgs(process.argv.slice(2));
+const args = parseArgs(process.argv.slice(2), [
+  "candidate",
+  "assets-dir",
+  "addon-parts-dir",
+  "release-manifest",
+  "linux-cef-manifest",
+]);
 const candidate = validateStagingBuild({
   candidatePath: resolveArg("candidate"),
   assetsDir: resolveArg("assets-dir"),
@@ -10,19 +17,6 @@ const candidate = validateStagingBuild({
   linuxCefManifestPath: resolveArg("linux-cef-manifest"),
 });
 console.log(`Validated staging build ${candidate.version} from ${candidate.source_commit}`);
-
-function parseArgs(rawArgs) {
-  const parsed = {};
-  for (let index = 0; index < rawArgs.length; index += 2) {
-    const option = rawArgs[index];
-    const value = rawArgs[index + 1];
-    if (!option?.startsWith("--") || value === undefined) {
-      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
-    }
-    parsed[option.slice(2)] = value;
-  }
-  return parsed;
-}
 
 function resolveArg(name) {
   if (!args[name]) {

--- a/scripts/validate-staging-build.mjs
+++ b/scripts/validate-staging-build.mjs
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { validateStagingBuild } from "./staging-build-validation.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const candidate = validateStagingBuild({
+  candidatePath: resolveArg("candidate"),
+  assetsDir: resolveArg("assets-dir"),
+  addonPartsDir: resolveArg("addon-parts-dir"),
+  releaseManifestPath: resolveArg("release-manifest"),
+  linuxCefManifestPath: resolveArg("linux-cef-manifest"),
+});
+console.log(`Validated staging build ${candidate.version} from ${candidate.source_commit}`);
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    parsed[option.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function resolveArg(name) {
+  if (!args[name]) {
+    throw new Error(`Missing --${name}`);
+  }
+  return path.resolve(args[name]);
+}

--- a/scripts/validate-staging-publish-bundle.mjs
+++ b/scripts/validate-staging-publish-bundle.mjs
@@ -5,10 +5,10 @@ import {
   validatePlatformArchives,
   validateReleaseManifest,
 } from "./staging-release-validation.mjs";
-import { readJson } from "./staging-validation-files.mjs";
+import { parseArgs, readJson } from "./staging-validation-files.mjs";
 import { validateStagingCandidate } from "./staging-candidate.mjs";
 
-const args = parseArgs(process.argv.slice(2));
+const args = parseArgs(process.argv.slice(2), ["bundle"]);
 const root = path.resolve(requiredArg("bundle"));
 const assetsDir = path.join(root, "release-assets");
 const candidate = validateStagingCandidate(readJson(path.join(root, "metadata", "candidate.json")));
@@ -25,19 +25,6 @@ validateAddonArchive(
 );
 validateLinuxCefArchive(assetsDir, linuxCef);
 console.log(`Validated publish bundle ${candidate.version}`);
-
-function parseArgs(rawArgs) {
-  const parsed = {};
-  for (let index = 0; index < rawArgs.length; index += 2) {
-    const option = rawArgs[index];
-    const value = rawArgs[index + 1];
-    if (!option?.startsWith("--") || value === undefined) {
-      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
-    }
-    parsed[option.slice(2)] = value;
-  }
-  return parsed;
-}
 
 function requiredArg(name) {
   if (!args[name]) {

--- a/scripts/validate-staging-publish-bundle.mjs
+++ b/scripts/validate-staging-publish-bundle.mjs
@@ -1,0 +1,47 @@
+import path from "node:path";
+import { validateAddonArchive } from "./staging-addon-validation.mjs";
+import {
+  validateLinuxCefArchive,
+  validatePlatformArchives,
+  validateReleaseManifest,
+} from "./staging-release-validation.mjs";
+import { readJson } from "./staging-validation-files.mjs";
+import { validateStagingCandidate } from "./staging-candidate.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const root = path.resolve(requiredArg("bundle"));
+const assetsDir = path.join(root, "release-assets");
+const candidate = validateStagingCandidate(readJson(path.join(root, "metadata", "candidate.json")));
+const linuxCef = readJson(path.join(root, "metadata", "linux-cef.json"));
+const manifest = readJson(
+  path.join(assetsDir, `fennara-release-manifest-v${candidate.version}.json`),
+);
+
+validateReleaseManifest(candidate, manifest, assetsDir, linuxCef);
+validatePlatformArchives(candidate, assetsDir);
+validateAddonArchive(
+  candidate,
+  path.join(assetsDir, `fennara-release-addon-v${candidate.version}.zip`),
+);
+validateLinuxCefArchive(assetsDir, linuxCef);
+console.log(`Validated publish bundle ${candidate.version}`);
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    parsed[option.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  if (!args[name]) {
+    throw new Error(`Missing --${name}`);
+  }
+  return args[name];
+}

--- a/scripts/verify-published-assets.mjs
+++ b/scripts/verify-published-assets.mjs
@@ -1,0 +1,46 @@
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const args = parseArgs(process.argv.slice(2));
+const expected = fileHashes(path.resolve(requiredArg("expected-dir")));
+const actual = fileHashes(path.resolve(requiredArg("actual-dir")));
+
+if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+  throw new Error(
+    `published release assets differ from validated assets\nexpected: ${JSON.stringify(expected, null, 2)}\nactual: ${JSON.stringify(actual, null, 2)}`,
+  );
+}
+console.log(`Verified ${Object.keys(expected).length} published release assets`);
+
+function fileHashes(directory) {
+  const records = {};
+  for (const entry of readdirSync(directory).sort()) {
+    const file = path.join(directory, entry);
+    if (!statSync(file).isFile()) {
+      throw new Error(`Unexpected directory in release assets: ${file}`);
+    }
+    records[entry] = createHash("sha256").update(readFileSync(file)).digest("hex");
+  }
+  return records;
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    parsed[option.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  if (!args[name]) {
+    throw new Error(`Missing --${name}`);
+  }
+  return args[name];
+}

--- a/scripts/verify-published-assets.mjs
+++ b/scripts/verify-published-assets.mjs
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
+import { parseArgs, requiredArg } from "./staging-validation-files.mjs";
 
-const args = parseArgs(process.argv.slice(2));
-const expected = fileHashes(path.resolve(requiredArg("expected-dir")));
-const actual = fileHashes(path.resolve(requiredArg("actual-dir")));
+const args = parseArgs(process.argv.slice(2), ["expected-dir", "actual-dir"]);
+const expected = fileHashes(path.resolve(requiredArg(args, "expected-dir")));
+const actual = fileHashes(path.resolve(requiredArg(args, "actual-dir")));
 
 if (JSON.stringify(expected) !== JSON.stringify(actual)) {
   throw new Error(
@@ -23,24 +24,4 @@ function fileHashes(directory) {
     records[entry] = createHash("sha256").update(readFileSync(file)).digest("hex");
   }
   return records;
-}
-
-function parseArgs(rawArgs) {
-  const parsed = {};
-  for (let index = 0; index < rawArgs.length; index += 2) {
-    const option = rawArgs[index];
-    const value = rawArgs[index + 1];
-    if (!option?.startsWith("--") || value === undefined) {
-      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
-    }
-    parsed[option.slice(2)] = value;
-  }
-  return parsed;
-}
-
-function requiredArg(name) {
-  if (!args[name]) {
-    throw new Error(`Missing --${name}`);
-  }
-  return args[name];
 }

--- a/scripts/write-release-manifest.mjs
+++ b/scripts/write-release-manifest.mjs
@@ -8,6 +8,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parseReleaseVersion, validateReleaseIdentity } from "./release-identity.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_MINIMUM_CLI_VERSION = "0.3.3";
@@ -49,6 +50,7 @@ writeFileSync(outPath, `${JSON.stringify(manifest, null, 2)}\n`);
 console.log(`Created ${path.relative(root, outPath)}`);
 
 function buildManifest() {
+  const release = readReleaseIdentity();
   const assets = {
     cli: {},
     local: {},
@@ -75,11 +77,24 @@ function buildManifest() {
   return {
     schema_version: 1,
     version,
+    release,
     minimum_cli_version: minimumCliVersion,
     install_primitives: installPrimitives,
     assets,
     shared_runtimes: sharedRuntimes,
   };
+}
+
+function readReleaseIdentity() {
+  const identityPath = path.join(
+    root,
+    "godot_demo",
+    "addons",
+    "fennara",
+    "release.json",
+  );
+  const identity = JSON.parse(readFileSync(identityPath, "utf8"));
+  return validateReleaseIdentity(identity, version);
 }
 
 function sharedRuntimeRecords() {
@@ -186,8 +201,9 @@ function requiredArray(value, label) {
 }
 
 function validateVersion(value, label) {
-  if (!/^\d+\.\d+\.\d+$/.test(value)) {
-    throw new Error(`Invalid ${label}: ${value}`);
+  const parsed = parseReleaseVersion(value, label);
+  if (parsed.build) {
+    throw new Error(`${label} must not contain SemVer build metadata`);
   }
 }
 
@@ -217,11 +233,11 @@ Usage:
   node scripts/write-release-manifest.mjs --assets-dir release-assets --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json
 
 Options:
-  --version <x.y.z>                Release version. Default: VERSION.
+  --version <semver>               Release version. Default: VERSION.
   --assets-dir <dir>               Directory containing release zip assets. Default: release-assets.
                                    Release local/addon assets must use fennara-release-local-* and fennara-release-addon-* names.
   --linux-cef-manifest <path>      Generated enabled Linux CEF manifest. Default: local/webview-runtimes/linux-cef.json.
-  --minimum-cli-version <x.y.z>    Minimum CLI for schema/primitives. Default: ${DEFAULT_MINIMUM_CLI_VERSION}.
+  --minimum-cli-version <semver>   Minimum CLI for schema/primitives. Default: ${DEFAULT_MINIMUM_CLI_VERSION}.
   --out <path>                     Output manifest path. Default: dist/fennara-release-manifest-v<version>.json.
 `);
 }

--- a/scripts/write-release-manifest.mjs
+++ b/scripts/write-release-manifest.mjs
@@ -9,15 +9,10 @@ import {
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseReleaseVersion, validateReleaseIdentity } from "./release-identity.mjs";
+import { RELEASE_TARGETS } from "./release-targets.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const DEFAULT_MINIMUM_CLI_VERSION = "0.3.3";
-const RELEASE_PLATFORMS = [
-  { key: "windows-x86_64", platform: "windows", arch: "x86_64" },
-  { key: "linux-x86_64", platform: "linux", arch: "x86_64" },
-  { key: "macos-arm64", platform: "macos", arch: "arm64" },
-];
-
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
   printHelp();
   process.exit(0);
@@ -35,6 +30,10 @@ const linuxCefManifestPath = path.resolve(
   args["linux-cef-manifest"] ?? path.join("local", "webview-runtimes", "linux-cef.json"),
 );
 const minimumCliVersion = args["minimum-cli-version"] ?? DEFAULT_MINIMUM_CLI_VERSION;
+const releaseIdentityPath = path.resolve(
+  root,
+  args["release-identity"] ?? path.join("godot_demo", "addons", "fennara", "release.json"),
+);
 
 validateVersion(version, "version");
 validateVersion(minimumCliVersion, "minimum CLI version");
@@ -57,7 +56,7 @@ function buildManifest() {
     addon: assetRecord(`fennara-release-addon-v${version}.zip`),
   };
 
-  for (const target of RELEASE_PLATFORMS) {
+  for (const target of RELEASE_TARGETS) {
     assets.cli[target.key] = assetRecord(
       `fennara-cli-${target.platform}-${target.arch}-v${version}.zip`,
       target,
@@ -86,14 +85,7 @@ function buildManifest() {
 }
 
 function readReleaseIdentity() {
-  const identityPath = path.join(
-    root,
-    "godot_demo",
-    "addons",
-    "fennara",
-    "release.json",
-  );
-  const identity = JSON.parse(readFileSync(identityPath, "utf8"));
+  const identity = JSON.parse(readFileSync(releaseIdentityPath, "utf8"));
   return validateReleaseIdentity(identity, version);
 }
 
@@ -237,6 +229,7 @@ Options:
   --assets-dir <dir>               Directory containing release zip assets. Default: release-assets.
                                    Release local/addon assets must use fennara-release-local-* and fennara-release-addon-* names.
   --linux-cef-manifest <path>      Generated enabled Linux CEF manifest. Default: local/webview-runtimes/linux-cef.json.
+  --release-identity <path>        Release identity JSON. Default: godot_demo/addons/fennara/release.json.
   --minimum-cli-version <semver>   Minimum CLI for schema/primitives. Default: ${DEFAULT_MINIMUM_CLI_VERSION}.
   --out <path>                     Output manifest path. Default: dist/fennara-release-manifest-v<version>.json.
 `);

--- a/scripts/write-staging-candidate.mjs
+++ b/scripts/write-staging-candidate.mjs
@@ -1,15 +1,24 @@
 import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createStagingCandidate } from "./staging-candidate.mjs";
+import { parseArgs, requiredArg } from "./staging-validation-files.mjs";
 
-const args = parseArgs(process.argv.slice(2));
-const outPath = path.resolve(requiredArg("out"));
+const args = parseArgs(process.argv.slice(2), [
+  "base-version",
+  "pull-request",
+  "candidate",
+  "source-commit",
+  "source-repository",
+  "out",
+  "github-output",
+]);
+const outPath = path.resolve(requiredArg(args, "out"));
 const candidate = createStagingCandidate({
-  baseVersion: requiredArg("base-version"),
-  pullRequest: requiredArg("pull-request"),
-  candidateNumber: requiredArg("candidate"),
-  sourceCommit: requiredArg("source-commit"),
-  sourceRepository: requiredArg("source-repository"),
+  baseVersion: requiredArg(args, "base-version"),
+  pullRequest: requiredArg(args, "pull-request"),
+  candidateNumber: requiredArg(args, "candidate"),
+  sourceCommit: requiredArg(args, "source-commit"),
+  sourceRepository: requiredArg(args, "source-repository"),
 });
 
 mkdirSync(path.dirname(outPath), { recursive: true });
@@ -34,40 +43,3 @@ if (args["github-output"]) {
 
 console.log(`Created ${outPath}`);
 console.log(`Staging candidate ${candidate.version} from ${candidate.source_repository}@${candidate.source_commit}`);
-
-function parseArgs(rawArgs) {
-  const parsed = {};
-  const allowed = new Set([
-    "base-version",
-    "pull-request",
-    "candidate",
-    "source-commit",
-    "source-repository",
-    "out",
-    "github-output",
-  ]);
-  for (let index = 0; index < rawArgs.length; index += 2) {
-    const option = rawArgs[index];
-    const value = rawArgs[index + 1];
-    if (!option?.startsWith("--") || value === undefined) {
-      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
-    }
-    const name = option.slice(2);
-    if (!allowed.has(name)) {
-      throw new Error(`Unknown option ${option}`);
-    }
-    if (parsed[name] !== undefined) {
-      throw new Error(`Duplicate option ${option}`);
-    }
-    parsed[name] = value;
-  }
-  return parsed;
-}
-
-function requiredArg(name) {
-  const value = args[name];
-  if (!value) {
-    throw new Error(`Missing --${name}`);
-  }
-  return value;
-}

--- a/scripts/write-staging-candidate.mjs
+++ b/scripts/write-staging-candidate.mjs
@@ -1,0 +1,73 @@
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createStagingCandidate } from "./staging-candidate.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const outPath = path.resolve(requiredArg("out"));
+const candidate = createStagingCandidate({
+  baseVersion: requiredArg("base-version"),
+  pullRequest: requiredArg("pull-request"),
+  candidateNumber: requiredArg("candidate"),
+  sourceCommit: requiredArg("source-commit"),
+  sourceRepository: requiredArg("source-repository"),
+});
+
+mkdirSync(path.dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(candidate, null, 2)}\n`);
+
+if (args["github-output"]) {
+  const outputs = {
+    version: candidate.version,
+    channel: candidate.channel,
+    pull_request: candidate.pull_request,
+    source_commit: candidate.source_commit,
+    source_repository: candidate.source_repository,
+    release_tag: candidate.release_tag,
+  };
+  appendFileSync(
+    path.resolve(args["github-output"]),
+    Object.entries(outputs)
+      .map(([name, value]) => `${name}=${value}`)
+      .join("\n") + "\n",
+  );
+}
+
+console.log(`Created ${outPath}`);
+console.log(`Staging candidate ${candidate.version} from ${candidate.source_repository}@${candidate.source_commit}`);
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  const allowed = new Set([
+    "base-version",
+    "pull-request",
+    "candidate",
+    "source-commit",
+    "source-repository",
+    "out",
+    "github-output",
+  ]);
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    const name = option.slice(2);
+    if (!allowed.has(name)) {
+      throw new Error(`Unknown option ${option}`);
+    }
+    if (parsed[name] !== undefined) {
+      throw new Error(`Duplicate option ${option}`);
+    }
+    parsed[name] = value;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  const value = args[name];
+  if (!value) {
+    throw new Error(`Missing --${name}`);
+  }
+  return value;
+}

--- a/scripts/write-staging-pointer.mjs
+++ b/scripts/write-staging-pointer.mjs
@@ -29,13 +29,21 @@ function readJson(file) {
 
 function parseArgs(rawArgs) {
   const parsed = {};
+  const allowed = new Set(["candidate", "manifest", "out"]);
   for (let index = 0; index < rawArgs.length; index += 2) {
     const option = rawArgs[index];
     const value = rawArgs[index + 1];
     if (!option?.startsWith("--") || value === undefined) {
       throw new Error(`Invalid argument ${JSON.stringify(option)}`);
     }
-    parsed[option.slice(2)] = value;
+    const name = option.slice(2);
+    if (!allowed.has(name)) {
+      throw new Error(`Unknown option ${option}`);
+    }
+    if (parsed[name] !== undefined) {
+      throw new Error(`Duplicate option ${option}`);
+    }
+    parsed[name] = value;
   }
   return parsed;
 }

--- a/scripts/write-staging-pointer.mjs
+++ b/scripts/write-staging-pointer.mjs
@@ -1,0 +1,48 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { createChannelPointer } from "./release-identity.mjs";
+import { validateStagingCandidate } from "./staging-candidate.mjs";
+
+const args = parseArgs(process.argv.slice(2));
+const candidate = validateStagingCandidate(readJson(requiredArg("candidate")));
+const manifestPath = path.resolve(requiredArg("manifest"));
+const manifestBytes = readFileSync(manifestPath);
+const manifest = JSON.parse(manifestBytes);
+if (manifest.version !== candidate.version) {
+  throw new Error(
+    `release manifest version ${JSON.stringify(manifest.version)} does not match ${candidate.version}`,
+  );
+}
+const pointer = createChannelPointer(
+  candidate,
+  createHash("sha256").update(manifestBytes).digest("hex"),
+);
+const outPath = path.resolve(requiredArg("out"));
+mkdirSync(path.dirname(outPath), { recursive: true });
+writeFileSync(outPath, `${JSON.stringify(pointer, null, 2)}\n`);
+console.log(`Created ${outPath}`);
+
+function readJson(file) {
+  return JSON.parse(readFileSync(path.resolve(file), "utf8"));
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 2) {
+    const option = rawArgs[index];
+    const value = rawArgs[index + 1];
+    if (!option?.startsWith("--") || value === undefined) {
+      throw new Error(`Invalid argument ${JSON.stringify(option)}`);
+    }
+    parsed[option.slice(2)] = value;
+  }
+  return parsed;
+}
+
+function requiredArg(name) {
+  if (!args[name]) {
+    throw new Error(`Missing --${name}`);
+  }
+  return args[name];
+}

--- a/scripts/write-staging-pointer.mjs
+++ b/scripts/write-staging-pointer.mjs
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { createChannelPointer } from "./release-identity.mjs";
+import { createChannelPointer, validateReleaseIdentity } from "./release-identity.mjs";
 import { validateStagingCandidate } from "./staging-candidate.mjs";
 
 const args = parseArgs(process.argv.slice(2));
@@ -13,6 +13,11 @@ if (manifest.version !== candidate.version) {
   throw new Error(
     `release manifest version ${JSON.stringify(manifest.version)} does not match ${candidate.version}`,
   );
+}
+const manifestIdentity = validateReleaseIdentity(manifest.release, candidate.version);
+const candidateIdentity = validateReleaseIdentity(candidate, candidate.version);
+if (JSON.stringify(manifestIdentity) !== JSON.stringify(candidateIdentity)) {
+  throw new Error("release manifest identity does not match staging candidate");
 }
 const pointer = createChannelPointer(
   candidate,


### PR DESCRIPTION
### What changed?

- Added a trusted staging workflow that freezes a pull request head SHA, builds exact cross-platform candidates, defaults to dry-run validation, publishes immutable prereleases only when explicitly requested, verifies public downloads, and advances an isolated per-PR pointer monotonically.
- Added exact staging identity and channel discovery across Node, Rust, and the native editor integration.
- Made first-run install, project update, and CLI self-update preserve the selected channel while freezing one exact target before mutation.
- Added shared-runtime safety checks that reject activation or shutdown while another Godot project is connected, with rollback and project reopen behavior for late conflicts.
- Added staging UI identity, PR-aware update text, copied diagnostics, automated workflow coverage, and release documentation.
- Made stable release publication draft-first, immutable, resumable, and byte-consistent with the legacy mutable `latest` release.
- Raised the release manifest minimum CLI version to `0.3.8`, because staging installation and updater handoff depend on the new channel-aware CLI behavior.

### Why?

Pull-request staging builds need to be isolated, reproducible, and safe to install without changing the stable release path. A staging install must retain its origin through first run, project updates, CLI self-update, daemon activation, and recovery. The workflow also needs to prevent untrusted pull-request code from receiving release credentials and must never move a channel pointer to an unverified candidate.

### How did you verify it?

```text
node --test scripts/tests/*.test.mjs
cargo test --workspace --locked --manifest-path local/Cargo.toml
cd fennara-cpp
scons platform=windows target=editor
```

Workflow YAML files were parsed with `yaml.safe_load`, changed JavaScript modules were checked with `node --check`, and `git diff --check` passed.

### Checklist

- [x] I kept the change focused
- [x] I updated docs if behavior changed
- [x] I did not include unrelated changes
- [x] I explained any workflow or release-process changes

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PR-isolated staging channels with identity-aware update discovery using validated channel-pointer artifacts.
  * Introduced staging candidate build/publish workflow with immutable-release enforcement and added stricter SemVer parsing/normalization.
  * Added CLI support for `--channel pr-<number>` and surfaced staging track/channel metadata in the update UI (including a staging badge).
* **Bug Fixes**
  * Improved update-check cancellation, and expanded update status/error reporting; strengthened daemon shutdown when other projects are connected.
* **Documentation**
  * Updated release/versioning, CLI, and architecture docs for staging and immutable release behavior.
* **Tests**
  * Expanded unit tests and added workflow validations for staging candidates, manifests, bundles, and publish rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->