### PR TITLE
docs(release): clarify stable update guidance

### DIFF
--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       base_version:
-        description: "Planned stable version, for example 0.3.9."
+        description: "Planned stable version in X.Y.Z form."
         required: true
         type: string
       candidate:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,4 +108,8 @@ The lowest `fennara` CLI version allowed to consume a release manifest. If a rel
 
 **Latest Release**
 
-The moving GitHub release/tag used by installers and default updates. Updating source files after publishing does not change release assets; already-published manifest assets must be replaced explicitly.
+GitHub's Latest Release pointer to an exact versioned release. Installers and
+default updates resolve this pointer through GitHub's API. Fennara does not use
+a literal `latest` tag or release. Updating source files after publishing does
+not change release assets; already-published manifest assets must be replaced
+explicitly.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ for the complete app list and manual configuration instructions.
 
 When the Fennara dock shows **Update**, press it and follow the prompts.
 
-> **Upgrading from Fennara v0.3.9 or older:** Reinstall the CLI once with the
+> **Upgrading from Fennara v0.3.8 or older:** Reinstall the CLI once with the
 > platform install command above before running `fennara update`. Those CLI
 > versions resolve a retired release tag and cannot discover current releases.
 > Reinstalling the CLI switches future updates to GitHub's Latest Release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,7 @@ not captured by default. The daemon exposes a small local debug read endpoint at
 
 ## Install Layout
 
-For the default Asset Library flow, the GDExtension first presents a native
+For the manually copied release-addon flow, the GDExtension first presents a native
 setup panel when the exact local installation is missing. Its bootstrap bridge
 downloads the addon version's release manifest and CLI archive with Godot's
 HTTP client, verifies the declared SHA-256, and places only the CLI in Fennara
@@ -313,8 +313,9 @@ still apply in both modes.
 ## Updates
 
 `fennara update` is the normal project update command. It reads the installed
-addon release identity, resolves stable latest or that addon's isolated staging
-channel, and freezes the result to one exact version. It first checks
+add-on release identity, resolves GitHub's Latest Release pointer or that
+add-on's isolated staging channel, and freezes the result to one exact version.
+It first checks
 the version of that release manifest's per-platform CLI asset and, when newer,
 stages that CLI, lets the old process exit, replaces the installed CLI, and
 resumes with the same target. It then uses the same manifest-driven resolver and installer as
@@ -365,8 +366,9 @@ Each public release publishes separate assets so installs can stay modular:
 | `fennara-webview-cef-linux-x64-<cef-version>.zip` | Linux-only shared CEF runtime installed once into Fennara app data. |
 | `fennara-release-manifest-v<version>.json` | Schema-versioned install/update plan with asset names, hashes, minimum CLI version, and shared runtime declarations. |
 
-The moving `latest` release is what normal users should install from. Versioned
-releases such as `v0.2.8` stay available for pinning and debugging.
+Normal users install from the exact versioned release currently designated as
+GitHub Latest. Fennara does not create or move a literal `latest` tag or release.
+Older versioned releases stay available for pinning and debugging.
 
 Linux CEF runtime payloads are not part of `fennara-addon-*`. They are selected
 by the release manifest and installed once into the shared app-data

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,6 +123,13 @@ project guidance, and checks the platform webview prerequisite. Use
 the CLI has already been replaced. Do not use it to bypass a release's minimum
 CLI requirement.
 
