### PR TITLE
fix(chat): keep selected LM Studio models visible

### DIFF
--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -840,15 +840,6 @@
     updateChatSize();
     syncReasoningControls();
     updateComposerEffort();
-    const list = document.querySelector("#model-suggestions");
-    if (list && Array.isArray(settings.text_model_suggestions)) {
-      list.replaceChildren();
-      for (const model of settings.text_model_suggestions) {
-        const option = document.createElement("option");
-        option.value = model;
-        list.append(option);
-      }
-    }
     if (options.refreshModels !== false) {
       requestModelList();
     }

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/generation/cost.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/generation/cost.rs
@@ -88,7 +88,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: "http://127.0.0.1:1234/v1".to_string(),
-            custom_models: Vec::new(),
             local_model_limits: std::collections::BTreeMap::new(),
         };
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/models.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/models.rs
@@ -16,7 +16,6 @@ const LOCAL_MODELS_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) struct ModelCatalog {
     pub(crate) models: Vec<ModelInfo>,
     pub(crate) recommended_ids: Vec<&'static str>,
-    pub(crate) custom_ids: Vec<String>,
     pub(crate) live: bool,
     pub(crate) error: Option<String>,
     pub(crate) catalog_status: CatalogStatus,
@@ -80,7 +79,6 @@ pub(crate) struct ModelInfo {
 
 pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) -> ModelCatalog {
     let recommended_ids = settings::recommended_model_ids();
-    let custom_ids = settings.custom_models.clone();
     catalog_cache::spawn_refresh_if_stale();
     let has_openai_key = auth::has_api_key(ProviderId::OPENAI)
         || std::env::var("OPENAI_API_KEY")
@@ -164,7 +162,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &mut models,
                 &cached_catalog.catalog,
                 &recommended_ids,
-                &custom_ids,
             );
         }
     }
@@ -175,7 +172,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.openai,
                 "OpenAI",
                 ProviderId::OPENAI,
-                &custom_ids,
             );
         }
     }
@@ -186,7 +182,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.anthropic,
                 "Anthropic",
                 ProviderId::ANTHROPIC,
-                &custom_ids,
             );
         }
     }
@@ -197,19 +192,12 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.ollama_cloud,
                 "Ollama Cloud",
                 ProviderId::OLLAMA_CLOUD,
-                &custom_ids,
             );
         }
     }
     if has_zai_key {
         if let Ok(cached_catalog) = &cached_catalog {
-            append_hosted_catalog_models(
-                &mut models,
-                &cached_catalog.zai,
-                "Z.AI",
-                ProviderId::ZAI,
-                &custom_ids,
-            );
+            append_hosted_catalog_models(&mut models, &cached_catalog.zai, "Z.AI", ProviderId::ZAI);
         }
     }
     if has_deepseek_key {
@@ -219,7 +207,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.deepseek,
                 "DeepSeek",
                 ProviderId::DEEPSEEK,
-                &custom_ids,
             );
         }
     }
@@ -230,7 +217,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.moonshot,
                 "Moonshot AI",
                 ProviderId::MOONSHOTAI,
-                &custom_ids,
             );
         }
     }
@@ -241,7 +227,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.moonshot_cn,
                 "Moonshot AI (China)",
                 ProviderId::MOONSHOTAI_CN,
-                &custom_ids,
             );
         }
     }
@@ -252,7 +237,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.kimi_for_coding,
                 "Kimi For Coding",
                 ProviderId::KIMI_FOR_CODING,
-                &custom_ids,
             );
         }
     }
@@ -263,7 +247,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.minimax,
                 "MiniMax (minimax.io)",
                 ProviderId::MINIMAX,
-                &custom_ids,
             );
         }
     }
@@ -274,7 +257,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.minimax_coding_plan,
                 "MiniMax Token Plan (minimax.io)",
                 ProviderId::MINIMAX_CODING_PLAN,
-                &custom_ids,
             );
         }
     }
@@ -285,7 +267,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.minimax_cn,
                 "MiniMax (minimaxi.com)",
                 ProviderId::MINIMAX_CN,
-                &custom_ids,
             );
         }
     }
@@ -296,7 +277,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.minimax_cn_coding_plan,
                 "MiniMax Token Plan (minimaxi.com)",
                 ProviderId::MINIMAX_CN_CODING_PLAN,
-                &custom_ids,
             );
         }
     }
@@ -307,7 +287,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
                 &cached_catalog.nvidia,
                 "NVIDIA",
                 ProviderId::NVIDIA,
-                &custom_ids,
             );
         }
     }
