### PR TITLE
docs(install): clarify macOS CLI recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ The built-in chat dock uses the platform webview: Microsoft Edge WebView2 on Win
 
 ## Install
 
-Choose either the addon or CLI install.
+On Windows and Linux, choose either the addon or CLI install. On macOS, use the
+CLI install below if you want to avoid the macOS security notification that can
+appear after manually downloading and extracting the addon ZIP.
 
 ### Add The Addon To Your Project
 
@@ -65,10 +67,19 @@ Choose either the addon or CLI install.
 
 Open the project, select the Fennara dock, and press **Set Up Fennara**.
 
-### Alternative: Install With The CLI
+> **macOS:** The release addon contains a native library that is not currently
+> Apple-notarized. If you download the addon ZIP through a browser and extract
+> it manually, macOS may report that it cannot verify
+> `libfennara.macos.editor` is free of malware. To avoid this notification, use
+> the CLI installation below. If you already see the notification, close Godot,
+> remove the manually copied `addons/fennara/` folder, then install Fennara with
+> the CLI.
 
-You do not need this if you used the addon option above. Use the CLI only if
-you prefer installing Fennara from the terminal.
+### Install With The CLI (Recommended On macOS)
+
+The CLI installs the same Fennara addon. It is the recommended installation
+method on macOS because it avoids the browser and Finder quarantine path that
+causes the notification described above.
 
 Install the CLI on Windows:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,13 @@ app data. It then launches `fennara install` and reads the durable operation
 state for progress and diagnostics. Chat and the webview remain inactive until
 setup succeeds and the matching daemon connects.
 
+On macOS, user-facing documentation recommends installing through the CLI. The
+in-editor bootstrap can run only after the GDExtension native library loads, so
+it cannot remediate a Gatekeeper block caused by manually downloading and
+extracting the non-notarized addon ZIP. Users whose manually copied addon is
+blocked must remove it before running `fennara install`, because the CLI
+preserves a complete existing addon.
+
 A shared app-data bootstrap lock serializes CLI download and activation across
 concurrent Godot editors. Lock ownership transfers to the launched installer
 process, so another editor waits until that exact process exits. The panel

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,8 +4,9 @@ Use the CLI when you prefer the terminal, need diagnostics or recovery, or want
 an automated install with an exact version.
 
 > [!TIP]
-> You do not need to install the CLI manually if **Set Up Fennara** already
-> completed in the Godot dock.
+> The CLI is the recommended installation method on macOS. It avoids the macOS
+> security notification that can occur when a browser-downloaded addon ZIP is
+> extracted manually and its native library inherits Finder quarantine.
 
 ## Common Flow
 