+> [!IMPORTANT]
+> If you are upgrading from Fennara v0.3.8 or older, reinstall the CLI once
+> with the platform installation command in [Setup](setup.md#install-from-the-terminal-recommended-on-macos)
+> before running `fennara update`. Those CLIs query a retired release tag and
+> cannot discover current releases. Reinstalling the CLI does not remove your
+> project addon or settings.
+
 ### Prepare While Godot Is Open
 
 The in-editor update button uses the staging form:

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -40,7 +40,8 @@ Download the release manifest, your platform files, and the shared addon zip.
 | macOS arm64 local runtime | `fennara-release-local-macos-arm64-v<version>.zip` |
 | Versioned all-platform addon | `fennara-release-addon-v<version>.zip` |
 
-For Godot Asset Library links, use the stable latest asset:
+The release also includes this stable-name addon alias for documentation and
+manual downloads:
 
 ```text
 fennara-addon-latest.zip

--- a/docs/release.md
+++ b/docs/release.md
@@ -22,7 +22,7 @@ Releases are manual. Do not publish from pull request workflows.
 
 Release tooling accepts SemVer values. Stable releases use `X.Y.Z`. Staging
 candidates use an isolated pull-request prerelease such as
-`0.3.9-pr.101.2`, where `pr-101` is the staging channel and `2` is that
+`1.2.3-pr.101.2`, where `pr-101` is the staging channel and `2` is that
 channel's candidate number.
 
 To bump the repo version:
@@ -44,7 +44,7 @@ written automatically by the normal command above. A staging build workspace
 uses the explicit identity inputs:
 
 ```bash
-node scripts/set-version.mjs 0.3.9-pr.101.2 \
+node scripts/set-version.mjs 1.2.3-pr.101.2 \
   --track staging \
   --channel pr-101 \
   --source-commit <full-commit-sha>
@@ -132,7 +132,7 @@ The `version` input must match `VERSION`.
 The workflow publishes:
 
 - `v<version>`
-- `latest` when `promote_latest` is true
+- marks `v<version>` as GitHub Latest when `promote_latest` is true
 
 The release workflow prepares the Linux CEF runtime before platform packaging.
 It downloads the pinned official CEF 139 Linux minimal SDK, assembles the
@@ -167,7 +167,7 @@ Package roles:
 | `fennara-cli-*` | Install script payload containing only the `fennara` CLI for one platform |
 | `fennara-release-local-*` | MCP and daemon launchers plus versioned runtime binaries for one platform |
 | `fennara-release-addon-v*` | Versioned all-platform addon resolved through the release manifest |
-| `fennara-addon-latest.zip` | Stable all-platform addon URL for the Godot Asset Library and documentation |
+| `fennara-addon-latest.zip` | Stable-name all-platform addon alias for documentation and manual downloads |
 | `fennara-webview-cef-linux-x64-*` | Linux-only shared CEF runtime installed once in Fennara app data |
 | `fennara-release-manifest-v*` | Install and update plan containing asset names, SHA-256 values, install primitives, and shared runtimes |
 
@@ -195,11 +195,12 @@ manifest whenever the release publishes one. The manifest records:
 - the shared addon asset with SHA-256
 - platform-specific shared runtime assets, currently Linux CEF
 
-The current manifest generator and release workflows use
-`minimum_cli_version: 0.3.8` by default. Normal package layout or asset name
-changes should be handled by manifest data, not by changing the outer CLI.
-Raise `minimum_cli_version` only when a release needs a new manifest schema or
-install primitive that older CLIs truly cannot perform.
+Release workflows pass `minimum_cli_version` explicitly instead of relying on
+the manifest generator's fallback. Normal package layout or asset name changes
+should be handled by manifest data, not by changing the outer CLI. Raise the
+minimum when a release needs a newer updater handoff, manifest schema, install
+primitive, self-update behavior, or other CLI capability that an older
+published CLI cannot safely perform.
 
 When the CLI is too old, `fennara update` should use the manifest's
 per-platform `assets.cli` entry to update the installed CLI first, then resume
@@ -220,8 +221,8 @@ Staging channels are isolated per pull request:
 | Value | PR 101 example |
 | --- | --- |
 | Channel | `pr-101` |
-| Candidate version | `0.3.9-pr.101.2` |
-| Exact release | `v0.3.9-pr.101.2` |
+| Candidate version | `1.2.3-pr.101.2` |
+| Exact release | `v1.2.3-pr.101.2` |
 | Channel ref | `fennara-staging/pr-101` |
 | Pointer file | `fennara-staging-channel-pr-101.json` |
 
@@ -232,7 +233,8 @@ CLI can resolve this pointer with the internal version request
 
 PR 101 and PR 125 therefore use different release tags and pointer assets.
 Updating one channel cannot redirect testers on the other channel. Publishing
-one channel never changes stable `latest` or another pull request's channel.
+one channel never changes the stable GitHub Latest designation or another pull
+request's channel.
 
 ## Staging Candidate Workflow
 
@@ -242,7 +244,7 @@ head of an open pull request. Run it from `main` and provide:
 | Input | Meaning |
 | --- | --- |
 | `pull_request` | Open pull request to build |
-| `base_version` | Planned stable version, such as `0.3.9` |
+| `base_version` | Planned stable version in `X.Y.Z` form |
 | `candidate` | Increasing candidate number for this pull request |
 | `source_commit` | Optional full SHA that must still be the pull request head |
 | `publish` | Off for artifact-only validation, on to publish the candidate |
@@ -290,10 +292,10 @@ before completing publication or advancing a staging channel. Asset publication
 uses the job-scoped `GITHUB_TOKEN` with contents write access.
 
 The stable workflow uses `minimum_cli_version: 0.3.11` because stable discovery
-no longer resolves the retired `latest` tag. The staging workflow uses
-`minimum_cli_version: 0.3.8`. Channel handoff, exact-target preservation across
-CLI replacement, and safe shared-runtime activation depend on the updater
-behavior introduced in that CLI.
+no longer resolves the retired `latest` tag. A staging candidate must require
+the oldest published CLI that supports its channel handoff, exact-target
+preservation across CLI replacement, and safe shared-runtime activation. Do not
+lower the minimum based only on manifest schema compatibility.
 
 The shared addon zip contains every built GDExtension binary referenced by `godot_demo/addons/fennara/fennara.gdextension`. Godot loads the matching library for the user's OS and ignores the others.
 
@@ -405,9 +407,9 @@ GitHub's Latest Release pointer selects the versioned release used by normal
 install and update flows. Fennara does not create or move a literal `latest` tag.
 
 - `install.ps1` and `install.sh` fetch the latest CLI asset by default.
-- `fennara update` fetches the release manifest from `latest` by default, self-updates the installed CLI when needed, then resolves local/addon/shared runtime assets from it.
+- `fennara update` fetches the release manifest through GitHub's Latest Release endpoint by default, self-updates the installed CLI when needed, then resolves local/addon/shared runtime assets from it.
 - In-editor updates stage verified assets before shutdown, recheck the complete staged-addon digest before replacement, keep the previous addon, launchers, and runtime manifest until activation validation succeeds, and require the reopened GDExtension handshake before deleting rollback data.
-- `fennara install` fetches the release manifest from `latest` by default, then resolves local/addon/shared runtime assets from it.
+- `fennara install` fetches the release manifest through GitHub's Latest Release endpoint by default, then resolves local/addon/shared runtime assets from it.
 - The Godot plugin update check compares against GitHub's latest release.
 
 Use `promote_latest: false` only when publishing a version that should not become the default user install.
@@ -466,5 +468,5 @@ fennara self-update
 - Release workflow runs from `main` only.
 - Release version input must match `VERSION`.
 - Pull request workflows may build and upload test artifacts, but must not publish releases.
-- Keep `latest` pointed at the newest release intended for normal users.
+- Keep the intended normal-user release designated as GitHub Latest.
 - Do not rewrite published release tags unless maintainers intentionally decide to replace a broken release.

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -52,7 +52,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `local/crates/fennara-cli/src/release_channel.rs` | Per-channel staging pointer validation and resolution to an exact versioned release. |
 | `local/crates/fennara-cli/src/release_manifest.rs` | Release manifest parsing, asset hash validation, identity binding, and platform package selection. |
 | `local/crates/fennara-cli/src/release_version.rs` | Shared CLI SemVer parsing and precedence used by manifests and release selection. |
-| `local/crates/fennara-cli/src/existing_addon_install.rs` | Exact-version adoption of an existing Asset Library or release addon without replacing project addon files. |
+| `local/crates/fennara-cli/src/existing_addon_install.rs` | Exact-version adoption of an existing complete addon without replacing project addon files. |
 | `local/crates/fennara-cli/src/daemon_setup.rs` | Shared daemon health check, exact-version readiness, and startup used by install and doctor. |
 | `local/crates/fennara-cli/tests/operation_failures.rs` | Process-level failure, durable diagnostics, redaction, and fail-closed operation-log tests. |
 | `local/crates/fennara-cli/src/diagnostics.rs` | User-facing access to the latest or a named sanitized operation report. |
@@ -79,7 +79,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `fennara-cpp/src/setup/` | Native first-run setup state, release-manifest CLI bootstrap, hash verification, CLI launch, and durable operation progress reader. |
 | `fennara-cpp/src/release/version.cpp` | Native SemVer validation and precedence used by release/update discovery. |
 | `fennara-cpp/src/release/identity.cpp` | Packaged stable/staging identity validation and legacy stable compatibility. |
-| `fennara-cpp/src/release/discovery.cpp` | Stable-latest and isolated staging-channel update discovery. |
+| `fennara-cpp/src/release/discovery.cpp` | GitHub Latest and isolated staging-channel update discovery. |
 | `fennara-cpp/src/update/` | Exact-target update coordination, durable receipt discovery, close/install handoff, and recovery UI state. |
 | `fennara-cpp/src/ui/setup_panel.cpp` | Webview-independent first-run setup panel with progress, retry, logs, and sanitized report actions. |
 | `fennara-cpp/vendor/cef/` | Official CEF 139 header snapshot used by the Linux OSR bridge. Runtime binaries stay outside the addon. |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,8 +27,7 @@ Install Fennara, choose where you want to chat, and connect your Godot project.
 > [Install From The Terminal](#install-from-the-terminal-recommended-on-macos)
 > to avoid this notification.
 
-1. Install **Fennara** from the Godot Asset Library, or download
-   `fennara-addon-latest.zip` from the
+1. Download `fennara-addon-latest.zip` from the
    [latest release](https://github.com/fennaraOfficial/fennara-godot-ai/releases/latest)
    and copy `addons/fennara/` into your project.
 2. Open the project and select the Fennara dock.
@@ -160,6 +159,13 @@ To update from the terminal, close Godot and run:
 cd path/to/your-godot-project
 fennara update
 ```
+
+> [!IMPORTANT]
+> If you are upgrading from Fennara v0.3.8 or older, reinstall the CLI once
+> with the platform installation command above before running `fennara update`.
+> Those CLIs query a retired release tag and cannot discover current releases.
+> Reinstalling the CLI switches future updates to GitHub's Latest Release
+> endpoint without removing your project addon or settings.
 
 If validation fails, use **Restore Previous Version**, **Open Logs**, or
 **Copy Report** in the dock. See the [CLI update reference](cli.md#update-a-project)


### PR DESCRIPTION
## Summary

- standardize the one-time CLI reinstall warning for Fennara v0.3.8 or older
- remove remaining Godot Asset Library installation wording
- describe stable discovery consistently as GitHub's Latest Release pointer, never a literal `latest` tag or release
- replace obsolete v0.3.9 staging examples with version-neutral operator guidance
- document how release workflows should choose the minimum compatible published CLI

## Why

The v0.3.11 release retired the literal `latest` tag and moved stable discovery to GitHub's Latest Release endpoint. Several documents still described the old tag model, omitted the required recovery step for v0.3.8 users, or referenced installation paths that are no longer recommended. This aligns the repository documentation with the live release behavior and reduces the chance of recreating the failed release design.

## Validation

```text
node scripts/check-version.mjs
node --test scripts/tests/*.test.mjs
git diff --check origin/main...HEAD
```

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that installations and updates use GitHub’s designated Latest Release and exact versioned assets, rather than a literal `latest` release.
  * Added upgrade guidance for users on Fennara v0.3.8 or older to reinstall the CLI before updating.
  * Updated manual installation instructions to use the stable-name addon download.
  * Refined release, staging, setup, architecture, and terminology guidance for greater clarity.
* **Chores**
  * Clarified the required `base_version` input format as `X.Y.Z`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->