### PR TITLE
fix(release): centralize minimum CLI policy

### DIFF
--- a/.github/workflows/package-preview.yml
+++ b/.github/workflows/package-preview.yml
@@ -439,7 +439,6 @@ jobs:
           node scripts/write-release-manifest.mjs \
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
-            --minimum-cli-version 0.3.8 \
             --out "release-assets/fennara-release-manifest-v${version}.json"
 
       - name: Upload release-shaped preview assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,6 @@ jobs:
           node scripts/write-release-manifest.mjs \
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
-            --minimum-cli-version 0.3.11 \
             --out "release-assets/fennara-release-manifest-v${VERSION}.json"
 
       - name: Publish release

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -510,7 +510,6 @@ jobs:
             --assets-dir release-assets \
             --linux-cef-manifest generated-linux-cef-manifest/linux-cef.json \
             --release-identity staging-metadata/candidate.json \
-            --minimum-cli-version 0.3.8 \
             --out "release-assets/fennara-release-manifest-v${VERSION}.json"
 
       - name: Validate complete candidate asset set

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,7 +104,10 @@ The JSON asset named `fennara-release-manifest-v<version>.json`. It maps release
 
 **Minimum CLI Version**
 
-The lowest `fennara` CLI version allowed to consume a release manifest. If a release needs newer install/update logic, this value must be raised in the generated manifest and in the release workflow that writes it.
+The lowest `fennara` CLI version allowed to consume a release manifest. If a
+release needs newer install/update logic, update its track in
+`scripts/release-policy.mjs`. The manifest writer applies that policy after
+validating the release identity; workflows do not choose the value.
 
 **Latest Release**
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -195,12 +195,14 @@ manifest whenever the release publishes one. The manifest records:
 - the shared addon asset with SHA-256
 - platform-specific shared runtime assets, currently Linux CEF
 
-Release workflows pass `minimum_cli_version` explicitly instead of relying on
-the manifest generator's fallback. Normal package layout or asset name changes
-should be handled by manifest data, not by changing the outer CLI. Raise the
-minimum when a release needs a newer updater handoff, manifest schema, install
-primitive, self-update behavior, or other CLI capability that an older
-published CLI cannot safely perform.
+`scripts/release-policy.mjs` is the source of truth for
+`minimum_cli_version`. The manifest writer selects the policy after validating
+the release identity, so Stable, Package Preview, and Staging cannot choose
+independent values. Normal package layout or asset name changes should be
+handled by manifest data, not by changing the outer CLI. Raise the policy when
+a release needs a newer updater handoff, manifest schema, install primitive,
+self-update behavior, or other CLI capability that an older published CLI
+cannot safely perform.
 
 When the CLI is too old, `fennara update` should use the manifest's
 per-platform `assets.cli` entry to update the installed CLI first, then resume
@@ -291,11 +293,12 @@ disabled. Both workflows verify release metadata and downloaded asset bytes
 before completing publication or advancing a staging channel. Asset publication
 uses the job-scoped `GITHUB_TOKEN` with contents write access.
 
-The stable workflow uses `minimum_cli_version: 0.3.11` because stable discovery
-no longer resolves the retired `latest` tag. A staging candidate must require
-the oldest published CLI that supports its channel handoff, exact-target
-preservation across CLI replacement, and safe shared-runtime activation. Do not
-lower the minimum based only on manifest schema compatibility.
+The release policy currently requires CLI `0.3.11` for stable manifests and
+CLI `0.3.8` for staging manifests. Stable discovery no longer resolves the
+retired `latest` tag. A staging candidate such as `0.3.11-pr.123.1` compares
+lower than stable `0.3.11` under SemVer, so its minimum must remain below the
+candidate version for first-run setup to install the candidate CLI. Do not
+change either minimum based only on manifest schema compatibility.
 
 The shared addon zip contains every built GDExtension binary referenced by `godot_demo/addons/fennara/fennara.gdextension`. Godot loads the matching library for the user's OS and ignores the others.
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -125,6 +125,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `scripts/set-version.mjs` | Updates versioned files across the repo. |
 | `scripts/check-version.mjs` | Checks version sync. |
 | `scripts/release-identity.mjs` | Shared Node validation and generation for SemVer release identity and per-PR staging pointers. |
