### PR TITLE
feat(daemon): add anonymous usage telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Fennara exposes a small set of Godot-aware tools:
 
 The goal is not to replace an agent's normal file tools. Fennara gives the missing Godot feedback loop.
 
+## Privacy
+
+Fennara sends one anonymous active-installation event at most once per UTC day
+after Godot connects. It contains a random installation UUID, Fennara and Godot
+versions, operating system, and CPU architecture. It does not contain project
+data, paths, prompts, tool activity, logs, screenshots, or account information.
+
+Telemetry can be disabled in **Chat Settings > Chat > Anonymous telemetry** or
+with `FENNARA_DISABLE_TELEMETRY=true`. See [Anonymous
+Telemetry](docs/telemetry.md) for the complete payload, storage, transport, and
+opt-out contract.
+
 ## Demos
 
 Watch a hands-on Fennara walkthrough:
@@ -194,6 +206,7 @@ See [Demos](docs/demos.md) for more videos from the Fennara channel.
 | [Chat providers](docs/providers.md) | Built-in chat models and keys |
 | [MCP setup](docs/mcp-setup.md) | Codex, Claude, Cursor, and other MCP apps |
 | [Tools](docs/tools.md) | The Godot feedback available to agents |
+| [Anonymous telemetry](docs/telemetry.md) | Data collected, delivery behavior, and opt-out controls |
 | [Contributing](CONTRIBUTING.md) | Development and pull request guidance |
 
 ## Community

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ after Godot connects. It contains a random installation UUID, Fennara and Godot
 versions, operating system, and CPU architecture. It does not contain project
 data, paths, prompts, tool activity, logs, screenshots, or account information.
 
