### PR TITLE
feat(release): standardize release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,9 +387,10 @@ jobs:
           fi
           mapfile -t desired_assets < <(printf '%s\n' "${assets[@]##*/}" | sort)
 
-          notes="Fennara Godot AI ${tag}
-
-          Built from ${GITHUB_SHA}."
+          short_sha="${GITHUB_SHA:0:7}"
+          released_date="$(date -u +'%d-%m-%Y')"
+          printf -v notes 'Fennara Godot AI %s\nBuilt from [%s](https://github.com/%s/commit/%s).\nReleased: %s' \
+            "${tag}" "${short_sha}" "${GITHUB_REPOSITORY}" "${GITHUB_SHA}" "${released_date}"
           reconcile_draft=false
           resume_published=false
 

--- a/scripts/tests/stable-release-workflow.test.mjs
+++ b/scripts/tests/stable-release-workflow.test.mjs
@@ -33,6 +33,16 @@ test("stable publication safely resumes a matching published release", () => {
   assert.match(publishStep, /for attempt in \{1\.\.12\}[\s\S]*?sleep 5/);
 });
 
+test("stable releases include version, linked source commit, and release date", () => {
+  const publishStep = namedStep(jobBlock(workflow, "publish"), "Publish release");
+  assert.match(publishStep, /short_sha="\$\{GITHUB_SHA:0:7\}"/);
+  assert.match(publishStep, /released_date="\$\(date -u \+'%d-%m-%Y'\)"/);
+  assert.match(
+    publishStep,
+    /Fennara Godot AI %s\\nBuilt from \[%s\]\(https:\/\/github\.com\/%s\/commit\/%s\)\.\\nReleased: %s/,
+  );
+});
+
 test("stable publication does not depend on the retired latest tag or immutability", () => {
   const publishJob = jobBlock(workflow, "publish");
   assert.doesNotMatch(publishJob, /Require immutable GitHub releases/);


### PR DESCRIPTION
## What changed

- Give every new stable GitHub release a consistent three-line default description.
- Show the release version, a linked seven-character source commit, and the UTC release date in `DD-MM-YYYY` format.
- Add a workflow regression test for the generated metadata.

This makes the source and publication date visible without opening the release assets or workflow run.

## Validation

```text
node --test scripts/tests/stable-release-workflow.test.mjs
node --test scripts/tests/*.test.mjs
git diff --check
```

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release notes now include the short commit identifier, release date, and a link to the source commit.

* **Bug Fixes**
  * Improved the stable release workflow to generate consistently formatted release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->