@@ -32,6 +33,11 @@ macOS and Linux:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/fennaraOfficial/fennara-godot-ai/main/install.sh | sh
 ```
+
+If a manually extracted macOS addon already triggers a notification for
+`libfennara.macos.editor`, close Godot and remove the manually copied
+`addons/fennara/` folder before running `fennara install`. The CLI otherwise
+preserves an existing complete addon.
 
 Open a new terminal if `fennara` is not immediately available, then check the
 installation:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -24,8 +24,23 @@ No. Fennara is not trying to make Godot optional. It is designed to make AI agen
 
 ## How should I install Fennara?
 
-Add the addon, open the Fennara dock, and press **Set Up Fennara**. You can also
-install from the terminal. See [Setup](setup.md) for both paths.
+On Windows and Linux, add the addon, open the Fennara dock, and press **Set Up
+Fennara**, or install from the terminal. On macOS, install through the CLI to
+avoid the security notification that can occur when a browser-downloaded addon
+ZIP is extracted manually. See [Setup](setup.md) for both paths.
+
+## Why does macOS say it cannot verify `libfennara.macos.editor`?
+
+The release addon contains a native library that is not currently
+Apple-notarized. When the addon ZIP is downloaded through a browser and
+extracted manually, Finder can propagate quarantine metadata to that library,
+causing the macOS notification.
+
+To avoid it, use the [CLI installation](setup.md#install-from-the-terminal-recommended-on-macos).
+If the notification already appears, close Godot, remove the manually copied
+`addons/fennara/` folder, install the CLI, and run `fennara install` from the
+project directory. The CLI installs the same addon without that browser and
+Finder quarantine path.
 
 ## Do I need a chat provider API key?
 

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -4,8 +4,18 @@ Use this page only when you need to assemble Fennara without the Godot setup
 flow or `fennara install`.
 
 > [!TIP]
-> Most users should add `addons/fennara` to the project, open the Fennara dock,
-> and press **Set Up Fennara**. See [Setup](setup.md).
+> On Windows and Linux, most users should add `addons/fennara` to the project,
+> open the Fennara dock, and press **Set Up Fennara**. On macOS, use the CLI.
+> See [Setup](setup.md).
+
+> [!IMPORTANT]
+> Manual addon ZIP installation is not recommended on macOS. The addon contains
+> a native library that is not currently Apple-notarized, and browser download
+> plus Finder extraction can cause macOS to report that it cannot verify
+> `libfennara.macos.editor` is free of malware. Use the
+> [CLI installation](setup.md#install-from-the-terminal-recommended-on-macos)
+> to avoid this notification. If the notification already appears, close Godot,
+> remove the manually copied `addons/fennara/` folder, and run `fennara install`.
 
 Manual installation has four parts: the CLI, the project addon, the shared local
 runtime package, and optional MCP app configuration.

--- a/docs/release.md
+++ b/docs/release.md
@@ -171,6 +171,14 @@ Package roles:
 | `fennara-webview-cef-linux-x64-*` | Linux-only shared CEF runtime installed once in Fennara app data |
 | `fennara-release-manifest-v*` | Install and update plan containing asset names, SHA-256 values, install primitives, and shared runtimes |
 
+The macOS addon GDExtension is not currently Apple-notarized. Browser downloads
+and manual Finder extraction can propagate quarantine metadata and trigger the
+macOS verification notification. User-facing installation documentation must
+recommend `fennara install` on macOS, explain the manual ZIP limitation, and
+tell affected users to remove the manually copied addon before reinstalling
+through the CLI. Release validation does not treat ZIP creation alone as macOS
+signing or notarization.
+
 The `fennara-release-local-*` prefix prevents older CLIs from silently bypassing
 the manifest-managed package path.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -4,7 +4,8 @@ Install Fennara, choose where you want to chat, and connect your Godot project.
 
 > [!TIP]
 > Most users only need to add the addon, open the Fennara dock, and press
-> **Set Up Fennara**.
+> **Set Up Fennara**. On macOS, use the CLI installation below to avoid the
+> security notification that can follow a manually downloaded addon ZIP.
 
 ## Before You Start
 
@@ -17,6 +18,14 @@ Install Fennara, choose where you want to chat, and connect your Godot project.
 | The .NET SDK available as `dotnet` | Only for C# diagnostics and runtime preflight |
 
 ## Install From Godot
+
+> [!IMPORTANT]
+> On macOS, the release addon contains a native library that is not currently
+> Apple-notarized. Downloading the addon ZIP through a browser and extracting it
+> manually can make macOS report that it cannot verify
+> `libfennara.macos.editor` is free of malware. Use
+> [Install From The Terminal](#install-from-the-terminal-recommended-on-macos)
+> to avoid this notification.
 
 1. Install **Fennara** from the Godot Asset Library, or download
    `fennara-addon-latest.zip` from the
@@ -34,9 +43,11 @@ project files.
 > The addon stays in your project. The CLI, daemon, MCP server, logs, and shared
 > browser runtime live in Fennara app data outside the project.
 
-## Alternative: Install From The Terminal
+## Install From The Terminal (Recommended On macOS)
 
-You do not need this if setup from the Godot dock succeeded.
+The CLI installs the same addon and is the recommended installation method on
+macOS. It avoids the browser and Finder quarantine path that causes the native
+library notification described above.
 
 Install the CLI on Windows:
 
@@ -56,6 +67,11 @@ Then run Fennara inside the project:
 cd path/to/your-godot-project
 fennara install
 ```
+
+If you already extracted the addon manually on macOS and see the notification,
+close Godot and remove the manually copied `addons/fennara/` folder before
+running `fennara install`. This matters because the CLI preserves an existing
+complete addon instead of replacing it.
 
 If the project already contains a complete Fennara addon, the CLI keeps it and
 installs the matching local components. Otherwise, it installs the current


### PR DESCRIPTION
## Purpose

Make the supported macOS installation path unambiguous for users who want to avoid the Gatekeeper notification triggered by manually downloading and extracting the release addon ZIP.

## Changes

- Recommends CLI installation on macOS in the README, Setup guide, CLI reference, Manual Install guide, and FAQ.
- Explains that the current native macOS library is not Apple-notarized and that browser download plus Finder extraction can propagate quarantine metadata.
- Tells affected users to close Godot, remove the blocked manually copied addon, and reinstall through the CLI.
- Clarifies that working existing addons remain valid and are intentionally preserved by the CLI.
- Records the bootstrap limitation in the architecture guide and the notarization expectation in the release guide.

## Validation

```text
git diff --check origin/main...HEAD
```

Manually checked all relative Markdown link targets, the referenced Setup heading anchor, the rendered warning structure, and consistency across the seven changed documentation files.

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and setup/CLI/manual installation docs with macOS-specific guidance explaining how to avoid Gatekeeper/quarantine verification warnings after manually downloading/extracting the addon.
  * Added clearer “recommended CLI” wording for macOS, including prerequisites and step-by-step recovery if the notification already appears.
  * Expanded the FAQ and added a release-assets note plus architecture guidance covering the macOS manual ZIP limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->