-Telemetry can be disabled in **Chat Settings > Chat > Anonymous telemetry** or
-with `FENNARA_DISABLE_TELEMETRY=true`. See [Anonymous
+Telemetry can be disabled in **Chat Settings > Chat > Anonymous telemetry**,
+with `FENNARA_DISABLE_TELEMETRY=true`, or with `DO_NOT_TRACK=1`. See [Anonymous
 Telemetry](docs/telemetry.md) for the complete payload, storage, transport, and
 opt-out contract.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ and keeps advanced details lower on the page.
 | [Slash commands](slash-commands.md) | `/provider` and `/model` in the chat dock |
 | [FAQ](faq.md) | Short answers to common questions |
 | [Demos](demos.md) | Videos and project walkthroughs |
+| [Anonymous telemetry](telemetry.md) | Data collected, delivery behavior, and opt-out controls |
 
 ## Reference And Recovery
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,6 +132,24 @@ not captured by default. The daemon exposes a small local debug read endpoint at
 `/chat/traces` for filtering by `chat_id`, `trace_id`, `turn_id`, or
 `generation_id`.
 
+## Anonymous Telemetry
+
+After a real Godot editor connection, the daemon can enqueue one anonymous
+active-installation event per UTC day. The bounded queue and background HTTP
+worker are separate from tool execution, chat generation, and the Godot bridge,
+so telemetry cannot delay or fail a user operation.
+
+The daemon persists one random installation UUID and the last accepted UTC day
+under `Fennara/telemetry/state.json`. The event contains only that UUID, the
+Fennara and numeric Godot versions, platform, and CPU architecture. The
+`fennara.io` receiver validates the exact payload and converts the UUID to a
+server-side HMAC before forwarding a personless event to PostHog.
+
+The saved Chat Settings preference is enabled by default. The UI can disable it,
+and `FENNARA_DISABLE_TELEMETRY` or `DO_NOT_TRACK` can enforce an environment
+override. Disabling deletes the local telemetry state. See
+[Anonymous Telemetry](telemetry.md) for the complete privacy contract.
+
 ## Install Layout
 
 For the manually copied release-addon flow, the GDExtension first presents a native
@@ -182,6 +200,8 @@ Fennara/
     fennara-daemon
   daemon-control-token
   current.json
+  telemetry/
+    state.json
   versions/
     <version>/
       fennara-mcp-runtime

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -36,6 +36,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `docs/README.md` | Task-oriented documentation index. |
 | `docs/setup.md` | User-facing addon-first setup, chat prerequisites, MCP connection, update flow, and troubleshooting. |
 | `docs/cli.md` | Terminal command reference, CLI-owned install/update behavior, recovery, diagnostics, app-data layout, and automation guidance. |
+| `docs/telemetry.md` | Anonymous activity payload, app-data state, delivery behavior, monthly-active definition, and opt-out controls. |
 | `CONTRIBUTING.md` | Contribution rules. |
 | `SECURITY.md` | Security reporting policy. |
 | `LICENSE.md` | Project license. |
@@ -58,6 +59,8 @@ This is the quick map for contributors and coding agents working in this reposit
 | `local/crates/fennara-cli/src/diagnostics.rs` | User-facing access to the latest or a named sanitized operation report. |
 | `local/crates/fennara-mcp/` | Local stdio MCP server and tool schema forwarding. |
 | `local/crates/fennara-daemon/` | Local daemon used for runtime sessions and Godot bridge work. |
+| `local/crates/fennara-daemon/src/runtime_daemon/telemetry.rs` | Anonymous daily-active scheduler, bounded queue, HTTP delivery, and daemon lifecycle integration. |
+| `local/crates/fennara-daemon/src/runtime_daemon/telemetry/state.rs` | Random installation identity validation, atomic app-data persistence, daily receipt state, and opt-out cleanup. |
 | `local/crates/fennara-daemon/src/runtime_daemon/permissions.rs` | Built-in chat approval modes, tool-risk classification, permission decisions, and pending approval request types. |
 | `local/crates/fennara-daemon/src/runtime_daemon/chat/exec_command.rs` | Daemon-owned built-in chat `exec_command` implementation: shell detection, cwd validation, process spawn, timeout/tree-kill, output capture, result artifact logging, and result formatting. |
 | `local/crates/fennara-daemon/src/runtime_daemon/chat/context_compaction/` | Built-in chat context compaction planner: exact-tail protection, OpenCode-style old tool-result pressure pruning, summary chunk selection/storage/replay, summary prompt serialization, token budgets, and placeholder rendering. |
@@ -174,6 +177,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | Change `runtime_script` ctx helpers, input, snapshots, waits, raycasts, captures, or cleanup | `runtime/`, `scripts/sync-runtime.mjs`, `godot_demo/addons/fennara/runtime/`, `local/schemas/tools/runtime_script.json`, and `docs/tools.md` |
 | Change in-editor chat UI, slash commands, or model/provider picker | `ui/chat/`, `godot_demo/addons/fennara/dist/`, `fennara-cpp/src/ui/dock.cpp`, and `fennara-cpp/src/ui/webview_host*` |
 | Change built-in chat providers | `local/crates/fennara-daemon/src/runtime_daemon/chat/providers/`, `local/crates/fennara-daemon/src/runtime_daemon/chat/models.rs`, `local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs`, and `ui/chat/` |
+| Change anonymous telemetry fields, scheduling, or privacy controls | `local/crates/fennara-daemon/src/runtime_daemon/telemetry.rs`, `local/crates/fennara-daemon/src/runtime_daemon/telemetry/`, `local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs`, `ui/chat/`, and `docs/telemetry.md` |
 | Change vendored chat UI libraries | `ui/chat/vendor/`, `godot_demo/addons/fennara/dist/vendor/`, and `THIRD_PARTY_NOTICES.md` |
 | Change C# support | `fennara-cpp/src/csharp/`, `fennara-cpp/include/fennara/csharp/`, and the C# tool schemas and guidance |
 | Change release packages, minimum CLI policy, or CLI self-update | `local/crates/fennara-cli/src/release_manifest.rs`, `local/crates/fennara-cli/src/release_client.rs`, `local/crates/fennara-cli/src/release_package.rs`, `local/crates/fennara-cli/src/self_update.rs`, `scripts/package-preview.mjs`, `scripts/release-policy.mjs`, `scripts/write-release-manifest.mjs`, and `.github/workflows/release.yml` |

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,79 @@
+# Anonymous Telemetry
+
+Fennara sends one small anonymous activity event at most once per UTC day. The
+event is sent only after a compatible Godot editor connects to the local daemon.
+It helps maintainers measure active installations, supported platform usage, and
+version adoption.
+
+Telemetry is enabled by default. Open **Chat Settings > Chat > Anonymous
+telemetry** to disable it. Headless and automated environments can set either:
+
+```text
+FENNARA_DISABLE_TELEMETRY=true
+DO_NOT_TRACK=1
+```
+
+An environment variable takes precedence over the saved UI preference. Turning
+telemetry off stops future events and deletes the local telemetry identity and
+last-send state. Turning it on again creates a new random identity when Godot
+next connects.
+
+## Event contents
+
+The `fennara_active_installation` event contains only:
+
+| Field | Purpose |
+| --- | --- |
+| `schema_version` | Version of the small telemetry payload contract |
+| `event` | Fixed event name |
+| `installation_id` | Random UUID generated locally, not derived from hardware or accounts |
+| `fennara_version` | Running daemon version |
+| `godot_version` | Numeric Godot version, such as `4.6.3` |
+| `platform` | `windows`, `macos`, or `linux` |
+| `architecture` | `x86_64` or `aarch64` |
+
+Fennara does not send project names, project paths, account information, prompts,
+chat messages, provider keys, model names, tool names, tool arguments, tool
+results, logs, screenshots, scene contents, filenames, or error text.
+
+## Storage and transport
+
+The daemon stores its random identity and last successful UTC day under the
+shared Fennara app-data directory:
+
+```text
+Fennara/
+  telemetry/
+    state.json
+```
+
+The daemon sends the event over HTTPS to
+`https://fennara.io/api/telemetry`. The receiver validates an exact field
+allowlist and replaces the raw installation UUID with a server-side HMAC before
+forwarding the event to PostHog. PostHog person profiles and IP geolocation are
+disabled for this event.
+
+The Vercel receiver necessarily observes normal network metadata while handling
+the HTTPS request. That metadata is not copied into the PostHog event payload.
+
+## Delivery behavior
+
+Telemetry runs outside Godot tool-call paths:
+
+- A bounded queue accepts activity signals without waiting.
+- One background worker reuses a single HTTP client.
+- Requests have a short timeout.
+- A full queue, filesystem problem, network failure, or server rejection is
+  silently tolerated and never fails a Fennara tool.
+- The UTC day is recorded only after the server accepts an event, so a later
+  Godot connection can retry a failed delivery.
+- Shutdown waits briefly, then cancels the telemetry worker instead of delaying
+  the daemon.
+
+One installation is one persisted random UUID. Using Fennara on two computers
+counts as two installations. Clearing Fennara app data or disabling and later
+re-enabling telemetry creates a new identity.
+
+Monthly active installations are counted as distinct anonymous installation
+identities that sent at least one `fennara_active_installation` event during the
+calendar month.

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -440,18 +440,24 @@
       connect,
       appendSystem,
       clearSystemStatus,
-      buildSavePayload: ({ chatSurface, approvalMode, telemetryEnabled: nextTelemetryEnabled }) => ({
-        type: "save_settings",
-        request_id: nextRequestId("save-settings"),
-        model: cleanUiModelId(modelInput?.value || currentModel),
-        reasoning_effort: currentReasoningEffort,
-        ollama_base_url: ollamaBaseUrl,
-        provider_base_urls: providerBaseUrlPayload(),
-        local_model_context_lengths: localModelContextLengthPayload(),
-        chat_surface: chatSurface,
-        approval_mode: approvalMode,
-        telemetry_enabled: nextTelemetryEnabled,
-      }),
+      buildSavePayload: ({ chatSurface, approvalMode, telemetryEnabled: nextTelemetryEnabled }) => {
+        const payload = {
+          type: "save_settings",
+          request_id: nextRequestId("save-settings"),
+          model: cleanUiModelId(modelInput?.value || currentModel),
+          reasoning_effort: currentReasoningEffort,
+          ollama_base_url: ollamaBaseUrl,
+          provider_base_urls: providerBaseUrlPayload(),
+          local_model_context_lengths: localModelContextLengthPayload(),
+          chat_surface: chatSurface,
+          approval_mode: approvalMode,
+        };
+        return window.FennaraSettingsPanel.includeTelemetryPreference(
+          payload,
+          nextTelemetryEnabled,
+          telemetryControlledByEnvironment,
+        );
+      },
     },
     constants: {
       savedNoticeMs: SETTINGS_SAVED_NOTICE_MS,

--- a/godot_demo/addons/fennara/dist/app.js
+++ b/godot_demo/addons/fennara/dist/app.js
@@ -56,6 +56,8 @@
   const chatSurfaceBrowserInput = document.querySelector("[data-chat-surface-browser]");
   const chatSurfaceRestartStatus = document.querySelector("[data-chat-surface-restart]");
   const approvalModeControls = document.querySelectorAll("[data-approval-mode]");
+  const telemetryEnabledInput = document.querySelector("[data-telemetry-enabled]");
+  const telemetryEnvironmentStatus = document.querySelector("[data-telemetry-environment-status]");
   const settingsSavedToast = document.querySelector("[data-settings-saved-toast]");
   const openSettingsProvidersButton = document.querySelector("[data-open-settings-providers]");
   const modelInput = document.querySelector("[data-model]");
@@ -159,6 +161,8 @@
   let currentReasoningEffort = "medium";
   let currentChatSurface = CHAT_SURFACE_EMBEDDED;
   let currentApprovalMode = APPROVAL_MODE_ASK;
+  let telemetryEnabled = true;
+  let telemetryControlledByEnvironment = false;
   let hasOpenRouterKey = false;
   let hasOllamaCloudKey = false;
   let providerRegistry = [];
@@ -411,6 +415,8 @@
       chatSurfaceBrowserInput,
       chatSurfaceRestartStatus,
       approvalModeControls,
+      telemetryEnabledInput,
+      telemetryEnvironmentStatus,
       settingsSavedToast,
       saveSettingsButton,
       openProvidersButton: openSettingsProvidersButton,
@@ -427,12 +433,14 @@
       cleanApprovalMode,
       getCurrentChatSurface: () => currentChatSurface,
       getCurrentApprovalMode: () => currentApprovalMode,
+      getTelemetryEnabled: () => telemetryEnabled,
+      getTelemetryControlledByEnvironment: () => telemetryControlledByEnvironment,
       openProviderPicker,
       sendIfOpen: daemonClient.sendIfOpen,
       connect,
       appendSystem,
       clearSystemStatus,
-      buildSavePayload: ({ chatSurface, approvalMode }) => ({
+      buildSavePayload: ({ chatSurface, approvalMode, telemetryEnabled: nextTelemetryEnabled }) => ({
         type: "save_settings",
         request_id: nextRequestId("save-settings"),
         model: cleanUiModelId(modelInput?.value || currentModel),
@@ -442,6 +450,7 @@
         local_model_context_lengths: localModelContextLengthPayload(),
         chat_surface: chatSurface,
         approval_mode: approvalMode,
+        telemetry_enabled: nextTelemetryEnabled,
       }),
     },
     constants: {
@@ -821,6 +830,8 @@
     currentReasoningEffort = cleanReasoningEffort(settings.reasoning_effort);
     currentChatSurface = cleanChatSurface(settings.chat_surface);
     currentApprovalMode = cleanApprovalMode(settings.approval_mode);
+    telemetryEnabled = settings.telemetry_enabled !== false;
+    telemetryControlledByEnvironment = Boolean(settings.telemetry_controlled_by_environment);
     if (!currentProvider && hasOpenRouterKey) {
       currentProvider = "openrouter";
     }
@@ -828,6 +839,7 @@
       chatSurfaceBrowserInput.checked = currentChatSurface === CHAT_SURFACE_BROWSER;
     }
     syncApprovalModeControls();
+    syncTelemetryControl();
     updateChatSurfaceRestartNotice();
     if (ollamaBaseUrlInput) {
       syncOllamaSetupFields();
@@ -1234,6 +1246,10 @@
 
   function syncApprovalModeControls() {
     return settingsPanel?.syncApprovalModeControls();
+  }
+
+  function syncTelemetryControl() {
+    return settingsPanel?.syncTelemetryControl();
   }
 
   function updateChatSurfaceRestartNotice(surface) {

--- a/godot_demo/addons/fennara/dist/index.html
+++ b/godot_demo/addons/fennara/dist/index.html
@@ -493,6 +493,19 @@
                 Restart Godot for this change to take effect.
               </p>
             </fieldset>
+            <fieldset class="settings-group">
+              <legend>Anonymous telemetry</legend>
+              <label class="settings-check">
+                <input type="checkbox" data-telemetry-enabled checked />
+                <span>Share anonymous daily usage</span>
+              </label>
+              <p class="settings-note">
+                Sends an anonymous installation ID, Fennara and Godot versions, operating system, and CPU architecture at most once per UTC day. It never sends project names, paths, prompts, tool inputs, tool results, logs, or screenshots.
+              </p>
+              <p class="settings-status" data-telemetry-environment-status hidden>
+                Telemetry is disabled by an environment variable.
+              </p>
+            </fieldset>
           </section>
           <section class="settings-page mcp-apps-page" data-settings-page="mcp" hidden>
             <div class="mcp-apps-intro">

--- a/godot_demo/addons/fennara/dist/settings-panel.js
+++ b/godot_demo/addons/fennara/dist/settings-panel.js
@@ -1,4 +1,11 @@
 (function () {
+  function includeTelemetryPreference(payload, telemetryEnabled, controlledByEnvironment) {
+    if (!controlledByEnvironment) {
+      payload.telemetry_enabled = Boolean(telemetryEnabled);
+    }
+    return payload;
+  }
+
   function createSettingsPanel(options = {}) {
     const elements = options.elements || {};
     const callbacks = options.callbacks || {};
@@ -267,5 +274,6 @@
 
   window.FennaraSettingsPanel = {
     createSettingsPanel,
+    includeTelemetryPreference,
   };
 })();

--- a/godot_demo/addons/fennara/dist/settings-panel.js
+++ b/godot_demo/addons/fennara/dist/settings-panel.js
@@ -7,6 +7,8 @@
     const chatSurfaceBrowserInput = elements.chatSurfaceBrowserInput || null;
     const chatSurfaceRestartStatus = elements.chatSurfaceRestartStatus || null;
     const approvalModeControls = Array.from(elements.approvalModeControls || []);
+    const telemetryEnabledInput = elements.telemetryEnabledInput || null;
+    const telemetryEnvironmentStatus = elements.telemetryEnvironmentStatus || null;
     const settingsSavedToast = elements.settingsSavedToast || null;
     const saveSettingsButton = elements.saveSettingsButton || null;
     const openProvidersButton = elements.openProvidersButton || null;
@@ -27,6 +29,8 @@
     const cleanApprovalMode = callbacks.cleanApprovalMode || ((mode) => mode === approvalModeFullAccess ? approvalModeFullAccess : approvalModeAsk);
     const getCurrentChatSurface = callbacks.getCurrentChatSurface || (() => chatSurfaceEmbedded);
     const getCurrentApprovalMode = callbacks.getCurrentApprovalMode || (() => approvalModeAsk);
+    const getTelemetryEnabled = callbacks.getTelemetryEnabled || (() => true);
+    const getTelemetryControlledByEnvironment = callbacks.getTelemetryControlledByEnvironment || (() => false);
     const openProviderPicker = callbacks.openProviderPicker || function () {};
     const buildSavePayload = callbacks.buildSavePayload || (() => null);
     const sendIfOpen = callbacks.sendIfOpen || (() => false);
@@ -52,6 +56,7 @@
       const payload = buildSavePayload({
         chatSurface: selectedChatSurface(),
         approvalMode: selectedApprovalMode(),
+        telemetryEnabled: selectedTelemetryEnabled(),
       });
       if (payload) {
         queueSave(payload);
@@ -67,6 +72,10 @@
       control.addEventListener("change", () => {
         setDirty(true);
       });
+    });
+
+    telemetryEnabledInput?.addEventListener("change", () => {
+      setDirty(true);
     });
 
     openProvidersButton?.addEventListener("click", (event) => {
@@ -89,6 +98,7 @@
         chatSurfaceBrowserInput.checked = getCurrentChatSurface() === chatSurfaceBrowser;
       }
       syncApprovalModeControls();
+      syncTelemetryControl();
       updateChatSurfaceRestartNotice(getCurrentChatSurface());
       markClean();
       if (settingsDialog && typeof settingsDialog.showModal === "function") {
@@ -105,11 +115,26 @@
       return cleanApprovalMode(selected?.value || getCurrentApprovalMode());
     }
 
+    function selectedTelemetryEnabled() {
+      return telemetryEnabledInput?.checked ?? getTelemetryEnabled();
+    }
+
     function syncApprovalModeControls() {
       const currentApprovalMode = getCurrentApprovalMode();
       approvalModeControls.forEach((control) => {
         control.checked = cleanApprovalMode(control.value) === currentApprovalMode;
       });
+    }
+
+    function syncTelemetryControl() {
+      const controlledByEnvironment = Boolean(getTelemetryControlledByEnvironment());
+      if (telemetryEnabledInput) {
+        telemetryEnabledInput.checked = Boolean(getTelemetryEnabled());
+        telemetryEnabledInput.disabled = controlledByEnvironment;
+      }
+      if (telemetryEnvironmentStatus) {
+        telemetryEnvironmentStatus.hidden = !controlledByEnvironment;
+      }
     }
 
     function updateChatSurfaceRestartNotice(surface = selectedChatSurface()) {
@@ -230,9 +255,11 @@
       queueSave,
       selectedApprovalMode,
       selectedChatSurface,
+      selectedTelemetryEnabled,
       setDirty,
       setSaving,
       syncApprovalModeControls,
+      syncTelemetryControl,
       updateChatSurfaceRestartNotice,
       updateSaveButton,
     };

--- a/llms.txt
+++ b/llms.txt
@@ -32,6 +32,7 @@ User guides:
 - docs/providers.md
 - docs/slash-commands.md
 - docs/manual-install.md
+- docs/telemetry.md
 
 Contributor reference:
 - docs/repo-map.md

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs
@@ -28,7 +28,7 @@ mod models;
 mod prompt;
 mod providers;
 mod schema;
-mod settings;
+pub(crate) mod settings;
 mod store;
 mod tools;
 pub(crate) mod trace;
@@ -63,6 +63,7 @@ struct ClientRequest {
     provider_base_urls: Option<BTreeMap<String, String>>,
     custom_provider: Option<SaveCustomProviderRequest>,
     approval_mode: Option<String>,
+    telemetry_enabled: Option<bool>,
     local_model_context_lengths: Option<BTreeMap<String, u32>>,
     approval_id: Option<String>,
     decision: Option<String>,
@@ -446,9 +447,13 @@ where
                 local_model_context_lengths: request.local_model_context_lengths,
                 chat_surface: request.chat_surface,
                 approval_mode: request.approval_mode,
+                telemetry_enabled: request.telemetry_enabled,
             };
             match save_settings(update) {
                 Ok(settings) => {
+                    if let Some(telemetry) = state.telemetry.read().await.as_ref().cloned() {
+                        telemetry.set_enabled(settings.telemetry_is_enabled());
+                    }
                     models::spawn_catalog_refresh_if_needed();
                     send_json(
                         sender,

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{
     collections::BTreeMap,
-    env, fs,
+    env,
+    ffi::OsStr,
+    fs,
     io::Write,
     path::{Path, PathBuf},
     sync::{
@@ -49,6 +51,8 @@ pub(crate) struct ChatSettings {
     pub(crate) chat_surface: String,
     #[serde(default, deserialize_with = "deserialize_approval_mode")]
     pub(crate) approval_mode: ApprovalMode,
+    #[serde(default = "default_true")]
+    pub(crate) telemetry_enabled: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -66,6 +70,8 @@ pub(crate) struct PublicChatSettings {
     pub(crate) chat_surface: String,
     pub(crate) approval_mode: String,
     pub(crate) approval_mode_options: Vec<serde_json::Value>,
+    pub(crate) telemetry_enabled: bool,
+    pub(crate) telemetry_controlled_by_environment: bool,
 }
 
 impl Default for ChatSettings {
@@ -80,6 +86,7 @@ impl Default for ChatSettings {
             local_model_context_lengths: BTreeMap::new(),
             chat_surface: DEFAULT_CHAT_SURFACE.to_string(),
             approval_mode: ApprovalMode::Ask,
+            telemetry_enabled: true,
         }
     }
 }
@@ -103,7 +110,13 @@ impl ChatSettings {
             chat_surface: clean_chat_surface(&self.chat_surface).to_string(),
             approval_mode: self.approval_mode.as_str().to_string(),
             approval_mode_options: approval_mode_options(),
+            telemetry_enabled: self.telemetry_is_enabled(),
+            telemetry_controlled_by_environment: telemetry_disabled_by_environment(),
         }
+    }
+
+    pub(crate) fn telemetry_is_enabled(&self) -> bool {
+        self.telemetry_enabled && !telemetry_disabled_by_environment()
     }
 }
 
@@ -134,6 +147,7 @@ pub(crate) struct SaveSettingsRequest {
     pub(crate) local_model_context_lengths: Option<BTreeMap<String, u32>>,
     pub(crate) chat_surface: Option<String>,
     pub(crate) approval_mode: Option<String>,
+    pub(crate) telemetry_enabled: Option<bool>,
 }
 
 pub(crate) fn load_settings() -> ChatSettings {
@@ -332,6 +346,9 @@ pub(crate) fn save_settings(update: SaveSettingsRequest) -> Result<ChatSettings,
     }
     if let Some(approval_mode) = update.approval_mode {
         settings.approval_mode = clean_approval_mode(&approval_mode);
+    }
+    if let Some(telemetry_enabled) = update.telemetry_enabled {
+        settings.telemetry_enabled = telemetry_enabled;
     }
 
     write_settings_file(&settings)?;
@@ -626,6 +643,24 @@ fn default_reasoning_effort() -> String {
 
 fn default_chat_surface() -> String {
     DEFAULT_CHAT_SURFACE.to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn telemetry_disabled_by_environment() -> bool {
+    env_truthy(env::var_os("FENNARA_DISABLE_TELEMETRY").as_deref())
+        || env_truthy(env::var_os("DO_NOT_TRACK").as_deref())
+}
+
+fn env_truthy(value: Option<&OsStr>) -> bool {
+    value.is_some_and(|value| {
+        matches!(
+            value.to_string_lossy().trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
 }
 
 fn deserialize_approval_mode<'de, D>(deserializer: D) -> Result<ApprovalMode, D::Error>

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings.rs
@@ -110,13 +110,17 @@ impl ChatSettings {
             chat_surface: clean_chat_surface(&self.chat_surface).to_string(),
             approval_mode: self.approval_mode.as_str().to_string(),
             approval_mode_options: approval_mode_options(),
-            telemetry_enabled: self.telemetry_is_enabled(),
+            telemetry_enabled: self.telemetry_enabled,
             telemetry_controlled_by_environment: telemetry_disabled_by_environment(),
         }
     }
 
     pub(crate) fn telemetry_is_enabled(&self) -> bool {
-        self.telemetry_enabled && !telemetry_disabled_by_environment()
+        self.telemetry_is_enabled_with_environment(telemetry_disabled_by_environment())
+    }
+
+    fn telemetry_is_enabled_with_environment(&self, disabled_by_environment: bool) -> bool {
+        self.telemetry_enabled && !disabled_by_environment
     }
 }
 

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings/tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings/tests.rs
@@ -3,10 +3,28 @@ use std::collections::BTreeMap;
 #[cfg(windows)]
 use super::replace_settings_file;
 use super::{
-    ChatSettings, CustomHeaderMigration, migrate_custom_provider_headers,
+    ChatSettings, CustomHeaderMigration, env_truthy, migrate_custom_provider_headers,
     migrate_legacy_openrouter_selection, reconcile_custom_provider_models,
 };
 use crate::runtime_daemon::chat::providers::custom::{CustomProviderConfig, CustomProviderModel};
+
+#[test]
+fn legacy_settings_default_to_anonymous_telemetry_enabled() {
+    let settings: ChatSettings =
+        serde_json::from_str(r#"{"model":"openrouter/google/gemini-3.5-flash"}"#).unwrap();
+
+    assert!(settings.telemetry_enabled);
+}
+
+#[test]
+fn telemetry_environment_flags_accept_only_explicit_truthy_values() {
+    assert!(env_truthy(Some(std::ffi::OsStr::new("true"))));
+    assert!(env_truthy(Some(std::ffi::OsStr::new(" YES "))));
+    assert!(env_truthy(Some(std::ffi::OsStr::new("1"))));
+    assert!(!env_truthy(Some(std::ffi::OsStr::new("false"))));
+    assert!(!env_truthy(Some(std::ffi::OsStr::new(""))));
+    assert!(!env_truthy(None));
+}
 
 #[test]
 fn provider_edit_replaces_a_removed_selected_model() {

--- a/local/crates/fennara-daemon/src/runtime_daemon/chat/settings/tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/chat/settings/tests.rs
@@ -27,6 +27,19 @@ fn telemetry_environment_flags_accept_only_explicit_truthy_values() {
 }
 
 #[test]
+fn telemetry_environment_override_does_not_change_saved_preference() {
+    let settings = ChatSettings {
+        telemetry_enabled: true,
+        ..ChatSettings::default()
+    };
+
+    assert!(settings.telemetry_enabled);
+    assert!(settings.public().telemetry_enabled);
+    assert!(!settings.telemetry_is_enabled_with_environment(true));
+    assert!(settings.telemetry_is_enabled_with_environment(false));
+}
+
+#[test]
 fn provider_edit_replaces_a_removed_selected_model() {
     let mut settings = ChatSettings {
         model: "omniroute/removed/model".to_string(),

--- a/local/crates/fennara-daemon/src/runtime_daemon/godot_bridge.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/godot_bridge.rs
@@ -636,6 +636,7 @@ async fn handle_project_state_message(
             chat_token: optional_string(value, "chat_token"),
             tools: string_array(value, "tools"),
         };
+        let telemetry_godot_version = project.godot_version.clone();
 
         *session_id = Some(next_session_id.clone());
         state
@@ -648,6 +649,11 @@ async fn handle_project_state_message(
             .write()
             .await
             .insert(next_session_id.clone(), project);
+        if let Some(godot_version) = telemetry_godot_version
+            && let Some(telemetry) = state.telemetry.read().await.as_ref()
+        {
+            telemetry.record_activity(&godot_version);
+        }
         ensure_active_project_after_connect(state, &next_session_id).await;
         broadcast_active_project_changed(state).await;
         return true;

--- a/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod scene_runner;
 #[cfg(test)]
 mod shutdown_tests;
 pub(crate) mod state;
+pub(crate) mod telemetry;
 pub(crate) mod util;
 
 use state::AppState;
@@ -82,7 +83,7 @@ pub async fn run() {
         .route("/chat/ws", get(chat::chat_ws))
         .merge(privileged)
         .layer(Extension(control_token))
-        .with_state(state);
+        .with_state(state.clone());
 
     let addr: SocketAddr = format!("{DAEMON_HOST}:{DAEMON_PORT}")
         .parse()
@@ -90,6 +91,9 @@ pub async fn run() {
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .expect("failed to bind fennara daemon");
+    let telemetry =
+        telemetry::TelemetryRuntime::start(chat::settings::load_settings().telemetry_is_enabled());
+    *state.telemetry.write().await = Some(telemetry.handle());
 
     eprintln!("fennara-daemon listening on http://{addr}");
     axum::serve(listener, app)
@@ -98,6 +102,8 @@ pub async fn run() {
         })
         .await
         .expect("fennara daemon stopped unexpectedly");
+    state.telemetry.write().await.take();
+    telemetry.shutdown().await;
 }
 
 async fn health() -> Json<Value> {

--- a/local/crates/fennara-daemon/src/runtime_daemon/state.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/state.rs
@@ -14,6 +14,7 @@ use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 
 use super::chat::context::ChatContextSnippet;
 use super::permissions::PendingToolApproval;
+use super::telemetry::TelemetryHandle;
 
 #[derive(Clone)]
 pub(crate) struct AppState {
@@ -32,6 +33,7 @@ pub(crate) struct AppState {
     pub(crate) runtime_sessions: Arc<Mutex<HashMap<String, RuntimeSession>>>,
     pub(crate) shutdown_sender: Arc<Mutex<Option<oneshot::Sender<()>>>>,
     pub(crate) docs_warmup_running: Arc<AtomicBool>,
+    pub(crate) telemetry: Arc<RwLock<Option<TelemetryHandle>>>,
 }
 
 impl AppState {
@@ -53,6 +55,7 @@ impl AppState {
             runtime_sessions: Arc::new(Mutex::new(HashMap::new())),
             shutdown_sender: Arc::new(Mutex::new(Some(shutdown_tx))),
             docs_warmup_running: Arc::new(AtomicBool::new(false)),
+            telemetry: Arc::new(RwLock::new(None)),
         }
     }
 }

--- a/local/crates/fennara-daemon/src/runtime_daemon/telemetry.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/telemetry.rs
@@ -1,0 +1,300 @@
+use reqwest::Client;
+use serde::Serialize;
+use std::{
+    env,
+    path::PathBuf,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::{
+    sync::{mpsc, oneshot, watch},
+    task::JoinHandle,
+};
+
+use super::{DAEMON_VERSION, util::fennara_app_dir};
+use state::TelemetryState;
+
+mod state;
+
+const ENDPOINT: &str = "https://fennara.io/api/telemetry";
+const EVENT_NAME: &str = "fennara_active_installation";
+const PAYLOAD_SCHEMA_VERSION: u8 = 1;
+const QUEUE_CAPACITY: usize = 4;
+const CHECK_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(500);
+const SECONDS_PER_DAY: u64 = 24 * 60 * 60;
+
+#[derive(Clone)]
+pub(crate) struct TelemetryHandle {
+    activity_tx: mpsc::Sender<Activity>,
+    enabled_tx: watch::Sender<bool>,
+}
+
+pub(crate) struct TelemetryRuntime {
+    handle: TelemetryHandle,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    worker: Option<JoinHandle<()>>,
+}
+
+#[derive(Clone, Debug)]
+struct Activity {
+    godot_version: String,
+}
+
+#[derive(Clone)]
+struct WorkerConfig {
+    endpoint: String,
+    state_path: PathBuf,
+    platform: &'static str,
+    architecture: &'static str,
+    check_interval: Duration,
+}
+
+#[derive(Serialize)]
+struct ActiveInstallationEvent<'a> {
+    schema_version: u8,
+    event: &'static str,
+    installation_id: &'a str,
+    fennara_version: &'static str,
+    godot_version: &'a str,
+    platform: &'static str,
+    architecture: &'static str,
+}
+
+impl TelemetryHandle {
+    pub(crate) fn record_activity(&self, godot_version: &str) {
+        let Some(godot_version) = normalize_godot_version(godot_version) else {
+            return;
+        };
+        let _ = self.activity_tx.try_send(Activity { godot_version });
+    }
+
+    pub(crate) fn set_enabled(&self, enabled: bool) {
+        let _ = self.enabled_tx.send(enabled);
+    }
+}
+
+impl TelemetryRuntime {
+    pub(crate) fn start(enabled: bool) -> Self {
+        let Some(config) = production_config() else {
+            return Self::disabled(enabled);
+        };
+        Self::start_with_config(enabled, config)
+    }
+
+    fn start_with_config(enabled: bool, config: WorkerConfig) -> Self {
+        let (activity_tx, activity_rx) = mpsc::channel(QUEUE_CAPACITY);
+        let (enabled_tx, enabled_rx) = watch::channel(enabled);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let handle = TelemetryHandle {
+            activity_tx,
+            enabled_tx,
+        };
+        let worker = tokio::spawn(run_worker(config, activity_rx, enabled_rx, shutdown_rx));
+        Self {
+            handle,
+            shutdown_tx: Some(shutdown_tx),
+            worker: Some(worker),
+        }
+    }
+
+    fn disabled(enabled: bool) -> Self {
+        let (activity_tx, activity_rx) = mpsc::channel(1);
+        drop(activity_rx);
+        let (enabled_tx, enabled_rx) = watch::channel(enabled);
+        drop(enabled_rx);
+        Self {
+            handle: TelemetryHandle {
+                activity_tx,
+                enabled_tx,
+            },
+            shutdown_tx: None,
+            worker: None,
+        }
+    }
+
+    pub(crate) fn handle(&self) -> TelemetryHandle {
+        self.handle.clone()
+    }
+
+    pub(crate) async fn shutdown(mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        let Some(mut worker) = self.worker.take() else {
+            return;
+        };
+        if tokio::time::timeout(SHUTDOWN_TIMEOUT, &mut worker)
+            .await
+            .is_err()
+        {
+            worker.abort();
+            let _ = worker.await;
+        }
+    }
+}
+
+fn production_config() -> Option<WorkerConfig> {
+    let platform = match env::consts::OS {
+        "windows" => "windows",
+        "macos" => "macos",
+        "linux" => "linux",
+        _ => return None,
+    };
+    let architecture = match env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        _ => return None,
+    };
+    Some(WorkerConfig {
+        endpoint: ENDPOINT.to_string(),
+        state_path: fennara_app_dir().ok()?.join("telemetry").join("state.json"),
+        platform,
+        architecture,
+        check_interval: CHECK_INTERVAL,
+    })
+}
+
+async fn run_worker(
+    config: WorkerConfig,
+    mut activity_rx: mpsc::Receiver<Activity>,
+    mut enabled_rx: watch::Receiver<bool>,
+    mut shutdown_rx: oneshot::Receiver<()>,
+) {
+    let client = match Client::builder()
+        .user_agent(format!("Fennara/{DAEMON_VERSION}"))
+        .connect_timeout(Duration::from_secs(1))
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+    {
+        Ok(client) => client,
+        Err(_) => return,
+    };
+    let mut latest_activity: Option<Activity> = None;
+    let mut state: Option<TelemetryState> = None;
+    let mut interval = tokio::time::interval_at(
+        tokio::time::Instant::now() + config.check_interval,
+        config.check_interval,
+    );
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    if !*enabled_rx.borrow() {
+        remove_state(config.state_path.clone()).await;
+    }
+
+    loop {
+        tokio::select! {
+            _ = &mut shutdown_rx => break,
+            changed = enabled_rx.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+                let enabled = *enabled_rx.borrow_and_update();
+                if enabled {
+                    if let Some(activity) = latest_activity.as_ref() {
+                        send_if_due(&client, &config, activity, &mut state, utc_day()).await;
+                    }
+                } else {
+                    state = None;
+                    remove_state(config.state_path.clone()).await;
+                }
+            }
+            activity = activity_rx.recv() => {
+                let Some(activity) = activity else {
+                    break;
+                };
+                latest_activity = Some(activity);
+                if *enabled_rx.borrow()
+                    && let Some(activity) = latest_activity.as_ref()
+                {
+                    send_if_due(&client, &config, activity, &mut state, utc_day()).await;
+                }
+            }
+            _ = interval.tick() => {
+                if *enabled_rx.borrow()
+                    && let Some(activity) = latest_activity.as_ref()
+                {
+                    send_if_due(&client, &config, activity, &mut state, utc_day()).await;
+                }
+            }
+        }
+    }
+}
+
+async fn send_if_due(
+    client: &Client,
+    config: &WorkerConfig,
+    activity: &Activity,
+    state: &mut Option<TelemetryState>,
+    current_utc_day: u64,
+) {
+    if state.is_none() {
+        let state_path = config.state_path.clone();
+        *state = tokio::task::spawn_blocking(move || state::load_or_create(&state_path))
+            .await
+            .ok()
+            .and_then(Result::ok);
+    }
+    let Some(current_state) = state.as_mut() else {
+        return;
+    };
+    if current_state.last_sent_utc_day == Some(current_utc_day) {
+        return;
+    }
+
+    let event = ActiveInstallationEvent {
+        schema_version: PAYLOAD_SCHEMA_VERSION,
+        event: EVENT_NAME,
+        installation_id: &current_state.installation_id,
+        fennara_version: DAEMON_VERSION,
+        godot_version: &activity.godot_version,
+        platform: config.platform,
+        architecture: config.architecture,
+    };
+    let accepted = client
+        .post(&config.endpoint)
+        .json(&event)
+        .send()
+        .await
+        .is_ok_and(|response| response.status().is_success());
+    if accepted {
+        current_state.last_sent_utc_day = Some(current_utc_day);
+        let state_path = config.state_path.clone();
+        let state_to_write = current_state.clone();
+        let _ =
+            tokio::task::spawn_blocking(move || state::write(&state_path, &state_to_write)).await;
+    }
+}
+
+async fn remove_state(path: PathBuf) {
+    let _ = tokio::task::spawn_blocking(move || state::remove(&path)).await;
+}
+
+fn normalize_godot_version(value: &str) -> Option<String> {
+    let prefix: String = value
+        .trim()
+        .chars()
+        .take_while(|character| character.is_ascii_digit() || *character == '.')
+        .collect();
+    let parts: Vec<&str> = prefix.trim_end_matches('.').split('.').collect();
+    if !(2..=3).contains(&parts.len())
+        || parts
+            .iter()
+            .any(|part| part.is_empty() || part.len() > 3 || part.parse::<u16>().is_err())
+    {
+        return None;
+    }
+    Some(parts.join("."))
+}
+
+fn utc_day() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        / SECONDS_PER_DAY
+}
+
+#[cfg(test)]
+#[path = "telemetry/tests.rs"]
+mod tests;

--- a/local/crates/fennara-daemon/src/runtime_daemon/telemetry/state.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/telemetry/state.rs
@@ -1,0 +1,161 @@
+use serde::{Deserialize, Serialize};
+use std::{
+    fmt::Write as _,
+    fs,
+    io::Write,
+    path::Path,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+pub(super) const SCHEMA_VERSION: u8 = 1;
+static WRITE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct TelemetryState {
+    pub(super) schema_version: u8,
+    pub(super) installation_id: String,
+    pub(super) last_sent_utc_day: Option<u64>,
+}
+
+pub(super) fn load_or_create(path: &Path) -> Result<TelemetryState, String> {
+    if let Some(state) = read_valid(path)? {
+        return Ok(state);
+    }
+    let state = TelemetryState {
+        schema_version: SCHEMA_VERSION,
+        installation_id: generate_installation_id()?,
+        last_sent_utc_day: None,
+    };
+    write(path, &state)?;
+    Ok(state)
+}
+
+pub(super) fn read_valid(path: &Path) -> Result<Option<TelemetryState>, String> {
+    let previous = path.with_extension("json.previous");
+    let selected = if path.is_file() {
+        path
+    } else if previous.is_file() {
+        previous.as_path()
+    } else {
+        return Ok(None);
+    };
+    let raw = fs::read_to_string(selected)
+        .map_err(|error| format!("failed to read {}: {error}", selected.display()))?;
+    let Ok(state) = serde_json::from_str::<TelemetryState>(&raw) else {
+        return Ok(None);
+    };
+    Ok(
+        (state.schema_version == SCHEMA_VERSION
+            && is_valid_installation_id(&state.installation_id))
+        .then_some(state),
+    )
+}
+
+pub(super) fn write(path: &Path, state: &TelemetryState) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "telemetry state path has no parent".to_string())?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    let raw = serde_json::to_vec_pretty(state).map_err(|error| error.to_string())?;
+    let sequence = WRITE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let temp = path.with_extension(format!("json.tmp-{}-{sequence}", std::process::id()));
+    let result = write_secure_temp(&temp, &raw).and_then(|_| replace_file(&temp, path));
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+pub(super) fn remove(path: &Path) {
+    let _ = fs::remove_file(path);
+    let _ = fs::remove_file(path.with_extension("json.previous"));
+    if let Some(parent) = path.parent() {
+        let _ = fs::remove_dir(parent);
+    }
+}
+
+pub(super) fn generate_installation_id() -> Result<String, String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| format!("failed to generate telemetry installation id: {error}"))?;
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    let mut result = String::with_capacity(36);
+    for (index, byte) in bytes.iter().enumerate() {
+        if matches!(index, 4 | 6 | 8 | 10) {
+            result.push('-');
+        }
+        write!(result, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    Ok(result)
+}
+
+pub(super) fn is_valid_installation_id(value: &str) -> bool {
+    value.len() == 36
+        && value.bytes().enumerate().all(|(index, byte)| match index {
+            8 | 13 | 18 | 23 => byte == b'-',
+            14 => byte == b'4',
+            19 => matches!(byte, b'8' | b'9' | b'a' | b'b' | b'A' | b'B'),
+            _ => byte.is_ascii_hexdigit(),
+        })
+}
+
+fn write_secure_temp(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("failed to create {}: {error}", path.display()))?;
+    file.write_all(contents)
+        .and_then(|_| file.write_all(b"\n"))
+        .and_then(|_| file.sync_all())
+        .map_err(|error| format!("failed to write {}: {error}", path.display()))
+}
+
+#[cfg(not(windows))]
+fn replace_file(temp: &Path, path: &Path) -> Result<(), String> {
+    fs::rename(temp, path).map_err(|error| {
+        format!(
+            "failed to replace {} with {}: {error}",
+            path.display(),
+            temp.display()
+        )
+    })
+}
+
+#[cfg(windows)]
+fn replace_file(temp: &Path, path: &Path) -> Result<(), String> {
+    let backup = path.with_extension("json.previous");
+    let had_current = path.is_file();
+    if had_current {
+        if backup.is_file() {
+            fs::remove_file(&backup)
+                .map_err(|error| format!("failed to remove {}: {error}", backup.display()))?;
+        }
+        fs::rename(path, &backup).map_err(|error| {
+            format!(
+                "failed to back up {} as {}: {error}",
+                path.display(),
+                backup.display()
+            )
+        })?;
+    }
+    match fs::rename(temp, path) {
+        Ok(()) => {
+            let _ = fs::remove_file(backup);
+            Ok(())
+        }
+        Err(error) => {
+            if had_current && backup.is_file() && !path.exists() {
+                let _ = fs::rename(&backup, path);
+            }
+            Err(format!("failed to replace {}: {error}", path.display()))
+        }
+    }
+}

--- a/local/crates/fennara-daemon/src/runtime_daemon/telemetry/tests.rs
+++ b/local/crates/fennara-daemon/src/runtime_daemon/telemetry/tests.rs
@@ -1,0 +1,284 @@
+use super::state::{
+    SCHEMA_VERSION as STATE_SCHEMA_VERSION, generate_installation_id, is_valid_installation_id,
+    load_or_create as load_or_create_state, read_valid as read_valid_state, write as write_state,
+};
+use super::*;
+use axum::{Json, Router, extract::State, http::StatusCode, routing::post};
+use serde_json::Value;
+use std::{
+    fs,
+    path::Path,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicU16, AtomicU64, Ordering},
+    },
+};
+
+static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone)]
+struct CaptureState {
+    events: Arc<Mutex<Vec<Value>>>,
+    status: Arc<AtomicU16>,
+    delay_ms: Arc<AtomicU64>,
+}
+
+#[test]
+fn normalizes_only_supported_godot_version_shapes() {
+    assert_eq!(
+        normalize_godot_version("4.6.3.stable.official"),
+        Some("4.6.3".to_string())
+    );
+    assert_eq!(
+        normalize_godot_version(" 4.5.stable "),
+        Some("4.5".to_string())
+    );
+    assert_eq!(normalize_godot_version("4"), None);
+    assert_eq!(normalize_godot_version("4.6.3.1"), None);
+    assert_eq!(normalize_godot_version("custom"), None);
+    assert_eq!(normalize_godot_version("4..6"), None);
+}
+
+#[test]
+fn generated_installation_ids_are_valid_uuid_v4_values() {
+    for _ in 0..128 {
+        let installation_id = generate_installation_id().unwrap();
+        assert!(is_valid_installation_id(&installation_id));
+        assert_eq!(&installation_id[14..15], "4");
+        assert!(matches!(&installation_id[19..20], "8" | "9" | "a" | "b"));
+    }
+    assert!(!is_valid_installation_id("machine-name"));
+    assert!(!is_valid_installation_id(
+        "550e8400-e29b-11d4-a716-446655440000"
+    ));
+}
+
+#[test]
+fn telemetry_state_is_persisted_reused_and_repaired() {
+    let dir = test_dir("state");
+    let path = dir.join("state.json");
+
+    let first = load_or_create_state(&path).unwrap();
+    let second = load_or_create_state(&path).unwrap();
+    assert_eq!(first.installation_id, second.installation_id);
+    assert!(is_valid_installation_id(&first.installation_id));
+
+    fs::write(&path, r#"{"schema_version":1,"installation_id":"bad"}"#).unwrap();
+    let repaired = load_or_create_state(&path).unwrap();
+    assert!(is_valid_installation_id(&repaired.installation_id));
+    assert_ne!(repaired.installation_id, first.installation_id);
+
+    cleanup(&dir);
+}
+
+#[tokio::test]
+async fn accepted_event_contains_only_the_approved_contract_and_sends_once_per_day() {
+    let dir = test_dir("accepted");
+    let (endpoint, capture, server) = capture_server(StatusCode::ACCEPTED).await;
+    let config = test_config(endpoint, dir.join("state.json"));
+    let client = Client::new();
+    let activity = Activity {
+        godot_version: "4.6.3".to_string(),
+    };
+    let mut state = None;
+
+    send_if_due(&client, &config, &activity, &mut state, 42).await;
+    send_if_due(&client, &config, &activity, &mut state, 42).await;
+
+    let events = capture.events.lock().unwrap();
+    assert_eq!(events.len(), 1);
+    let event = events[0].as_object().unwrap();
+    assert_eq!(event.len(), 7);
+    assert_eq!(event["schema_version"], 1);
+    assert_eq!(event["event"], EVENT_NAME);
+    assert_eq!(event["fennara_version"], DAEMON_VERSION);
+    assert_eq!(event["godot_version"], "4.6.3");
+    assert_eq!(event["platform"], "windows");
+    assert_eq!(event["architecture"], "x86_64");
+    assert!(is_valid_installation_id(
+        event["installation_id"].as_str().unwrap()
+    ));
+    drop(events);
+
+    let persisted = read_valid_state(&config.state_path).unwrap().unwrap();
+    assert_eq!(persisted.last_sent_utc_day, Some(42));
+
+    server.abort();
+    cleanup(&dir);
+}
+
+#[tokio::test]
+async fn failed_delivery_is_not_marked_sent_and_retries() {
+    let dir = test_dir("retry");
+    let (endpoint, capture, server) = capture_server(StatusCode::BAD_GATEWAY).await;
+    let config = test_config(endpoint, dir.join("state.json"));
+    let client = Client::new();
+    let activity = Activity {
+        godot_version: "4.6".to_string(),
+    };
+    let mut state = None;
+
+    send_if_due(&client, &config, &activity, &mut state, 77).await;
+    assert_eq!(
+        state.as_ref().and_then(|state| state.last_sent_utc_day),
+        None
+    );
+
+    capture
+        .status
+        .store(StatusCode::ACCEPTED.as_u16(), Ordering::Relaxed);
+    send_if_due(&client, &config, &activity, &mut state, 77).await;
+
+    assert_eq!(capture.events.lock().unwrap().len(), 2);
+    assert_eq!(
+        state.as_ref().and_then(|state| state.last_sent_utc_day),
+        Some(77)
+    );
+
+    server.abort();
+    cleanup(&dir);
+}
+
+#[tokio::test]
+async fn disabled_runtime_deletes_identity_and_does_not_send_until_enabled() {
+    let dir = test_dir("toggle");
+    let state_path = dir.join("state.json");
+    let existing = TelemetryState {
+        schema_version: STATE_SCHEMA_VERSION,
+        installation_id: generate_installation_id().unwrap(),
+        last_sent_utc_day: None,
+    };
+    write_state(&state_path, &existing).unwrap();
+    let (endpoint, capture, server) = capture_server(StatusCode::ACCEPTED).await;
+    let config = test_config(endpoint, state_path.clone());
+    let runtime = TelemetryRuntime::start_with_config(false, config);
+    let handle = runtime.handle();
+
+    wait_until(|| !state_path.exists()).await;
+    handle.record_activity("4.6.3.stable");
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    assert!(capture.events.lock().unwrap().is_empty());
+
+    handle.set_enabled(true);
+    wait_until(|| !capture.events.lock().unwrap().is_empty()).await;
+    assert!(state_path.is_file());
+
+    handle.set_enabled(false);
+    wait_until(|| !state_path.exists()).await;
+
+    runtime.shutdown().await;
+    server.abort();
+    cleanup(&dir);
+}
+
+#[test]
+fn a_full_activity_queue_drops_new_signals_without_waiting() {
+    let (activity_tx, mut activity_rx) = mpsc::channel(1);
+    let (enabled_tx, _enabled_rx) = watch::channel(true);
+    let handle = TelemetryHandle {
+        activity_tx,
+        enabled_tx,
+    };
+
+    handle.record_activity("4.6.3.stable");
+    handle.record_activity("4.5.2.stable");
+
+    assert_eq!(
+        activity_rx.try_recv().unwrap().godot_version,
+        "4.6.3".to_string()
+    );
+    assert!(activity_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn shutdown_cancels_a_slow_request_within_its_bound() {
+    let dir = test_dir("shutdown");
+    let (endpoint, capture, server) = capture_server(StatusCode::ACCEPTED).await;
+    capture.delay_ms.store(5_000, Ordering::Relaxed);
+    let runtime =
+        TelemetryRuntime::start_with_config(true, test_config(endpoint, dir.join("state.json")));
+    runtime.handle().record_activity("4.6.3");
+    wait_until(|| !capture.events.lock().unwrap().is_empty()).await;
+
+    let started = std::time::Instant::now();
+    runtime.shutdown().await;
+
+    assert!(started.elapsed() < Duration::from_secs(2));
+    server.abort();
+    cleanup(&dir);
+}
+
+async fn capture_server(initial_status: StatusCode) -> (String, CaptureState, JoinHandle<()>) {
+    async fn capture(State(state): State<CaptureState>, Json(event): Json<Value>) -> StatusCode {
+        state.events.lock().unwrap().push(event);
+        let delay_ms = state.delay_ms.load(Ordering::Relaxed);
+        if delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        }
+        StatusCode::from_u16(state.status.load(Ordering::Relaxed))
+            .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+
+    let state = CaptureState {
+        events: Arc::new(Mutex::new(Vec::new())),
+        status: Arc::new(AtomicU16::new(initial_status.as_u16())),
+        delay_ms: Arc::new(AtomicU64::new(0)),
+    };
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/api/telemetry", post(capture))
+        .with_state(state.clone());
+    let server = tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    (format!("http://{address}/api/telemetry"), state, server)
+}
+
+fn test_config(endpoint: String, state_path: PathBuf) -> WorkerConfig {
+    WorkerConfig {
+        endpoint,
+        state_path,
+        platform: "windows",
+        architecture: "x86_64",
+        check_interval: Duration::from_millis(10),
+    }
+}
+
+fn test_dir(name: &str) -> PathBuf {
+    let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("temp")
+        .join("telemetry-tests");
+    let dir = root.join(format!("{}-{name}-{sequence}", std::process::id()));
+    cleanup(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn cleanup(path: &Path) {
+    if path.starts_with(
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("..")
+            .join("temp"),
+    ) {
+        let _ = fs::remove_dir_all(path);
+    }
+}
+
+async fn wait_until(predicate: impl Fn() -> bool) {
+    for _ in 0..100 {
+        if predicate() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("condition did not become true before timeout");
+}

--- a/scripts/tests/settings-panel.test.mjs
+++ b/scripts/tests/settings-panel.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(
+  new URL("../../ui/chat/settings-panel.js", import.meta.url),
+  "utf8",
+);
+const context = { window: {} };
+vm.runInNewContext(source, context);
+const includeTelemetryPreference =
+  context.window.FennaraSettingsPanel.includeTelemetryPreference;
+
+test("environment-controlled settings saves preserve the stored telemetry preference", () => {
+  const payload = { type: "save_settings" };
+
+  includeTelemetryPreference(payload, false, true);
+
+  assert.equal(Object.hasOwn(payload, "telemetry_enabled"), false);
+});
+
+test("user-controlled settings saves include the selected telemetry preference", () => {
+  const payload = { type: "save_settings" };
+
+  includeTelemetryPreference(payload, false, false);
+
+  assert.equal(payload.telemetry_enabled, false);
+});

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -440,18 +440,24 @@
       connect,
       appendSystem,
       clearSystemStatus,
-      buildSavePayload: ({ chatSurface, approvalMode, telemetryEnabled: nextTelemetryEnabled }) => ({
-        type: "save_settings",
-        request_id: nextRequestId("save-settings"),
-        model: cleanUiModelId(modelInput?.value || currentModel),
-        reasoning_effort: currentReasoningEffort,
-        ollama_base_url: ollamaBaseUrl,
-        provider_base_urls: providerBaseUrlPayload(),
-        local_model_context_lengths: localModelContextLengthPayload(),
-        chat_surface: chatSurface,
-        approval_mode: approvalMode,
-        telemetry_enabled: nextTelemetryEnabled,
-      }),
+      buildSavePayload: ({ chatSurface, approvalMode, telemetryEnabled: nextTelemetryEnabled }) => {
+        const payload = {
+          type: "save_settings",
+          request_id: nextRequestId("save-settings"),
+          model: cleanUiModelId(modelInput?.value || currentModel),
+          reasoning_effort: currentReasoningEffort,
+          ollama_base_url: ollamaBaseUrl,
+          provider_base_urls: providerBaseUrlPayload(),
+          local_model_context_lengths: localModelContextLengthPayload(),
+          chat_surface: chatSurface,
+          approval_mode: approvalMode,
+        };
+        return window.FennaraSettingsPanel.includeTelemetryPreference(
+          payload,
+          nextTelemetryEnabled,
+          telemetryControlledByEnvironment,
+        );
+      },
     },
     constants: {
       savedNoticeMs: SETTINGS_SAVED_NOTICE_MS,

--- a/ui/chat/app.js
+++ b/ui/chat/app.js
@@ -56,6 +56,8 @@
   const chatSurfaceBrowserInput = document.querySelector("[data-chat-surface-browser]");
   const chatSurfaceRestartStatus = document.querySelector("[data-chat-surface-restart]");
   const approvalModeControls = document.querySelectorAll("[data-approval-mode]");
+  const telemetryEnabledInput = document.querySelector("[data-telemetry-enabled]");
+  const telemetryEnvironmentStatus = document.querySelector("[data-telemetry-environment-status]");
   const settingsSavedToast = document.querySelector("[data-settings-saved-toast]");
   const openSettingsProvidersButton = document.querySelector("[data-open-settings-providers]");
   const modelInput = document.querySelector("[data-model]");
@@ -159,6 +161,8 @@
   let currentReasoningEffort = "medium";
   let currentChatSurface = CHAT_SURFACE_EMBEDDED;
   let currentApprovalMode = APPROVAL_MODE_ASK;
+  let telemetryEnabled = true;
+  let telemetryControlledByEnvironment = false;
   let hasOpenRouterKey = false;
   let hasOllamaCloudKey = false;
   let providerRegistry = [];
@@ -411,6 +415,8 @@
       chatSurfaceBrowserInput,
       chatSurfaceRestartStatus,
       approvalModeControls,
+      telemetryEnabledInput,
+      telemetryEnvironmentStatus,
       settingsSavedToast,
       saveSettingsButton,
       openProvidersButton: openSettingsProvidersButton,
@@ -427,12 +433,14 @@
       cleanApprovalMode,
       getCurrentChatSurface: () => currentChatSurface,
       getCurrentApprovalMode: () => currentApprovalMode,
+      getTelemetryEnabled: () => telemetryEnabled,
+      getTelemetryControlledByEnvironment: () => telemetryControlledByEnvironment,
       openProviderPicker,
       sendIfOpen: daemonClient.sendIfOpen,
       connect,
       appendSystem,
       clearSystemStatus,
-      buildSavePayload: ({ chatSurface, approvalMode }) => ({
+      buildSavePayload: ({ chatSurface, approvalMode, telemetryEnabled: nextTelemetryEnabled }) => ({
         type: "save_settings",
         request_id: nextRequestId("save-settings"),
         model: cleanUiModelId(modelInput?.value || currentModel),
@@ -442,6 +450,7 @@
         local_model_context_lengths: localModelContextLengthPayload(),
         chat_surface: chatSurface,
         approval_mode: approvalMode,
+        telemetry_enabled: nextTelemetryEnabled,
       }),
     },
     constants: {
@@ -821,6 +830,8 @@
     currentReasoningEffort = cleanReasoningEffort(settings.reasoning_effort);
     currentChatSurface = cleanChatSurface(settings.chat_surface);
     currentApprovalMode = cleanApprovalMode(settings.approval_mode);
+    telemetryEnabled = settings.telemetry_enabled !== false;
+    telemetryControlledByEnvironment = Boolean(settings.telemetry_controlled_by_environment);
     if (!currentProvider && hasOpenRouterKey) {
       currentProvider = "openrouter";
     }
@@ -828,6 +839,7 @@
       chatSurfaceBrowserInput.checked = currentChatSurface === CHAT_SURFACE_BROWSER;
     }
     syncApprovalModeControls();
+    syncTelemetryControl();
     updateChatSurfaceRestartNotice();
     if (ollamaBaseUrlInput) {
       syncOllamaSetupFields();
@@ -1234,6 +1246,10 @@
 
   function syncApprovalModeControls() {
     return settingsPanel?.syncApprovalModeControls();
+  }
+
+  function syncTelemetryControl() {
+    return settingsPanel?.syncTelemetryControl();
   }
 
   function updateChatSurfaceRestartNotice(surface) {

--- a/ui/chat/index.html
+++ b/ui/chat/index.html
@@ -493,6 +493,19 @@
                 Restart Godot for this change to take effect.
               </p>
             </fieldset>
+            <fieldset class="settings-group">
+              <legend>Anonymous telemetry</legend>
+              <label class="settings-check">
+                <input type="checkbox" data-telemetry-enabled checked />
+                <span>Share anonymous daily usage</span>
+              </label>
+              <p class="settings-note">
+                Sends an anonymous installation ID, Fennara and Godot versions, operating system, and CPU architecture at most once per UTC day. It never sends project names, paths, prompts, tool inputs, tool results, logs, or screenshots.
+              </p>
+              <p class="settings-status" data-telemetry-environment-status hidden>
+                Telemetry is disabled by an environment variable.
+              </p>
+            </fieldset>
           </section>
           <section class="settings-page mcp-apps-page" data-settings-page="mcp" hidden>
             <div class="mcp-apps-intro">

--- a/ui/chat/settings-panel.js
+++ b/ui/chat/settings-panel.js
@@ -1,4 +1,11 @@
 (function () {
+  function includeTelemetryPreference(payload, telemetryEnabled, controlledByEnvironment) {
+    if (!controlledByEnvironment) {
+      payload.telemetry_enabled = Boolean(telemetryEnabled);
+    }
+    return payload;
+  }
+
   function createSettingsPanel(options = {}) {
     const elements = options.elements || {};
     const callbacks = options.callbacks || {};
@@ -267,5 +274,6 @@
 
   window.FennaraSettingsPanel = {
     createSettingsPanel,
+    includeTelemetryPreference,
   };
 })();

--- a/ui/chat/settings-panel.js
+++ b/ui/chat/settings-panel.js
@@ -7,6 +7,8 @@
     const chatSurfaceBrowserInput = elements.chatSurfaceBrowserInput || null;
     const chatSurfaceRestartStatus = elements.chatSurfaceRestartStatus || null;
     const approvalModeControls = Array.from(elements.approvalModeControls || []);
+    const telemetryEnabledInput = elements.telemetryEnabledInput || null;
+    const telemetryEnvironmentStatus = elements.telemetryEnvironmentStatus || null;
     const settingsSavedToast = elements.settingsSavedToast || null;
     const saveSettingsButton = elements.saveSettingsButton || null;
     const openProvidersButton = elements.openProvidersButton || null;
@@ -27,6 +29,8 @@
     const cleanApprovalMode = callbacks.cleanApprovalMode || ((mode) => mode === approvalModeFullAccess ? approvalModeFullAccess : approvalModeAsk);
     const getCurrentChatSurface = callbacks.getCurrentChatSurface || (() => chatSurfaceEmbedded);
     const getCurrentApprovalMode = callbacks.getCurrentApprovalMode || (() => approvalModeAsk);
+    const getTelemetryEnabled = callbacks.getTelemetryEnabled || (() => true);
+    const getTelemetryControlledByEnvironment = callbacks.getTelemetryControlledByEnvironment || (() => false);
     const openProviderPicker = callbacks.openProviderPicker || function () {};
     const buildSavePayload = callbacks.buildSavePayload || (() => null);
     const sendIfOpen = callbacks.sendIfOpen || (() => false);
@@ -52,6 +56,7 @@
       const payload = buildSavePayload({
         chatSurface: selectedChatSurface(),
         approvalMode: selectedApprovalMode(),
+        telemetryEnabled: selectedTelemetryEnabled(),
       });
       if (payload) {
         queueSave(payload);
@@ -67,6 +72,10 @@
       control.addEventListener("change", () => {
         setDirty(true);
       });
+    });
+
+    telemetryEnabledInput?.addEventListener("change", () => {
+      setDirty(true);
     });
 
     openProvidersButton?.addEventListener("click", (event) => {
@@ -89,6 +98,7 @@
         chatSurfaceBrowserInput.checked = getCurrentChatSurface() === chatSurfaceBrowser;
       }
       syncApprovalModeControls();
+      syncTelemetryControl();
       updateChatSurfaceRestartNotice(getCurrentChatSurface());
       markClean();
       if (settingsDialog && typeof settingsDialog.showModal === "function") {
@@ -105,11 +115,26 @@
       return cleanApprovalMode(selected?.value || getCurrentApprovalMode());
     }
 
+    function selectedTelemetryEnabled() {
+      return telemetryEnabledInput?.checked ?? getTelemetryEnabled();
+    }
+
     function syncApprovalModeControls() {
       const currentApprovalMode = getCurrentApprovalMode();
       approvalModeControls.forEach((control) => {
         control.checked = cleanApprovalMode(control.value) === currentApprovalMode;
       });
+    }
+
+    function syncTelemetryControl() {
+      const controlledByEnvironment = Boolean(getTelemetryControlledByEnvironment());
+      if (telemetryEnabledInput) {
+        telemetryEnabledInput.checked = Boolean(getTelemetryEnabled());
+        telemetryEnabledInput.disabled = controlledByEnvironment;
+      }
+      if (telemetryEnvironmentStatus) {
+        telemetryEnvironmentStatus.hidden = !controlledByEnvironment;
+      }
     }
 
     function updateChatSurfaceRestartNotice(surface = selectedChatSurface()) {
@@ -230,9 +255,11 @@
       queueSave,
       selectedApprovalMode,
       selectedChatSurface,
+      selectedTelemetryEnabled,
       setDirty,
       setSaving,
       syncApprovalModeControls,
+      syncTelemetryControl,
       updateChatSurfaceRestartNotice,
       updateSaveButton,
     };


### PR DESCRIPTION
## Summary

- Send one anonymous active-installation event after a valid Godot editor connection, at most once per UTC day
- Deliver events through `https://fennara.io/api/telemetry`, so desktop installations never receive PostHog credentials
- Use a bounded background queue, short HTTP timeouts, atomic local state, and bounded daemon shutdown
- Add a Settings toggle plus `FENNARA_DISABLE_TELEMETRY` and `DO_NOT_TRACK` environment overrides
- Document the event schema, storage, opt-out behavior, privacy boundaries, and monthly-active calculation

## Motivation

Fennara needs a privacy-conscious way to estimate active installations and understand which supported versions and platforms are in use. This implementation collects only the minimum aggregate fields needed for those measurements, without collecting project content or user activity details.

Each event contains only:

- schema version
- fixed event name
- random installation UUID
- Fennara version
- normalized Godot version
- operating system
- CPU architecture

It does not collect project names, paths, files, prompts, tool calls, errors, screenshots, logs, IP addresses as event properties, or personal identity.

## Validation

```text
cd local
cargo test -p fennara-daemon --no-fail-fast -q
cargo fmt --all -- --check
```

```text
node --check ui/chat/app.js
node --check ui/chat/settings-panel.js
node scripts/sync-chat-ui.mjs
git diff --check
```

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added anonymous, once-per-UTC-day active-installation telemetry sent after a compatible Godot editor connection.
  * Added an “Anonymous telemetry” toggle to Chat Settings, with runtime synchronization of the effective telemetry state.
* **Privacy**
  * Telemetry excludes project details, prompts/tool activity, logs, and screenshots; sends a minimal payload (installation ID plus Fennara/Godot versions, OS, and CPU architecture).
  * Environment overrides can disable telemetry and remove local telemetry state.
* **Documentation**
  * Added/expanded telemetry documentation in README, docs index, and a dedicated telemetry guide.
* **Tests**
  * Added coverage for telemetry enablement, environment truthiness behavior, and delivery/state persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->