### PR TITLE
fix(release): restore trusted staging build caches

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -294,11 +294,71 @@ jobs:
             --out-dir "${RUNNER_TEMP}/fennara-cef-sdk" \
             --download-dir "${RUNNER_TEMP}/fennara-cef-download"
 
+      - name: Compute godot-cpp cache key
+        id: godot_cpp_cache_key
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_hash="${{ hashFiles('fennara-cpp/godot-cpp/SConstruct', 'fennara-cpp/godot-cpp/tools/**/*.py', 'fennara-cpp/godot-cpp/include/**/*.h', 'fennara-cpp/godot-cpp/include/**/*.hpp', 'fennara-cpp/godot-cpp/gdextension/*.json') }}"
+          image_id="${ImageOS:-${RUNNER_OS:-unknown}}-${ImageVersion:-unknown}"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            toolchain_id="$(powershell -NoProfile -Command '$vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"; if (Test-Path $vswhere) { $install = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath; if ($install) { $versions = Get-ChildItem (Join-Path $install "VC\Tools\MSVC") -Directory | Sort-Object Name -Descending; if ($versions) { $versions[0].Name } } }' | tr -d '\r')"
+          else
+            toolchain_id="$(c++ --version | head -n 1)"
+          fi
+          toolchain_id="$(printf "%s" "${toolchain_id:-unknown}" | tr -c 'A-Za-z0-9_.-' '-')"
+          base="godot-cpp-v2-${{ runner.os }}-${{ matrix.platform }}-editor-${source_hash}-${image_id}-${toolchain_id}"
+          echo "primary=${base}-${{ github.run_id }}-${{ github.run_attempt }}" >> "$GITHUB_OUTPUT"
+          echo "restore=${base}-" >> "$GITHUB_OUTPUT"
+          echo "image-id=${image_id}" >> "$GITHUB_OUTPUT"
+          echo "toolchain-id=${toolchain_id}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore trusted SCons and godot-cpp outputs
+        id: godot_cpp_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            fennara-cpp/.scons_cache/
+            fennara-cpp/.sconsign.dblite
+            fennara-cpp/godot-cpp/bin/
+            fennara-cpp/godot-cpp/gen/
+            fennara-cpp/godot-cpp/src/**/*.obj
+            fennara-cpp/godot-cpp/src/**/*.pdb
+          key: ${{ steps.godot_cpp_cache_key.outputs.primary }}
+          restore-keys: |
+            ${{ steps.godot_cpp_cache_key.outputs.restore }}
+
+      - name: Report godot-cpp cache restore
+        run: |
+          echo "cache-hit: ${{ steps.godot_cpp_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: ${{ steps.godot_cpp_cache_key.outputs.primary }}"
+          echo "cache-restore-prefix: ${{ steps.godot_cpp_cache_key.outputs.restore }}"
+          echo "runner-image: ${{ steps.godot_cpp_cache_key.outputs.image-id }}"
+          echo "toolchain-id: ${{ steps.godot_cpp_cache_key.outputs.toolchain-id }}"
+
+      - name: Restore trusted Cargo artifacts
+        id: cargo_cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            local/target
+          key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}
+          restore-keys: |
+            local-cargo-${{ runner.os }}-
+
+      - name: Report Cargo cache restore
+        run: |
+          echo "cache-hit: ${{ steps.cargo_cache.outputs.cache-hit }}"
+          echo "cache-primary-key: local-cargo-${{ runner.os }}-${{ hashFiles('local/Cargo.lock') }}"
+
       - name: Build GDExtension
         working-directory: fennara-cpp
         env:
+          SCONS_CACHE: ${{ github.workspace }}/fennara-cpp/.scons_cache
           FENNARA_CEF_ROOT: ${{ steps.linux_cef_sdk.outputs.cef_root }}
-        run: scons platform=${{ matrix.platform }} target=editor
+        run: scons platform=${{ matrix.platform }} target=editor --debug=explain --cache-show
 
       - name: Build local tools
         working-directory: local