+| `scripts/release-policy.mjs` | Minimum compatible published CLI policy for stable and staging release manifests. |
 | `scripts/staging-candidate.mjs` | Trusted staging candidate identity generation and monotonic per-PR pointer decisions. |
 | `scripts/staging-*-validation.mjs` / `scripts/staging-validation-files.mjs` | Focused staging addon, archive, manifest, shared filesystem, and publication-bundle validation. |
 | `scripts/validate-staging-build.mjs` / `scripts/validate-staging-publish-bundle.mjs` | Strict validation entrypoints for untrusted build outputs and the trusted publication bundle. |
@@ -168,7 +169,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | Change built-in chat providers | `local/crates/fennara-daemon/src/runtime_daemon/chat/providers/`, `local/crates/fennara-daemon/src/runtime_daemon/chat/models.rs`, `local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs`, and `ui/chat/` |
 | Change vendored chat UI libraries | `ui/chat/vendor/`, `godot_demo/addons/fennara/dist/vendor/`, and `THIRD_PARTY_NOTICES.md` |
 | Change C# support | `fennara-cpp/src/csharp/`, `fennara-cpp/include/fennara/csharp/`, and the C# tool schemas and guidance |
-| Change release packages or CLI self-update | `local/crates/fennara-cli/src/release_manifest.rs`, `local/crates/fennara-cli/src/release_client.rs`, `local/crates/fennara-cli/src/release_package.rs`, `local/crates/fennara-cli/src/self_update.rs`, `scripts/package-preview.mjs`, `scripts/write-release-manifest.mjs`, and `.github/workflows/release.yml` |
+| Change release packages, minimum CLI policy, or CLI self-update | `local/crates/fennara-cli/src/release_manifest.rs`, `local/crates/fennara-cli/src/release_client.rs`, `local/crates/fennara-cli/src/release_package.rs`, `local/crates/fennara-cli/src/self_update.rs`, `scripts/package-preview.mjs`, `scripts/release-policy.mjs`, `scripts/write-release-manifest.mjs`, and `.github/workflows/release.yml` |
 | Bump version | `node scripts/set-version.mjs <version>` |
 | Update setup/docs for chat vs MCP, providers, or slash commands | `README.md`, `docs/mcp-setup.md`, `docs/chat-vs-mcp.md`, `docs/providers.md`, `docs/slash-commands.md`, `docs/setup.md`, `docs/faq.md`, `docs/manual-install.md`, `docs/tools.md`, `docs/examples.md`, and `llms.txt` |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,7 @@ Run `check-version.mjs` in CI and before release packaging. Use `set-version.mjs
 
 - `package-preview.mjs`: syncs committed addon payloads, then assembles per-platform preview archives after the GDExtension and local Rust binaries have already been built.
 - `package-addon-all.mjs`: combines platform addon parts into the final all-platform addon archive.
+- `release-policy.mjs`: defines the minimum compatible published CLI for each release track.
 - `write-release-manifest.mjs`: writes `fennara-release-manifest-v<version>.json` from release assets and validates every referenced SHA-256.
 
 Both scripts use `.package-preview/` as temporary staging and write zip outputs under the repo-root `dist/` folder. Those outputs are ignored and should not be committed.

--- a/scripts/release-policy.mjs
+++ b/scripts/release-policy.mjs
@@ -1,0 +1,15 @@
+const MINIMUM_CLI_VERSION_BY_TRACK = Object.freeze({
+  stable: "0.3.11",
+  staging: "0.3.8",
+});
+
+export function minimumCliVersionForTrack(track) {
+  if (!Object.hasOwn(MINIMUM_CLI_VERSION_BY_TRACK, track)) {
+    throw new Error(`release policy does not define track ${JSON.stringify(track)}`);
+  }
+  return MINIMUM_CLI_VERSION_BY_TRACK[track];
+}
+
+export const RELEASE_POLICY = Object.freeze({
+  minimumCliVersionByTrack: MINIMUM_CLI_VERSION_BY_TRACK,
+});

--- a/scripts/tests/release-policy.test.mjs
+++ b/scripts/tests/release-policy.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createReleaseIdentity } from "../release-identity.mjs";
+import { minimumCliVersionForTrack, RELEASE_POLICY } from "../release-policy.mjs";
+import { RELEASE_TARGETS } from "../release-targets.mjs";
+
+const workflows = ["package-preview.yml", "release.yml", "staging-release.yml"].map(
+  (name) =>
+    readFileSync(new URL(`../../.github/workflows/${name}`, import.meta.url), "utf8"),
+);
+
+test("release policy owns the minimum CLI version for every release track", () => {
+  assert.deepEqual(RELEASE_POLICY.minimumCliVersionByTrack, {
+    stable: "0.3.11",
+    staging: "0.3.8",
+  });
+  assert.equal(minimumCliVersionForTrack("stable"), "0.3.11");
+  assert.equal(minimumCliVersionForTrack("staging"), "0.3.8");
+  assert.throws(() => minimumCliVersionForTrack("preview"), /does not define track/);
+  assert.throws(() => minimumCliVersionForTrack("toString"), /does not define track/);
+});
+
+test("release workflows cannot override the policy minimum", () => {
+  for (const workflow of workflows) {
+    assert.doesNotMatch(workflow, /--minimum-cli-version/);
+  }
+});
+
+test("manifest writer applies release policy to stable and staging identities", () => {
+  const tempParent = fileURLToPath(new URL("../../temp/", import.meta.url));
+  mkdirSync(tempParent, { recursive: true });
+  const directory = mkdtempSync(path.join(tempParent, "release-policy-"));
+  const script = fileURLToPath(new URL("../write-release-manifest.mjs", import.meta.url));
+
+  try {
+    for (const identity of [
+      createReleaseIdentity({ version: "1.2.3" }),
+      createReleaseIdentity({
+        version: "1.2.3-pr.101.1",
+        track: "staging",
+        channel: "pr-101",
+        sourceCommit: "0123456789abcdef0123456789abcdef01234567",
+      }),
+    ]) {
+      const assetsDir = path.join(directory, identity.track, "assets");
+      const identityPath = path.join(directory, identity.track, "release.json");
+      const outPath = path.join(directory, identity.track, "manifest.json");
+      mkdirSync(assetsDir, { recursive: true });
+      writeAssets(assetsDir, identity.version);
+      writeFileSync(identityPath, JSON.stringify(identity));
+
+      const result = spawnSync(
+        process.execPath,
+        [
+          script,
+          "--version",
+          identity.version,
+          "--assets-dir",
+          assetsDir,
+          "--linux-cef-manifest",
+          path.join(directory, "missing-linux-cef.json"),
+          "--release-identity",
+          identityPath,
+          "--out",
+          outPath,
+        ],
+        { encoding: "utf8" },
+      );
+      assert.equal(result.status, 0, result.stderr);
+      const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+      assert.equal(manifest.release.track, identity.track);
+      assert.equal(
+        manifest.minimum_cli_version,
+        minimumCliVersionForTrack(identity.track),
+      );
+    }
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("manifest writer rejects the removed minimum CLI override", () => {
+  const script = fileURLToPath(new URL("../write-release-manifest.mjs", import.meta.url));
+  const result = spawnSync(process.execPath, [script, "--minimum-cli-version", "9.9.9"], {
+    encoding: "utf8",
+  });
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unknown option: --minimum-cli-version/);
+});
+
+function writeAssets(assetsDir, version) {
+  for (const target of RELEASE_TARGETS) {
+    writeFileSync(
+      path.join(assetsDir, `fennara-cli-${target.platform}-${target.arch}-v${version}.zip`),
+      `cli-${target.key}`,
+    );
+    writeFileSync(
+      path.join(
+        assetsDir,
+        `fennara-release-local-${target.platform}-${target.arch}-v${version}.zip`,
+      ),
+      `local-${target.key}`,
+    );
+  }
+  writeFileSync(
+    path.join(assetsDir, `fennara-release-addon-v${version}.zip`),
+    "addon",
+  );
+}

--- a/scripts/write-release-manifest.mjs
+++ b/scripts/write-release-manifest.mjs
@@ -9,10 +9,17 @@ import {
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseReleaseVersion, validateReleaseIdentity } from "./release-identity.mjs";
+import { minimumCliVersionForTrack } from "./release-policy.mjs";
 import { RELEASE_TARGETS } from "./release-targets.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const DEFAULT_MINIMUM_CLI_VERSION = "0.3.3";
+const ALLOWED_ARGS = new Set([
+  "version",
+  "assets-dir",
+  "out",
+  "linux-cef-manifest",
+  "release-identity",
+]);
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
   printHelp();
   process.exit(0);
@@ -29,14 +36,12 @@ const linuxCefManifestPath = path.resolve(
   root,
   args["linux-cef-manifest"] ?? path.join("local", "webview-runtimes", "linux-cef.json"),
 );
-const minimumCliVersion = args["minimum-cli-version"] ?? DEFAULT_MINIMUM_CLI_VERSION;
 const releaseIdentityPath = path.resolve(
   root,
   args["release-identity"] ?? path.join("godot_demo", "addons", "fennara", "release.json"),
 );
 
 validateVersion(version, "version");
-validateVersion(minimumCliVersion, "minimum CLI version");
 if (!existsSync(assetsDir) || !statSync(assetsDir).isDirectory()) {
   throw new Error(`--assets-dir must be an existing directory: ${assetsDir}`);
 }
@@ -50,6 +55,8 @@ console.log(`Created ${path.relative(root, outPath)}`);
 
 function buildManifest() {
   const release = readReleaseIdentity();
+  const minimumCliVersion = minimumCliVersionForTrack(release.track);
+  validateVersion(minimumCliVersion, `minimum CLI version for ${release.track}`);
   const assets = {
     cli: {},
     local: {},
@@ -206,11 +213,15 @@ function parseArgs(rawArgs) {
     if (!arg.startsWith("--")) {
       throw new Error(`Unexpected argument: ${arg}`);
     }
+    const name = arg.slice(2);
+    if (!ALLOWED_ARGS.has(name)) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
     const value = rawArgs[index + 1];
     if (value === undefined || value.startsWith("--")) {
       throw new Error(`Missing value for ${arg}`);
     }
-    parsed[arg.slice(2)] = value;
+    parsed[name] = value;
     index += 1;
   }
   return parsed;
@@ -230,7 +241,6 @@ Options:
                                    Release local/addon assets must use fennara-release-local-* and fennara-release-addon-* names.
   --linux-cef-manifest <path>      Generated enabled Linux CEF manifest. Default: local/webview-runtimes/linux-cef.json.
   --release-identity <path>        Release identity JSON. Default: godot_demo/addons/fennara/release.json.
-  --minimum-cli-version <semver>   Minimum CLI for schema/primitives. Default: ${DEFAULT_MINIMUM_CLI_VERSION}.
   --out <path>                     Output manifest path. Default: dist/fennara-release-manifest-v<version>.json.
 `);
 }


