### PR TITLE
fix(installer): repair Linux CEF runtime markers

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -401,7 +401,11 @@ clearly.
 The CLI must publish Linux CEF runtime updates atomically: extract and validate
 in a staging directory, write the runtime marker only after required files are
 present, then publish the version directory and update `current.json` with a
-temp-file rename. Running editors keep using the runtime they already loaded.
+temp-file rename. The installed `fennara-cef-runtime.json` marker must identify
+the native loader contract with `"runtime": "cef"`. Install and update repair a
+matching legacy marker that only contains `"kind": "cef"` without downloading
+the CEF payload again. Running editors keep using the runtime they already
+loaded.
 
 The CLI embeds the generated project guidance templates from `local/templates/`.
 When release packaging builds the CLI, those templates are compiled into the binary with the rest of the CLI code.

--- a/local/crates/fennara-cli/src/webview_runtime.rs
+++ b/local/crates/fennara-cli/src/webview_runtime.rs
@@ -106,10 +106,19 @@ fn ensure_linux_cef_manifest(
     }
 
     let target_dir = layout.linux_cef_runtime_dir(platform_arch, version);
-    if runtime_complete(&target_dir, manifest) {
+    if runtime_repairable(&target_dir, manifest) {
+        let repaired = !runtime_complete(&target_dir, manifest);
+        if repaired {
+            write_runtime_marker(&target_dir, manifest)?;
+        }
         write_current_runtime(&target_dir, manifest)?;
         return Ok(Some(format!(
-            "webview runtime: Linux CEF runtime is installed at {}",
+            "webview runtime: Linux CEF runtime {} at {}",
+            if repaired {
+                "marker repaired"
+            } else {
+                "is installed"
+            },
             display_path(&target_dir)
         )));
     }
@@ -169,10 +178,14 @@ pub fn report_for_doctor(layout: &AppLayout, repair: bool) -> Result<(), String>
         layout.linux_cef_runtime_dir(platform_arch, version)
     };
     println!("linux cef runtime: {}", display_path(&runtime_dir));