--- a/docs/release.md
+++ b/docs/release.md
@@ -250,8 +250,12 @@ head of an open pull request. Run it from `main` and provide:
 The workflow freezes the pull request head SHA before any platform build. The
 Windows, Linux, and macOS jobs check out that exact commit with read-only
 permissions, no persisted Git credentials, no release credentials, and no
-shared dependency caches. Candidate code can produce build artifacts, but it
-cannot publish a GitHub Release.
+ability to save shared dependency caches. They may restore compatible
+SCons/godot-cpp and Cargo caches written by trusted default-branch workflows.
+Staging uses the restore-only cache action, so candidate code can consume
+trusted build outputs but cannot replace or poison caches for later runs.
+Candidate code can produce build artifacts, but it cannot publish a GitHub
+Release.
 
 Trusted repository scripts then validate the candidate identity, exact archive
 inventory, addon contents, platform package layout, release manifest, and every

--- a/scripts/tests/staging-workflow.test.mjs
+++ b/scripts/tests/staging-workflow.test.mjs
@@ -71,6 +71,21 @@ test("candidate version stamping uses bash on every platform", () => {
   assert.match(stampStep, /^        shell: bash$/m);
 });
 
+test("candidate builds restore trusted caches without saving them", () => {
+  const packageJob = jobBlocks(workflow).get("package");
+  assert.ok(packageJob, "workflow must contain the package job");
+  assert.equal(
+    (packageJob.match(/uses: actions\/cache\/restore@v4/g) ?? []).length,
+    2,
+    "staging packages must restore the godot-cpp and Cargo caches",
+  );
+  assert.doesNotMatch(packageJob, /uses: actions\/cache@/);
+  assert.doesNotMatch(packageJob, /uses: actions\/cache\/save@/);
+  assert.match(packageJob, /key: \$\{\{ steps\.godot_cpp_cache_key\.outputs\.primary \}\}/);
+  assert.match(packageJob, /key: local-cargo-\$\{\{ runner\.os \}\}-\$\{\{ hashFiles\('local\/Cargo\.lock'\) \}\}/);
+  assert.match(packageJob, /SCONS_CACHE: \$\{\{ github\.workspace \}\}\/fennara-cpp\/\.scons_cache/);
+});
+
 test("immutable-release preflight uses an administration token", () => {
   const publish = jobBlocks(workflow).get("publish");
   assert.ok(publish, "workflow must contain the publish job");


### PR DESCRIPTION
## Purpose

Reduce staging candidate build time and Actions usage by reusing compatible caches already produced by trusted default-branch workflows.

## Root cause

The staging package matrix rebuilt godot-cpp, SCons outputs, and the Rust workspace from scratch on every run, even when compatible `main` caches existed. Using the normal cache action would be unsafe because the workflow builds pull request code while running in the default-branch cache scope.

## Changes

- Restore compatible SCons and godot-cpp outputs with `actions/cache/restore@v4`.
- Restore Cargo registry, Git, and target artifacts with the restore-only action.
- Reuse the same platform, runner-image, toolchain, dependency, and lockfile keys as trusted build workflows.
- Enable the SCons cache directory and cache diagnostics during staging builds.
- Add a regression test that requires both restores and rejects any staging cache save action.
- Document the restore-only trust boundary for staging candidates.

## Validation

- `node --test scripts/tests/*.test.mjs`
- `python -c "import pathlib,yaml; yaml.safe_load(pathlib.Path('.github/workflows/staging-release.yml').read_text(encoding='utf-8')); print('yaml-ok')"`
- `git diff --check origin/main...HEAD`

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Staging builds now restore trusted build and dependency caches to reduce build times.
  * Cache usage is isolated to prevent candidate builds from overwriting shared caches.

* **Documentation**
  * Clarified cache permissions and restrictions for staging candidate workflows.

* **Tests**
  * Added coverage to verify cache restoration, cache key handling, and protection against cache saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->