### PR TITLE
fix(release): run staging version stamp in bash

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -241,6 +241,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Stamp candidate version in the runner workspace
+        shell: bash
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
           CHANNEL: ${{ needs.resolve.outputs.channel }}

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -61,6 +61,16 @@ test("shell commands do not interpolate resolve outputs directly", () => {
   }
 });
 
+test("candidate version stamping uses bash on every platform", () => {
+  const packageJob = jobBlocks(workflow).get("package");
+  assert.ok(packageJob, "workflow must contain the package job");
+  const stampStep = stepBlocks(packageJob).find((block) =>
+    /name: Stamp candidate version in the runner workspace/.test(block),
+  );
+  assert.ok(stampStep, "package job must stamp the staging candidate version");
+  assert.match(stampStep, /^        shell: bash$/m);
+});
+
 test("immutable-release preflight uses an administration token", () => {
   const publish = jobBlocks(workflow).get("publish");
   assert.ok(publish, "workflow must contain the publish job");
@@ -94,9 +104,11 @@ function runBlocks(source) {
 }
 
 function checkoutSteps(source) {
-  return source
-    .split(/(?=^      - )/m)
-    .filter((block) => /uses: actions\/checkout@/.test(block));
+  return stepBlocks(source).filter((block) => /uses: actions\/checkout@/.test(block));
+}
+
+function stepBlocks(source) {
+  return source.split(/(?=^      - )/m);
 }
 
 function jobBlocks(source) {


### PR DESCRIPTION
## Purpose

Allow the Staging Release packaging matrix to stamp candidate versions on Windows.

## Root cause

The shared version-stamping step uses Bash line continuations, but GitHub Actions selected PowerShell as the default shell on the Windows runner. PowerShell stopped at `--track` with a parser error before compilation began.

## Changes

- Run the shared staging version-stamping step explicitly with Bash on every platform.
- Add a workflow regression test that binds the explicit Bash shell to the package job's exact stamping step.

## Validation

```text
node --test scripts/tests/*.test.mjs
git diff --check origin/main...HEAD
```

Parsed `.github/workflows/staging-release.yml` with `yaml.safe_load`.

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging release reliability by ensuring candidate version stamping uses Bash consistently across platforms.

* **Tests**
  * Added automated coverage to verify consistent shell behavior during staging releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->