+    let runtime_complete = runtime_complete(&runtime_dir, &manifest);
+    let runtime_repairable = runtime_repairable(&runtime_dir, &manifest);
     println!(
         "linux cef runtime status: {}",
-        if runtime_complete(&runtime_dir, &manifest) {
+        if runtime_complete {
             "installed"
+        } else if runtime_repairable {
+            "installed; marker repair required"
         } else if manifest
             .get("enabled")
             .and_then(Value::as_bool)
@@ -194,7 +207,10 @@ pub fn report_for_doctor(layout: &AppLayout, repair: bool) -> Result<(), String>
     if repair {
         let removed = cleanup_stale_process_dirs(&layout.webview_profile_root().join("cef"))?;
         println!("linux cef stale profile cleanup: removed {removed}");
-        if runtime_complete(&runtime_dir, &manifest) {
+        if runtime_repairable {
+            if !runtime_complete {
+                write_runtime_marker(&runtime_dir, &manifest)?;
+            }
             write_current_runtime(&runtime_dir, &manifest)?;
             println!("linux cef current marker: repaired");
         }
@@ -237,6 +253,10 @@ fn runtime_matches_current_platform(manifest: &Value) -> bool {
 }
 
 fn runtime_complete(runtime_dir: &Path, manifest: &Value) -> bool {
+    runtime_repairable(runtime_dir, manifest) && runtime_marker_is_native_compatible(runtime_dir)
+}
+
+fn runtime_repairable(runtime_dir: &Path, manifest: &Value) -> bool {
     runtime_dir.join("fennara-cef-runtime.json").is_file()
         && runtime_marker_matches(runtime_dir, manifest)
         && manifest
@@ -245,6 +265,19 @@ fn runtime_complete(runtime_dir: &Path, manifest: &Value) -> bool {
             .map(|version| runtime_dir.ends_with(version))
             .unwrap_or(false)
         && required_files_present(runtime_dir, manifest).is_ok()
+}
+
+fn runtime_marker_is_native_compatible(runtime_dir: &Path) -> bool {
+    let marker_path = runtime_dir.join("fennara-cef-runtime.json");
+    let Ok(raw) = fs::read_to_string(marker_path) else {
+        return false;
+    };
+    let Ok(marker) = serde_json::from_str::<Value>(&raw) else {
+        return false;
+    };
+
+    marker_string(&marker, "runtime") == Some("cef")
+        && marker_string(&marker, "platform") == Some("linux")
 }
 
 fn runtime_marker_matches(runtime_dir: &Path, manifest: &Value) -> bool {
@@ -357,18 +390,7 @@ fn download_and_install_zip(
     let install_result = (|| {
         copy_dir(&extract_dir, &staging_dir)?;
         required_files_present(&staging_dir, manifest)?;
-        let raw = serde_json::to_string_pretty(manifest)
-            .map_err(|err| format!("failed to serialize Linux CEF runtime manifest: {err}"))?;
-        fs::write(
-            staging_dir.join("fennara-cef-runtime.json"),
-            format!("{raw}\n"),
-        )
-        .map_err(|err| {
-            format!(
-                "failed to write Linux CEF runtime marker in {}: {err}",
-                display_path(&staging_dir)
-            )
-        })?;
+        write_runtime_marker(&staging_dir, manifest)?;
         publish_runtime_dir(&staging_dir, target_dir, manifest)
     })();
 
@@ -376,6 +398,9 @@ fn download_and_install_zip(
         let _ = fs::remove_dir_all(&staging_dir);
     }
     install_result?;
+    if !runtime_complete(target_dir, manifest) {
+        write_runtime_marker(target_dir, manifest)?;
+    }
     write_current_runtime(target_dir, manifest)
 }
 
@@ -386,7 +411,7 @@ fn publish_runtime_dir(
 ) -> Result<(), String> {
     let mut moved_aside: Option<PathBuf> = None;
     if target_dir.exists() {
-        if runtime_complete(target_dir, manifest) {
+        if runtime_repairable(target_dir, manifest) {
             fs::remove_dir_all(staging_dir).map_err(|err| {
                 format!(
                     "failed to remove redundant Linux CEF staging dir {}: {err}",
@@ -419,7 +444,7 @@ fn publish_runtime_dir(
                 let _ = fs::remove_dir_all(backup);
             }
         }
-        Err(_) if target_dir.exists() && runtime_complete(target_dir, manifest) => {
+        Err(_) if target_dir.exists() && runtime_repairable(target_dir, manifest) => {
             let _ = fs::remove_dir_all(staging_dir);
             if let Some(backup) = moved_aside {
                 let _ = fs::remove_dir_all(backup);
@@ -437,16 +462,50 @@ fn publish_runtime_dir(
             ));
         }
     }
-    let raw = serde_json::to_string_pretty(manifest)
-        .map_err(|err| format!("failed to serialize Linux CEF runtime manifest: {err}"))?;
-    let marker_path = target_dir.join("fennara-cef-runtime.json");
-    fs::write(&marker_path, format!("{raw}\n")).map_err(|err| {
+    required_files_present(target_dir, manifest)
+}
+
+fn write_runtime_marker(runtime_dir: &Path, manifest: &Value) -> Result<(), String> {
+    let mut marker = manifest.clone();
+    let marker_object = marker
+        .as_object_mut()
+        .ok_or_else(|| "Linux CEF runtime manifest must be an object".to_string())?;
+    marker_object.insert("runtime".to_string(), Value::String("cef".to_string()));
+    marker_object.insert("platform".to_string(), Value::String("linux".to_string()));
+
+    let raw = serde_json::to_string_pretty(&marker)
+        .map_err(|err| format!("failed to serialize Linux CEF runtime marker: {err}"))?;
+    let marker_path = runtime_dir.join("fennara-cef-runtime.json");
+    let temp_path =
+        marker_path.with_file_name(format!("fennara-cef-runtime.json.tmp-{}", unique_suffix()));
+    fs::write(&temp_path, format!("{raw}\n")).map_err(|err| {
         format!(
-            "failed to verify Linux CEF runtime marker in {}: {err}",
-            display_path(&marker_path)
+            "failed to write Linux CEF runtime marker {}: {err}",
+            display_path(&temp_path)
         )
     })?;
-    required_files_present(target_dir, manifest)
+    publish_runtime_marker(&temp_path, &marker_path)
+}
+
+fn publish_runtime_marker(temp_path: &Path, marker_path: &Path) -> Result<(), String> {
+    #[cfg(windows)]
+    if marker_path.is_file() {
+        fs::remove_file(marker_path).map_err(|err| {
+            let _ = fs::remove_file(temp_path);
+            format!(
+                "failed to replace Linux CEF runtime marker {}: {err}",
+                display_path(marker_path)
+            )
+        })?;
+    }
+
+    fs::rename(temp_path, marker_path).map_err(|err| {
+        let _ = fs::remove_file(temp_path);
+        format!(
+            "failed to publish Linux CEF runtime marker {}: {err}",
+            display_path(marker_path)
+        )
+    })
 }
 
 fn create_temp_dir() -> Result<PathBuf, String> {
@@ -585,6 +644,9 @@ fn write_current_runtime(target_dir: &Path, manifest: &Value) -> Result<(), Stri
         )
     })
 }
+
+#[cfg(test)]
+mod tests;
 
 fn cleanup_stale_process_dirs(root: &Path) -> Result<usize, String> {
     if !root.is_dir() {

--- a/local/crates/fennara-cli/src/webview_runtime/tests.rs
+++ b/local/crates/fennara-cli/src/webview_runtime/tests.rs
@@ -59,12 +59,18 @@ fn leaves_complete_runtime_marker_unchanged() {
     fs::write(runtime_dir.join("libcef.so"), "cef").unwrap();
 
     let manifest = release_manifest(version, platform_arch);
-    let mut complete_marker = manifest.clone();
-    complete_marker["runtime"] = json!("cef");
-    complete_marker["platform"] = json!("linux");
     let marker_bytes = format!(
-        "{}\n",
-        serde_json::to_string_pretty(&complete_marker).unwrap()
+        concat!(
+            "{{\n",
+            "  \"ignored_test_field\": true,\n",
+            "\t\"runtime\":\"cef\", \"platform\": \"linux\",\n",
+            "  \"version\": {},\n",
+            "  \"platform_arch\": {},\n",
+            "  \"archive\": {{ \"sha256\":\"abc123\" }}\n",
+            "}}\n"
+        ),
+        serde_json::to_string(version).unwrap(),
+        serde_json::to_string(platform_arch).unwrap(),
     );
     let marker_path = runtime_dir.join("fennara-cef-runtime.json");
     fs::write(&marker_path, &marker_bytes).unwrap();

--- a/local/crates/fennara-cli/src/webview_runtime/tests.rs
+++ b/local/crates/fennara-cli/src/webview_runtime/tests.rs
@@ -1,0 +1,117 @@
+use super::{
+    current_linux_platform_arch, ensure_linux_cef_manifest, runtime_complete, runtime_repairable,
+};
+use crate::app_layout::AppLayout;
+use serde_json::{Value, json};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[test]
+fn repairs_release_marker_missing_native_runtime_identity() {
+    let root = TestDir::new("repair-runtime-marker");
+    let version = "139.0.28+chromium-139.0.7258.139";
+    let layout = test_layout(&root);
+    let platform_arch = current_linux_platform_arch();
+    let runtime_dir = layout.linux_cef_runtime_dir(platform_arch, version);
+    fs::create_dir_all(&runtime_dir).unwrap();
+    fs::write(runtime_dir.join("libcef.so"), "cef").unwrap();
+
+    let manifest = release_manifest(version, platform_arch);
+    fs::write(
+        runtime_dir.join("fennara-cef-runtime.json"),
+        format!("{}\n", serde_json::to_string_pretty(&manifest).unwrap()),
+    )
+    .unwrap();
+
+    assert!(runtime_repairable(&runtime_dir, &manifest));
+    assert!(!runtime_complete(&runtime_dir, &manifest));
+
+    let message = ensure_linux_cef_manifest(&layout, &manifest, None)
+        .unwrap()
+        .unwrap();
+
+    let marker: Value =
+        serde_json::from_slice(&fs::read(runtime_dir.join("fennara-cef-runtime.json")).unwrap())
+            .unwrap();
+    assert_eq!(marker["kind"], "cef");
+    assert_eq!(marker["runtime"], "cef");
+    assert_eq!(marker["platform"], "linux");
+    assert!(runtime_complete(&runtime_dir, &manifest));
+    assert!(message.contains("marker repaired"));
+
+    let current: Value = serde_json::from_slice(
+        &fs::read(runtime_dir.parent().unwrap().join("current.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(current["runtime"], "cef");
+    assert_eq!(current["dir"], version);
+}
+
+fn release_manifest(version: &str, platform_arch: &str) -> Value {
+    json!({
+        "id": "linux-cef",
+        "kind": "cef",
+        "schema_version": 1,
+        "platform": "linux",
+        "arch": "x86_64",
+        "platform_arch": platform_arch,
+        "version": version,
+        "enabled": true,
+        "required_files": ["libcef.so"],
+        "archive": {
+            "format": "zip",
+            "name": "fennara-webview-cef-linux-x64.zip",
+            "sha256": "abc123"
+        }
+    })
+}
+
+fn test_layout(root: &Path) -> AppLayout {
+    let app_dir = root.join("app");
+    AppLayout {
+        bin_dir: app_dir.join("bin"),
+        versions_dir: app_dir.join("versions"),
+        cache_dir: app_dir.join("cache"),
+        logs_dir: app_dir.join("logs"),
+        operation_logs_dir: app_dir.join("logs/operations"),
+        operations_dir: app_dir.join("operations"),
+        tools_dir: app_dir.join("tools"),
+        webview_dir: app_dir.join("webview"),
+        current_manifest_path: app_dir.join("current.json"),
+        app_dir,
+    }
+}
+
+struct TestDir(PathBuf);
+
+impl TestDir {
+    fn new(name: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../temp")
+            .join(format!(
+                "webview-runtime-test-{name}-{}-{nonce}",
+                std::process::id()
+            ));
+        fs::create_dir_all(&root).unwrap();
+        Self(root)
+    }
+}
+
+impl std::ops::Deref for TestDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/local/crates/fennara-cli/src/webview_runtime/tests.rs
+++ b/local/crates/fennara-cli/src/webview_runtime/tests.rs
@@ -48,6 +48,37 @@ fn repairs_release_marker_missing_native_runtime_identity() {
     assert_eq!(current["dir"], version);
 }
 
+#[test]
+fn leaves_complete_runtime_marker_unchanged() {
+    let root = TestDir::new("complete-runtime-marker");
+    let version = "139.0.28+chromium-139.0.7258.139";
+    let layout = test_layout(&root);
+    let platform_arch = current_linux_platform_arch();
+    let runtime_dir = layout.linux_cef_runtime_dir(platform_arch, version);
+    fs::create_dir_all(&runtime_dir).unwrap();
+    fs::write(runtime_dir.join("libcef.so"), "cef").unwrap();
+
+    let manifest = release_manifest(version, platform_arch);
+    let mut complete_marker = manifest.clone();
+    complete_marker["runtime"] = json!("cef");
+    complete_marker["platform"] = json!("linux");
+    let marker_bytes = format!(
+        "{}\n",
+        serde_json::to_string_pretty(&complete_marker).unwrap()
+    );
+    let marker_path = runtime_dir.join("fennara-cef-runtime.json");
+    fs::write(&marker_path, &marker_bytes).unwrap();
+
+    assert!(runtime_complete(&runtime_dir, &manifest));
+
+    let message = ensure_linux_cef_manifest(&layout, &manifest, None)
+        .unwrap()
+        .unwrap();
+
+    assert!(message.contains("is installed"));
+    assert_eq!(fs::read_to_string(marker_path).unwrap(), marker_bytes);
+}
+
 fn release_manifest(version: &str, platform_arch: &str) -> Value {
     json!({
         "id": "linux-cef",

--- a/scripts/tests/release-manifest.test.mjs
+++ b/scripts/tests/release-manifest.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { createReleaseIdentity } from "../release-identity.mjs";
+import { RELEASE_TARGETS } from "../release-targets.mjs";
+
+test("Linux CEF release record includes the native runtime marker identity", () => {
+  const tempParent = fileURLToPath(new URL("../../temp/", import.meta.url));
+  mkdirSync(tempParent, { recursive: true });
+  const directory = mkdtempSync(path.join(tempParent, "release-manifest-"));
+  const assetsDir = path.join(directory, "assets");
+  const version = "1.2.3";
+  const cefAssetName = "fennara-webview-cef-linux-x64-test.zip";
+
+  try {
+    mkdirSync(assetsDir, { recursive: true });
+    writeReleaseAssets(assetsDir, version);
+    const cefBytes = Buffer.from("cef-runtime");
+    writeFileSync(path.join(assetsDir, cefAssetName), cefBytes);
+
+    const cefManifestPath = path.join(directory, "linux-cef.json");
+    writeFileSync(
+      cefManifestPath,
+      JSON.stringify({
+        schema_version: 1,
+        runtime: "cef",
+        platform: "linux",
+        arch: "x86_64",
+        platform_arch: "linux-x64",
+        version: "139.0.28+chromium-139.0.7258.139",
+        enabled: true,
+        required_files: ["libcef.so"],
+        archive: {
+          format: "zip",
+          name: cefAssetName,
+          sha256: createHash("sha256").update(cefBytes).digest("hex"),
+        },
+      }),
+    );
+
+    const identityPath = path.join(directory, "release.json");
+    writeFileSync(identityPath, JSON.stringify(createReleaseIdentity({ version })));
+    const outPath = path.join(directory, "manifest.json");
+    const result = spawnSync(
+      process.execPath,
+      [
+        fileURLToPath(new URL("../write-release-manifest.mjs", import.meta.url)),
+        "--version",
+        version,
+        "--assets-dir",
+        assetsDir,
+        "--linux-cef-manifest",
+        cefManifestPath,
+        "--release-identity",
+        identityPath,
+        "--out",
+        outPath,
+      ],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    const manifest = JSON.parse(readFileSync(outPath, "utf8"));
+    assert.equal(manifest.shared_runtimes[0].kind, "cef");
+    assert.equal(manifest.shared_runtimes[0].runtime, "cef");
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function writeReleaseAssets(assetsDir, version) {
+  for (const target of RELEASE_TARGETS) {
+    writeFileSync(
+      path.join(assetsDir, `fennara-cli-${target.platform}-${target.arch}-v${version}.zip`),
+      `cli-${target.key}`,
+    );
+    writeFileSync(
+      path.join(
+        assetsDir,
+        `fennara-release-local-${target.platform}-${target.arch}-v${version}.zip`,
+      ),
+      `local-${target.key}`,
+    );
+  }
+  writeFileSync(
+    path.join(assetsDir, `fennara-release-addon-v${version}.zip`),
+    "addon",
+  );
+}

--- a/scripts/write-release-manifest.mjs
+++ b/scripts/write-release-manifest.mjs
@@ -120,6 +120,7 @@ function sharedRuntimeRecords() {
     {
       id: "linux-cef",
       kind: "cef",
+      runtime: "cef",
       schema_version: linuxCef.schema_version ?? 1,
       platform: linuxCef.platform ?? "linux",
       arch: linuxCef.arch ?? "x86_64",


### PR DESCRIPTION
## Purpose

Fix Linux built-in chat startup for users whose installed CEF runtime marker was generated without the native `runtime` identity.

Fixes #132

## Root cause

The release manifest described the shared CEF runtime with `kind: "cef"`. The CLI copied that release record into `fennara-cef-runtime.json`, while the native Linux loader required `runtime: "cef"` and rejected the installed runtime.

## Changes

- Emit both the generic `kind` and native `runtime` identities in Linux CEF release records.
- Normalize newly installed runtime markers for the native loader.
- Repair matching legacy markers without downloading the large CEF payload again.
- Avoid rewriting healthy markers, and publish repaired markers through a temporary sibling and rename.
- Cover release-manifest generation and the existing-user repair path with focused tests.
- Document the installed marker contract and repair behavior.

## Release follow-up

This fix PR intentionally leaves the minimum CLI policy unchanged. The version-bump PR for the next stable release should raise the stable minimum to the CLI version containing this repair.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p fennara-cli`
- `cargo clippy -p fennara-cli --all-targets -- -D warnings`
- `node --test scripts/tests/*.test.mjs`

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux CEF runtime install/repair to correctly handle “repairable but incomplete” cases by updating the runtime marker and `current.json`.
  * Added stronger completeness checks by validating the stored marker matches the native CEF identity and Linux platform.
  * Refined install status messaging to clearly indicate when marker repair was required.
* **New Features**
  * Linux CEF release manifest generation now includes the native `runtime: "cef"` identity.
* **Documentation**
  * Expanded Linux CEF runtime update guidance with clearer atomic staging and marker/repair steps.
* **Tests**
  * Added Linux CEF marker repair integration tests and a Node.js release-manifest test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->