### PR DESCRIPTION
## Summary

- define stable and staging minimum CLI compatibility in `scripts/release-policy.mjs`
- make the manifest writer select the minimum after validating release identity
- remove minimum CLI values from Package Preview, Release, and Staging workflow YAML
- reject the retired command-line override and test generated manifests for both tracks

## Why

The minimum CLI value had diverged across workflows and a hidden generator fallback. This makes release compatibility a code-owned policy with one source of truth. Stable remains `0.3.11`. Staging remains `0.3.8` because a candidate such as `0.3.11-pr.123.1` is lower than `0.3.11` under SemVer and must be installable during first-run staging validation.

## Validation

- `node scripts/check-version.mjs`
- `node --check scripts/release-policy.mjs`
- `node --check scripts/write-release-manifest.mjs`
- `node --test scripts/tests/*.test.mjs`
- `git diff --check origin/main...HEAD`

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Release manifests now automatically apply the minimum supported CLI version for each release track.
  * Stable, staging, and package preview releases use consistent, centrally managed compatibility rules.
  * Release workflows no longer set minimum CLI versions independently.

* **Documentation**
  * Updated release guidance to clarify CLI compatibility rules and staging requirements.
  * Added documentation for release compatibility policy management.

* **Validation**
  * Improved validation prevents unsupported release tracks and direct manual overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->