@@ -328,7 +307,7 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
         .unwrap_or_else(|_| Err("Ollama models request timed out.".to_string()));
         let ollama_status = match ollama_result {
             Ok(ollama_models) => {
-                append_ollama_models(&mut models, &ollama_models, &custom_ids);
+                append_ollama_models(&mut models, &ollama_models);
                 OllamaStatus {
                     state: if ollama_models.is_empty() {
                         "empty"
@@ -357,7 +336,7 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
         let lmstudio_status = match lmstudio_result {
             Ok(lmstudio_models) => {
                 let catalog = cached_catalog.as_ref().ok().map(|cached| &cached.lmstudio);
-                append_lmstudio_models(&mut models, &lmstudio_models, catalog, &custom_ids);
+                append_lmstudio_models(&mut models, &lmstudio_models, catalog);
                 LocalProviderStatus {
                     state: if lmstudio_models.is_empty() {
                         "empty"
@@ -415,7 +394,6 @@ pub(crate) async fn list_models(settings: &ChatSettings, refresh_local: bool) ->
     ModelCatalog {
         models,
         recommended_ids,
-        custom_ids,
         live,
         error: if needs_hosted_catalog {
             openrouter_error
@@ -469,7 +447,6 @@ fn append_openrouter_catalog_models(
     models: &mut Vec<ModelInfo>,
     catalog: &OpenRouterCatalog,
     recommended_ids: &[&'static str],
-    custom_ids: &[String],
 ) {
     for model in &catalog.models {
         let id = model.definition.id.as_str();
@@ -477,31 +454,7 @@ fn append_openrouter_catalog_models(
         models.push(openrouter_catalog_model_info(
             model,
             recommended_ids.contains(&prefixed_id.as_str()),
-            custom_ids
-                .iter()
-                .any(|custom| custom == id || custom == &prefixed_id),
         ));
-    }
-    for id in custom_ids
-        .iter()
-        .filter_map(|selection| selection.strip_prefix("openrouter/"))
-    {
-        let prefixed_id = openrouter_model_id(id);
-        if models
-            .iter()
-            .any(|model| model.id == prefixed_id || model.canonical_slug.as_deref() == Some(id))
-        {
-            continue;
-        }
-        let mut model = model_info(
-            &prefixed_id,
-            None,
-            recommended_ids.contains(&prefixed_id.as_str()),
-            true,
-        );
-        model.provider_id = ProviderId::OPENROUTER.to_string();
-        model.provider = "OpenRouter".to_string();
-        models.push(model);
     }
 }
 
@@ -510,16 +463,9 @@ fn append_hosted_catalog_models(
     catalog: &OpenRouterCatalog,
     provider_label: &str,
     provider_id: &str,
-    custom_ids: &[String],
 ) {
     for catalog_model in &catalog.models {
-        let mut model = openrouter_catalog_model_info(
-            catalog_model,
-            false,
-            custom_ids
-                .iter()
-                .any(|custom| custom == &format!("{provider_id}/{}", catalog_model.definition.id)),
-        );
+        let mut model = openrouter_catalog_model_info(catalog_model, false);
         model.id = format!("{provider_id}/{}", catalog_model.definition.id);
         model.provider_id = provider_id.to_string();
         model.provider = provider_label.to_string();
@@ -564,7 +510,6 @@ fn append_custom_provider_models(
 fn openrouter_catalog_model_info(
     catalog_model: &OpenRouterCatalogModel,
     recommended: bool,
-    custom: bool,
 ) -> ModelInfo {
     let definition = &catalog_model.definition;
     let mut modalities = definition
@@ -587,9 +532,9 @@ fn openrouter_catalog_model_info(
         display_name: definition.display_name.clone(),
         provider_id: ProviderId::OPENROUTER.to_string(),
         provider: "OpenRouter".to_string(),
-        source: if custom { "custom" } else { "catalog" },
+        source: "catalog",
         recommended,
-        custom,
+        custom: false,
         verified: true,
         latest_alias: false,
         canonical_slug: Some(definition.id.to_string()),
@@ -636,7 +581,7 @@ async fn fetch_lmstudio_models(base_url: &str) -> Result<Vec<Value>, String> {
     providers::fetch_lmstudio_models(base_url, api_key.as_deref()).await
 }
 
-fn append_ollama_models(models: &mut Vec<ModelInfo>, raw_models: &[Value], custom_ids: &[String]) {
+fn append_ollama_models(models: &mut Vec<ModelInfo>, raw_models: &[Value]) {
     for raw in raw_models {
         let Some(local_id) = raw
             .get("name")
@@ -649,12 +594,7 @@ fn append_ollama_models(models: &mut Vec<ModelInfo>, raw_models: &[Value], custo
         if models.iter().any(|model| model.id == id) {
             continue;
         }
-        models.push(ollama_model_info(
-            &id,
-            Some(raw),
-            custom_ids.iter().any(|custom| custom == &id),
-            true,
-        ));
+        models.push(ollama_model_info(&id, Some(raw), true));
     }
 }
 
@@ -662,7 +602,6 @@ fn append_lmstudio_models(
     models: &mut Vec<ModelInfo>,
     raw_models: &[Value],
     catalog: Option<&OpenRouterCatalog>,
-    custom_ids: &[String],
 ) {
     for raw in raw_models {
         let Some(local_id) = raw
@@ -681,110 +620,11 @@ fn append_lmstudio_models(
             &id,
             Some(raw),
             catalog.and_then(|catalog| catalog.model(local_id)),
-            custom_ids.iter().any(|custom| custom == &id),
         ));
     }
 }
 
-fn model_info(id: &str, raw: Option<&Value>, recommended: bool, custom: bool) -> ModelInfo {
-    let display_name = raw
-        .and_then(|model| model.get("name"))
-        .and_then(Value::as_str)
-        .map(clean_display_name)
-        .unwrap_or_else(|| fallback_display_name(id));
-    let provider = raw
-        .and_then(|model| model.get("name"))
-        .and_then(Value::as_str)
-        .and_then(|name| name.split(':').next())
-        .map(str::trim)
-        .filter(|provider| !provider.is_empty())
-        .map(ToString::to_string)
-        .unwrap_or_else(|| fallback_provider(id));
-    let architecture = raw.and_then(|model| model.get("architecture"));
-    let input_modalities = string_array(
-        architecture
-            .and_then(|value| value.get("input_modalities"))
-            .or_else(|| raw.and_then(|value| value.get("input_modalities"))),
-    );
-    let output_modalities = string_array(
-        architecture
-            .and_then(|value| value.get("output_modalities"))
-            .or_else(|| raw.and_then(|value| value.get("output_modalities"))),
-    );
-    let mut modalities = input_modalities
-        .iter()
-        .map(|modality| format!("in:{modality}"))
-        .chain(
-            output_modalities
-                .iter()
-                .map(|modality| format!("out:{modality}")),
-        )
-        .collect::<Vec<_>>();
-    modalities.sort();
-    modalities.dedup();
-
-    let supported_parameters =
-        string_array(raw.and_then(|model| model.get("supported_parameters")));
-    let reasoning = raw.and_then(|model| model.get("reasoning"));
-    let supported_reasoning_efforts = string_array(
-        reasoning
-            .and_then(|value| value.get("supported_efforts"))
-            .or_else(|| reasoning.and_then(|value| value.get("efforts"))),
-    );
-
-    ModelInfo {
-        id: id.to_string(),
-        display_name,
-        provider_id: fallback_provider_id(id).to_string(),
-        provider,
-        source: if custom { "custom" } else { "recommended" },
-        recommended,
-        custom,
-        verified: raw.is_some_and(model_supports_text_chat),
-        latest_alias: id.starts_with('~') || id.ends_with("-latest"),
-        canonical_slug: raw
-            .and_then(|model| model.get("canonical_slug"))
-            .and_then(Value::as_str)
-            .map(ToString::to_string),
-        context_length: raw
-            .and_then(|model| model.get("context_length"))
-            .and_then(Value::as_u64),
-        max_output_tokens: raw
-            .and_then(|model| model.get("top_provider"))
-            .and_then(|provider| provider.get("max_completion_tokens"))
-            .and_then(Value::as_u64),
-        input_cost_per_million: raw
-            .and_then(|model| model.get("pricing"))
-            .and_then(|pricing| pricing.get("prompt"))
-            .and_then(price_per_million),
-        output_cost_per_million: raw
-            .and_then(|model| model.get("pricing"))
-            .and_then(|pricing| pricing.get("completion"))
-            .and_then(price_per_million),
-        cache_read_cost_per_million: None,
-        cache_write_cost_per_million: None,
-        tokens_per_second: raw
-            .and_then(|model| model.get("top_provider"))
-            .and_then(|provider| provider.get("throughput"))
-            .or_else(|| raw.and_then(|model| model.get("throughput")))
-            .and_then(Value::as_f64),
-        modalities,
-        supports_tools: supported_parameters
-            .iter()
-            .any(|parameter| parameter == "tools" || parameter == "tool_choice"),
-        supports_reasoning: reasoning.is_some()
-            || supported_parameters
-                .iter()
-                .any(|parameter| parameter == "reasoning" || parameter == "include_reasoning"),
-        supported_reasoning_efforts,
-        description: raw
-            .and_then(|model| model.get("description"))
-            .and_then(Value::as_str)
-            .map(|description| description.trim().to_string()),
-    }
-}
-
-fn ollama_model_info(id: &str, raw: Option<&Value>, custom: bool, verified: bool) -> ModelInfo {
+fn ollama_model_info(id: &str, raw: Option<&Value>, verified: bool) -> ModelInfo {
     let local_id = providers::ollama_model_id(id).unwrap_or(id);
     let capabilities = string_array(raw.and_then(|model| model.get("capabilities")));
     let mut modalities = vec!["in:text".to_string(), "out:text".to_string()];
@@ -796,9 +636,9 @@ fn ollama_model_info(id: &str, raw: Option<&Value>, custom: bool, verified: bool
         display_name: fallback_display_name(local_id),
         provider_id: ProviderId::OLLAMA.to_string(),
         provider: "Ollama".to_string(),
-        source: if custom { "custom" } else { "local" },
+        source: "local",
         recommended: false,
-        custom,
+        custom: false,
         verified,
         latest_alias: false,
         canonical_slug: raw
@@ -826,11 +666,10 @@ fn lmstudio_model_info(
     id: &str,
     raw: Option<&Value>,
     catalog_model: Option<&OpenRouterCatalogModel>,
-    custom: bool,
 ) -> ModelInfo {
     let local_id = providers::lmstudio_model_id(id).unwrap_or(id);
     if let Some(catalog_model) = catalog_model {
-        let mut model = openrouter_catalog_model_info(catalog_model, false, custom);
+        let mut model = openrouter_catalog_model_info(catalog_model, false);
         model.id = id.to_string();
         model.provider_id = ProviderId::LMSTUDIO.to_string();
         model.provider = "LM Studio".to_string();
@@ -861,9 +700,9 @@ fn lmstudio_model_info(
             .unwrap_or_else(|| fallback_display_name(local_id)),
         provider_id: ProviderId::LMSTUDIO.to_string(),
         provider: "LM Studio".to_string(),
-        source: if custom { "custom" } else { "local" },
+        source: "local",
         recommended: false,
-        custom,
+        custom: false,
         verified: true,
         latest_alias: false,
         canonical_slug: Some(local_id.to_string()),
@@ -934,13 +773,6 @@ pub(crate) fn model_supports_image_chat(model: &Value) -> bool {
             .is_some_and(|modality| modality.to_ascii_lowercase().contains("image"))
 }
 
-fn clean_display_name(name: &str) -> String {
-    name.split_once(':')
-        .map(|(_, display)| display.trim())
-        .unwrap_or(name.trim())
-        .to_string()
-}
-
 fn fallback_display_name(id: &str) -> String {
     id.trim_start_matches('~')
         .split('/')
@@ -948,82 +780,6 @@ fn fallback_display_name(id: &str) -> String {
         .unwrap_or(id)
         .replace('-', " ")
         .replace("latest", "Latest")
-}
-
-fn fallback_provider(id: &str) -> String {
-    let provider = id
-        .trim_start_matches('~')
-        .split('/')
-        .next()
-        .unwrap_or("OpenRouter");
-    match provider {
-        "openai" => "OpenAI".to_string(),
-        "anthropic" => "Anthropic".to_string(),
-        "z-ai" => "Z.ai".to_string(),
-        "x-ai" => "xAI".to_string(),
-        "moonshotai" => "Moonshot AI".to_string(),
-        "moonshotai-cn" => "Moonshot AI (China)".to_string(),
-        "kimi-for-coding" => "Kimi For Coding".to_string(),
-        "minimax" => "MiniMax (minimax.io)".to_string(),
-        "minimax-coding-plan" => "MiniMax Token Plan (minimax.io)".to_string(),
-        "minimax-cn" => "MiniMax (minimaxi.com)".to_string(),
-        "minimax-cn-coding-plan" => "MiniMax Token Plan (minimaxi.com)".to_string(),
-        "nvidia" => "NVIDIA".to_string(),
-        other => {
-            let mut chars = other.chars();
-            match chars.next() {
-                Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
-                None => "OpenRouter".to_string(),
-            }
-        }
-    }
-}
-
-fn fallback_provider_id(id: &str) -> &'static str {
-    if id.starts_with("ollama/") {
-        ProviderId::OLLAMA
-    } else if id.starts_with("openai/") {
-        ProviderId::OPENAI
-    } else if id.starts_with("anthropic/") {
-        ProviderId::ANTHROPIC
-    } else if id.starts_with("ollama-cloud/") {
-        ProviderId::OLLAMA_CLOUD
-    } else if id.starts_with("lmstudio/") {
-        ProviderId::LMSTUDIO
-    } else if id.starts_with("deepseek/") {
-        ProviderId::DEEPSEEK
-    } else if id.starts_with("zai/") {
-        ProviderId::ZAI
-    } else if id.starts_with("moonshotai-cn/") {
-        ProviderId::MOONSHOTAI_CN
-    } else if id.starts_with("moonshotai/") {
-        ProviderId::MOONSHOTAI
-    } else if id.starts_with("kimi-for-coding/") {
-        ProviderId::KIMI_FOR_CODING
-    } else if id.starts_with("minimax-cn-coding-plan/") {
-        ProviderId::MINIMAX_CN_CODING_PLAN
-    } else if id.starts_with("minimax-coding-plan/") {
-        ProviderId::MINIMAX_CODING_PLAN
-    } else if id.starts_with("minimax-cn/") {
-        ProviderId::MINIMAX_CN
-    } else if id.starts_with("minimax/") {
-        ProviderId::MINIMAX
-    } else if id.starts_with("nvidia/") {
-        ProviderId::NVIDIA
-    } else {
-        ProviderId::OPENROUTER
-    }
-}
-
-fn price_per_million(value: &Value) -> Option<f64> {
-    let price = value
-        .as_str()
-        .and_then(|raw| raw.parse::<f64>().ok())
-        .or_else(|| value.as_f64())?;
-    if price < 0.0 {
-        return None;
-    }
-    Some(price * 1_000_000.0)
 }
 
 fn string_array(value: Option<&Value>) -> Vec<String> {
@@ -1073,15 +829,8 @@ mod tests {
         }"#;
         let catalog = parse_moonshot_catalog(raw).unwrap();
         let mut models = Vec::new();
-        let custom_ids = Vec::new();
 
-        append_hosted_catalog_models(
-            &mut models,
-            &catalog,
-            "Moonshot AI",
-            ProviderId::MOONSHOTAI,
-            &custom_ids,
-        );
+        append_hosted_catalog_models(&mut models, &catalog, "Moonshot AI", ProviderId::MOONSHOTAI);
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "moonshotai/kimi-k2.7-code");
@@ -1111,14 +860,12 @@ mod tests {
         }"#;
         let catalog = super::super::providers::models_dev::parse_minimax_catalog(raw).unwrap();
         let mut models = Vec::new();
-        let custom_ids = Vec::new();
 
         append_hosted_catalog_models(
             &mut models,
             &catalog,
             "MiniMax (minimax.io)",
             ProviderId::MINIMAX,
-            &custom_ids,
         );
 
         assert_eq!(models.len(), 1);
@@ -1148,15 +895,8 @@ mod tests {
         }"#;
         let catalog = parse_nvidia_catalog(raw).unwrap();
         let mut models = Vec::new();
-        let custom_ids = Vec::new();
 
-        append_hosted_catalog_models(
-            &mut models,
-            &catalog,
-            "NVIDIA",
-            ProviderId::NVIDIA,
-            &custom_ids,
-        );
+        append_hosted_catalog_models(&mut models, &catalog, "NVIDIA", ProviderId::NVIDIA);
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "nvidia/meta/llama-3.3-70b-instruct");
@@ -1209,9 +949,39 @@ mod tests {
             "capabilities": ["completion", "tools"]
         });
 
-        let model = ollama_model_info("ollama/gemma4", Some(&raw), false, true);
+        let model = ollama_model_info("ollama/gemma4", Some(&raw), true);
 
         assert_eq!(model.context_length, Some(4096));
+    }
+
+    #[test]
+    fn selected_uncatalogued_lmstudio_model_remains_local() {
+        let settings: ChatSettings = serde_json::from_value(json!({
+            "model": "lmstudio/qwen/qwen3.6-27b",
+            "custom_models": ["lmstudio/qwen/qwen3.6-27b"]
+        }))
+        .unwrap();
+        let raw = json!({
+            "type": "llm",
+            "key": "qwen/qwen3.6-27b",
+            "display_name": "Qwen3.6 27B",
+            "loaded_instances": [],
+            "max_context_length": 262144
+        });
+        let mut models = Vec::new();
+
+        append_lmstudio_models(&mut models, &[raw], None);
+
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, settings.model);
+        assert_eq!(models[0].source, "local");
+        assert!(!models[0].custom);
+        assert!(
+            serde_json::to_value(settings)
+                .unwrap()
+                .get("custom_models")
+                .is_none()
+        );
     }
 
     #[test]
@@ -1232,7 +1002,7 @@ mod tests {
         });
         let mut models = Vec::new();
 
-        append_lmstudio_models(&mut models, &[raw], None, &[]);
+        append_lmstudio_models(&mut models, &[raw], None);
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].id, "lmstudio/google/gemma-4-26b-a4b");
@@ -1250,7 +1020,7 @@ mod tests {
         });
         let mut models = Vec::new();
 
-        append_lmstudio_models(&mut models, &[raw], None, &[]);
+        append_lmstudio_models(&mut models, &[raw], None);
 
         assert_eq!(models.len(), 1);
         assert_eq!(models[0].context_length, Some(131072));

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/capability_check.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/capability_check.rs
@@ -83,7 +83,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: "http://127.0.0.1:1234/v1".to_string(),
-            custom_models: Vec::new(),
             local_model_limits: std::collections::BTreeMap::new(),
         };
         let catalog = Catalog::from_settings(&settings);

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/catalog.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/catalog.rs
@@ -220,11 +220,6 @@ impl Catalog {
         catalog.insert_hosted_catalog(hosted_minimax_cn);
         catalog.insert_hosted_catalog(hosted_minimax_cn_coding_plan);
         catalog.insert_hosted_catalog(hosted_nvidia);
-        for model in &settings.custom_models {
-            if let Ok(model_ref) = model_ref_from_selection(model, &catalog) {
-                catalog.ensure_model_for_ref(&model_ref);
-            }
-        }
         catalog.default_model = Some(ModelRef::new(
             ProviderId::unchecked(ProviderId::OPENROUTER),
             ModelId::new(settings::DEFAULT_OPENROUTER_MODEL_ID).expect("default model id is valid"),
@@ -299,16 +294,6 @@ impl Catalog {
                 self.insert_model(model.definition.clone());
             }
         }
-    }
-
-    fn ensure_model_for_ref(&mut self, model_ref: &ModelRef) {
-        if self
-            .models
-            .contains_key(&(model_ref.provider.clone(), model_ref.model.clone()))
-        {
-            return;
-        }
-        self.insert_model(dynamic_model(&model_ref.provider, &model_ref.model));
     }
 }
 
@@ -426,7 +411,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: lmstudio::DEFAULT_BASE_URL.to_string(),
-            custom_models: Vec::new(),
             local_model_limits: BTreeMap::new(),
         }
     }
@@ -561,7 +545,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: lmstudio::DEFAULT_BASE_URL.to_string(),
-            custom_models: Vec::new(),
             local_model_limits,
         });
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/context.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/context.rs
@@ -221,7 +221,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: "http://127.0.0.1:1234/v1".to_string(),
-            custom_models: Vec::new(),
             local_model_limits: std::collections::BTreeMap::new(),
         };
         let catalog = Catalog::from_settings(&settings);
@@ -267,7 +266,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: "http://127.0.0.1:1234/v1".to_string(),
-            custom_models: Vec::new(),
             local_model_limits: std::collections::BTreeMap::new(),
         };
         let request = LlmRequest::from_chat(
@@ -326,7 +324,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: "http://127.0.0.1:1234/v1".to_string(),
-            custom_models: Vec::new(),
             local_model_limits: std::collections::BTreeMap::new(),
         };
         let catalog = Catalog::from_settings(&settings);
@@ -390,7 +387,6 @@ mod tests {
             custom_providers: Vec::new(),
             ollama_base_url: "http://127.0.0.1:11434".to_string(),
             lmstudio_base_url: "http://127.0.0.1:1234/v1".to_string(),
-            custom_models: Vec::new(),
             local_model_limits: std::collections::BTreeMap::new(),
         };
         let catalog = Catalog::from_settings(&settings);

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/mod.rs
@@ -113,7 +113,6 @@ pub(crate) fn settings_from_chat(settings: &ChatSettings) -> ProviderSettings {
         ollama_base_url: settings.ollama_base_url.clone(),
         lmstudio_base_url: settings
             .provider_base_url(types::ProviderId::LMSTUDIO, lmstudio::DEFAULT_BASE_URL),
-        custom_models: settings.custom_models.clone(),
         local_model_limits: local_model_limits_from_settings(&settings.local_model_context_lengths),
     }
 }
@@ -879,7 +878,6 @@ pub(crate) fn parse_model_ref(model: &str) -> Result<String, LlmError> {
         custom_providers: Vec::new(),
         ollama_base_url: super::settings::DEFAULT_OLLAMA_BASE_URL.to_string(),
         lmstudio_base_url: lmstudio::DEFAULT_BASE_URL.to_string(),
-        custom_models: Vec::new(),
         local_model_limits: BTreeMap::new(),
     });
     catalog::model_ref_from_selection(model, &catalog).map(|model_ref| model_ref.canonical())

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/types.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/providers/types.rs
@@ -294,7 +294,6 @@ pub(crate) struct ProviderSettings {
     pub(crate) custom_providers: Vec<CustomProviderRuntime>,
     pub(crate) ollama_base_url: String,
     pub(crate) lmstudio_base_url: String,
-    pub(crate) custom_models: Vec<String>,
     pub(crate) local_model_limits: BTreeMap<String, Limits>,
 }
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
@@ -42,8 +42,6 @@ pub(crate) struct ChatSettings {
     #[serde(default = "default_reasoning_effort")]
     pub(crate) reasoning_effort: String,
     #[serde(default)]
-    pub(crate) custom_models: Vec<String>,
-    #[serde(default)]
     pub(crate) custom_providers: Vec<CustomProviderConfig>,
     #[serde(default)]
     pub(crate) local_model_context_lengths: BTreeMap<String, u32>,
@@ -64,8 +62,6 @@ pub(crate) struct PublicChatSettings {
     pub(crate) default_model: &'static str,
     pub(crate) reasoning_effort: String,
     pub(crate) reasoning_effort_options: Vec<&'static str>,
-    pub(crate) text_model_suggestions: Vec<String>,
-    pub(crate) custom_models: Vec<String>,
     pub(crate) local_model_context_lengths: BTreeMap<String, u32>,
     pub(crate) chat_surface: String,
     pub(crate) approval_mode: String,
@@ -80,7 +76,6 @@ impl Default for ChatSettings {
             provider_base_urls: default_provider_base_urls(),
             model: DEFAULT_MODEL.to_string(),
             reasoning_effort: DEFAULT_REASONING_EFFORT.to_string(),
-            custom_models: Vec::new(),
             custom_providers: Vec::new(),
             local_model_context_lengths: BTreeMap::new(),
             chat_surface: DEFAULT_CHAT_SURFACE.to_string(),
@@ -104,12 +99,6 @@ impl ChatSettings {
             default_model: DEFAULT_MODEL,
             reasoning_effort: clean_reasoning_effort(&self.reasoning_effort).to_string(),
             reasoning_effort_options: vec!["low", DEFAULT_REASONING_EFFORT, "high"],
-            text_model_suggestions: suggestion_models(
-                &self.custom_models,
-                &self.custom_providers,
-                has_openrouter_key,
-            ),
-            custom_models: self.custom_models.clone(),
             local_model_context_lengths: self.local_model_context_lengths.clone(),
             chat_surface: clean_chat_surface(&self.chat_surface).to_string(),
             approval_mode: self.approval_mode.as_str().to_string(),
@@ -130,44 +119,6 @@ pub(crate) fn recommended_model_ids() -> Vec<&'static str> {
         "deepseek/deepseek-v4-pro",
         "openrouter/z-ai/glm-5.2",
     ]
-}
-
-fn suggestion_models(
-    custom_models: &[String],
-    custom_providers: &[CustomProviderConfig],
-    has_openrouter_key: bool,
-) -> Vec<String> {
-    let mut models = if has_openrouter_key {
-        recommended_model_ids()
-            .into_iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-    } else {
-        Vec::new()
-    };
-    for model in custom_models {
-        if !has_openrouter_key
-            && !model.starts_with("openai/")
-            && !model.starts_with("anthropic/")
-            && !model.starts_with("ollama/")
-            && !model.starts_with("lmstudio/")
-            && !model.starts_with("moonshotai/")
-            && !model.starts_with("moonshotai-cn/")
-            && !model.starts_with("kimi-for-coding/")
-            && !model.starts_with("minimax/")
-            && !model.starts_with("minimax-coding-plan/")
-            && !model.starts_with("minimax-cn/")
-            && !model.starts_with("minimax-cn-coding-plan/")
-            && !model.starts_with("nvidia/")
-            && custom::split_model_selection(custom_providers, model).is_none()
-        {
-            continue;
-        }
-        if !models.iter().any(|existing| existing == model) {
-            models.push(model.clone());
-        }
-    }
-    models
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -229,13 +180,6 @@ fn load_settings_unlocked() -> (ChatSettings, bool) {
         ProviderId::OLLAMA.to_string(),
         settings.ollama_base_url.clone(),
     );
-    let clean_custom_models = clean_model_list(&settings.custom_models);
-    let migrated_custom_models = clean_custom_models
-        .iter()
-        .map(|model| migrate_legacy_openrouter_selection(model, &settings.custom_providers))
-        .collect::<Vec<_>>();
-    settings.custom_models = clean_model_list(&migrated_custom_models);
-    let custom_models_migrated = settings.custom_models != clean_custom_models;
     settings.local_model_context_lengths =
         clean_local_model_context_lengths(&settings.local_model_context_lengths);
     settings.chat_surface = clean_chat_surface(&settings.chat_surface).to_string();
@@ -244,10 +188,7 @@ fn load_settings_unlocked() -> (ChatSettings, bool) {
         auth::migrate_legacy_api_key(ProviderId::OPENROUTER, legacy_openrouter_key);
     }
     if !custom_headers_migration_failed
-        && (had_legacy_openrouter_key
-            || model_migrated
-            || custom_models_migrated
-            || custom_headers_migrated)
+        && (had_legacy_openrouter_key || model_migrated || custom_headers_migrated)
     {
         if write_settings_file(&settings).is_ok() && custom_headers_migrated {
             let _ = fs::remove_file(previous);
@@ -379,7 +320,6 @@ pub(crate) fn save_settings(update: SaveSettingsRequest) -> Result<ChatSettings,
     }
     if let Some(model) = update.model {
         settings.model = clean_model(&model).unwrap_or_else(|| DEFAULT_MODEL.to_string());
-        remember_custom_model(&mut settings.custom_models, &settings.model);
     }
     if let Some(reasoning_effort) = update.reasoning_effort {
         settings.reasoning_effort = clean_reasoning_effort(&reasoning_effort).to_string();
@@ -514,25 +454,6 @@ fn replace_settings_file(temp: &Path, path: &Path) -> Result<(), String> {
     }
 }
 
-fn remember_custom_model(custom_models: &mut Vec<String>, model: &str) {
-    if recommended_model_ids()
-        .into_iter()
-        .any(|recommended| recommended == model)
-    {
-        return;
-    }
-    if model == DEFAULT_MODEL || model == "openrouter/auto" {
-        return;
-    }
-    if !model.contains('/') {
-        return;
-    }
-    if !custom_models.iter().any(|existing| existing == model) {
-        custom_models.push(model.to_string());
-    }
-    *custom_models = clean_model_list(custom_models);
-}
-
 fn reconcile_custom_provider_models(settings: &mut ChatSettings, provider: &CustomProviderConfig) {
     let prefix = format!("{}/", provider.id);
     let is_configured = |selection: &str| {
@@ -541,31 +462,9 @@ fn reconcile_custom_provider_models(settings: &mut ChatSettings, provider: &Cust
             .is_some_and(|model_id| provider.models.iter().any(|model| model.id == model_id))
     };
 
-    settings
-        .custom_models
-        .retain(|selection| !selection.starts_with(&prefix) || is_configured(selection));
-
     if settings.model.starts_with(&prefix) && !is_configured(&settings.model) {
-        let replacement = format!("{prefix}{}", provider.models[0].id);
-        settings.model = replacement.clone();
-        remember_custom_model(&mut settings.custom_models, &replacement);
+        settings.model = format!("{prefix}{}", provider.models[0].id);
     }
-}
-
-fn clean_model_list(models: &[String]) -> Vec<String> {
-    let mut clean = Vec::new();
-    for model in models {
-        let Some(model) = clean_model(model) else {
-            continue;
-        };
-        if !model.contains('/') {
-            continue;
-        }
-        if !clean.iter().any(|existing| existing == &model) {
-            clean.push(model);
-        }
-    }
-    clean
 }
 
 // Legacy compatibility only. New selections must always include their provider prefix.

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings/tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings/tests.rs
@@ -12,10 +12,6 @@ use crate::runtime_daemon::chat::providers::custom::{CustomProviderConfig, Custo
 fn provider_edit_replaces_a_removed_selected_model() {
     let mut settings = ChatSettings {
         model: "omniroute/removed/model".to_string(),
-        custom_models: vec![
-            "omniroute/removed/model".to_string(),
-            "openai/gpt-5.5".to_string(),
-        ],
         ..ChatSettings::default()
     };
     let provider = CustomProviderConfig {
@@ -34,10 +30,6 @@ fn provider_edit_replaces_a_removed_selected_model() {
     reconcile_custom_provider_models(&mut settings, &provider);
 
     assert_eq!(settings.model, "omniroute/replacement/model");
-    assert_eq!(
-        settings.custom_models,
-        vec!["openai/gpt-5.5", "omniroute/replacement/model"]
-    );
 }
 
 #[test]

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -840,15 +840,6 @@
     updateChatSize();
     syncReasoningControls();
     updateComposerEffort();
-    const list = document.querySelector("#model-suggestions");
-    if (list && Array.isArray(settings.text_model_suggestions)) {
-      list.replaceChildren();
-      for (const model of settings.text_model_suggestions) {
-        const option = document.createElement("option");
-        option.value = model;
-        list.append(option);
-      }
-    }
     if (options.refreshModels !== false) {
       requestModelList();
     }


### PR DESCRIPTION
## What changed

- removed the obsolete `custom_models` settings and provider-catalog state
- kept custom provider models sourced from their saved provider configuration
- made LM Studio and Ollama discovery always produce local models
- removed the unused model suggestion payload and matching UI code
- added regression coverage for a previously selected, uncatalogued `qwen/qwen3.6-27b` model

## Why

Selecting a non-recommended LM Studio model stored its ID in `custom_models`. On the next refresh, that remembered state changed the model source from `local` to `custom`, so the picker filtered it out even while LM Studio continued returning it.

Local models now derive their availability only from live local discovery. Existing settings containing the removed field remain readable, and the field is omitted on the next settings save.

Closes #125

## Validation

- `cargo test -p fennara-daemon`
- `$testFiles = Get-ChildItem -LiteralPath scripts/tests -Filter *.test.mjs | ForEach-Object { $_.FullName }; node --test $testFiles`
- `node --check ui/chat/app.js`
- `node --check godot_demo/addons/fennara/dist/app.js`
- `git diff --check origin/main`

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified model catalog handling by removing legacy custom-model tracking.
  * Local Ollama and LM Studio models are now consistently identified as local models.
  * Catalog models are consistently identified as catalog-provided models.
  * Added clearer handling for uncatalogued LM Studio models.
  * Removed outdated model suggestions from chat settings and the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->