### PR TITLE
fix(gdextension): exclude Fennara from game exports

### DIFF
--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -232,6 +232,27 @@ jobs:
             }
           }
 
+          $exportTest = Start-Process `
+            -FilePath "${{ steps.godot.outputs.console }}" `
+            -ArgumentList @(
+              "--headless",
+              "--editor",
+              "--path",
+              '"${{ github.workspace }}\godot_demo"',
+              "--script",
+              "res://tests/export_plugin_test.gd"
+            ) `
+            -NoNewWindow `
+            -PassThru
+          if (-not $exportTest.WaitForExit($testTimeoutSeconds * 1000)) {
+            Write-Host "::error::Native export plugin test exceeded ${testTimeoutSeconds} seconds."
+            & taskkill.exe /PID $exportTest.Id /T /F
+            exit 124
+          }
+          if ($exportTest.ExitCode -ne 0) {
+            exit $exportTest.ExitCode
+          }
+
       - name: Test Linux guidance containment
         if: steps.source.outputs.available == 'true' && matrix.platform == 'linux'
         timeout-minutes: 5

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ appear after manually downloading and extracting the addon ZIP.
 
 Open the project, select the Fennara dock, and press **Set Up Fennara**.
 
+Fennara is an editor dependency, not a game runtime dependency. During export,
+the editor plugin removes its runtime autoload from the exported project and
+skips `res://addons/fennara/` and `res://.fennara/`. The editor project is
+restored after the export finishes. If a CI checkout excludes the addon with
+`.gitignore`, run `fennara prepare-export --project path/to/project` before
+starting Godot, or install the addon in that checkout. Godot validates autoload
+paths before export plugins can run, so this preparation must happen first.
+
 > **macOS:** The release addon contains a native library that is not currently
 > Apple-notarized. If you download the addon ZIP through a browser and extract
 > it manually, macOS may report that it cannot verify

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -387,6 +387,20 @@ all connected Godot editors. A start request runs in the selected or
 chat-bound Godot project, but another running managed scene must be stopped
 before starting a new one.
 
+## Export Boundary
+
+Fennara is active only in the editor. Its export plugin temporarily removes the
+`_fennara_game_capture` autoload before Godot serializes exported project
+settings, skips every file under `res://addons/fennara/` and `res://.fennara/`,
+and temporarily removes its entry from Godot's generated GDExtension registry.
+It restores the original autoload and registry when export ends. It does not
+rewrite or persist changes to `export_presets.cfg` or `project.godot`.
+
+This boundary starts after Godot opens the project. A CI checkout that omits
+`addons/fennara/` must run `fennara prepare-export` or install the addon before
+launching Godot. An export plugin cannot repair a missing autoload target
+before project startup validation.
+
 ## Release Assets
 
 Each public release publishes separate assets so installs can stay modular:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,6 +66,7 @@ Linux: ~/.local/share/fennara
 | `fennara doctor` | Inspect or repair the local installation |
 | `fennara diagnostics` | Show a sanitized operation report |
 | `fennara mcp-setup` | Connect an external MCP app |
+| `fennara prepare-export` | Remove Fennara's autoload before an addon-free CI export |
 | `fennara recover` | Restore an interrupted native update |
 | `fennara self-update` | Update only the installed CLI |
 
@@ -102,6 +103,22 @@ Installation has two safe paths:
   the current platform library, and installs that exact version's CLI-managed
   components. It keeps the project addon unchanged. An explicit `--version`
   must match the existing addon.
+
+## Prepare An Addon-Free CI Export
+
+If `addons/fennara/` is excluded from a CI checkout, remove Fennara's persistent
+runtime autoload before Godot starts:
+
+```bash
+fennara prepare-export --project path/to/project
+godot --headless --path path/to/project --export-release "Preset"
+```
+
+The command edits only the `_fennara_game_capture` entry in `project.godot`.
+It preserves other autoloads and settings and is safe to rerun. This step must
+run before Godot because project startup validates autoload paths before editor
+or export plugins can execute. CI may instead install the Fennara addon before
+starting Godot.
 
 ## Update A Project
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -49,6 +49,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `local/crates/fennara-cli/src/operation.rs` | Public install/update operation coordinator, phases, and CLI handoff entry points. |
 | `local/crates/fennara-cli/src/operation/` | Focused operation journal, durable storage, diagnostic redaction, and test modules. |
 | `local/crates/fennara-cli/src/project_addon.rs` | Existing project-addon version and current-platform GDExtension library validation. |
+| `local/crates/fennara-cli/src/prepare_export.rs` | Addon-free CI export preparation that removes only Fennara's persistent runtime autoload before Godot starts. |
 | `local/crates/fennara-cli/src/release_identity.rs` | Stable/staging addon identity, exact release selectors, pull-request channel validation, and legacy stable compatibility. |
 | `local/crates/fennara-cli/src/release_channel.rs` | Per-channel staging pointer validation and resolution to an exact versioned release. |
 | `local/crates/fennara-cli/src/release_manifest.rs` | Release manifest parsing, asset hash validation, identity binding, and platform package selection. |
@@ -107,6 +108,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | `godot_demo/addons/fennara/dist/` | Packaged web UI assets used by the in-editor chat webview. |
 | `godot_demo/addons/fennara/runtime/` | Synced packaged copy of `runtime/` shipped inside the addon. |
 | `godot_demo/tests/first_run_setup_test.gd` | Headless native first-run setup state and deterministic failure test. |
+| `godot_demo/tests/export_plugin_test.gd` | Headless native export exclusion and autoload restoration regression test. |
 | `godot_demo/tests/screenshot_scene_contract_test.gd` | Headless native screenshot argument-contract regression test. |
 | `godot_demo/tests/image_sheet_test.gd` | Headless shared screenshot/runtime sheet composition regression test. |
 | `godot_demo/tests/runtime_image_context_test.gd` | Headless runtime raw-frame, sheet, and arbitrary-Image output regression test. |
@@ -168,6 +170,7 @@ This is the quick map for contributors and coding agents working in this reposit
 | Change CLI commands or terminal behavior | `local/crates/fennara-cli/src/` and `docs/cli.md` |
 | Change native update progress, shutdown confirmation, activation handshake, or recovery | `fennara-cpp/src/update/`, `fennara-cpp/src/ui/update_panel.cpp`, `fennara-cpp/src/ui/dock.cpp`, `local/crates/fennara-daemon/src/runtime_daemon/chat/mod.rs`, and `ui/chat/` |
 | Change native first-run setup or CLI bootstrap | `fennara-cpp/src/setup/`, `fennara-cpp/src/ui/setup_panel.cpp`, and `fennara-cpp/src/ui/dock.cpp` |
+| Change export-time addon exclusion | `fennara-cpp/src/ui/export_plugin.cpp`, `fennara-cpp/include/fennara/ui/export_plugin.hpp`, and `godot_demo/tests/export_plugin_test.gd` |
 | Change install/update operation logs, phases, error codes, or diagnostic reports | `local/crates/fennara-cli/src/operation.rs`, `local/crates/fennara-cli/src/operation/`, and `local/crates/fennara-cli/src/diagnostics.rs` |
 | Change webview prerequisite checks | `local/crates/fennara-cli/src/webview_prereq.rs`, `local/crates/fennara-cli/src/webview_runtime.rs`, and `fennara-cpp/src/ui/webview_host*` |
 | Change generated project guidance | `local/templates/` and `local/crates/fennara-cli/src/project_guidance.rs` |

--- a/fennara-cpp/include/fennara/ui/export_plugin.hpp
+++ b/fennara-cpp/include/fennara/ui/export_plugin.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <godot_cpp/classes/editor_export_platform.hpp>
+#include <godot_cpp/classes/editor_export_plugin.hpp>
+#include <godot_cpp/variant/packed_string_array.hpp>
+#include <godot_cpp/variant/string.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+#include <cstdint>
+
+namespace fennara {
+
+class FennaraExportPlugin : public godot::EditorExportPlugin {
+    GDCLASS(FennaraExportPlugin, godot::EditorExportPlugin)
+
+protected:
+    static void _bind_methods();
+
+private:
+    bool export_active = false;
+    bool had_runtime_autoload = false;
+    godot::Variant saved_runtime_autoload;
+    bool extension_list_changed = false;
+    godot::String extension_list_path;
+    godot::PackedByteArray saved_extension_list;
+
+    static bool _should_skip_path(const godot::String &path);
+    static godot::String _filter_extension_list(
+        const godot::String &contents);
+    void _resolve_extension_list_path();
+    bool _replace_extension_list(
+        const godot::PackedByteArray &contents);
+    bool _restore_extension_list_backup();
+    void _suppress_extension_list_entry();
+    void _restore_export_state();
+
+public:
+    FennaraExportPlugin();
+    ~FennaraExportPlugin();
+
+    godot::String _get_name() const override;
+    bool _supports_platform(
+        const godot::Ref<godot::EditorExportPlatform> &platform) const override;
+    void _export_begin(const godot::PackedStringArray &features,
+                       bool is_debug,
+                       const godot::String &path,
+                       uint32_t flags) override;
+    void _export_file(const godot::String &path,
+                      const godot::String &type,
+                      const godot::PackedStringArray &features) override;
+    void _export_end() override;
+
+#ifdef FENNARA_SETUP_TEST_HOOKS
+    bool test_should_skip_path(const godot::String &path) const;
+    godot::String test_filter_extension_list(
+        const godot::String &contents) const;
+    void test_suppress_extension_list_entry();
+    void test_export_begin();
+    void test_export_end();
+#endif
+};
+
+} // namespace fennara

--- a/fennara-cpp/include/fennara/ui/export_plugin.hpp
+++ b/fennara-cpp/include/fennara/ui/export_plugin.hpp
@@ -2,6 +2,7 @@
 
 #include <godot_cpp/classes/editor_export_platform.hpp>
 #include <godot_cpp/classes/editor_export_plugin.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
 #include <godot_cpp/variant/packed_string_array.hpp>
 #include <godot_cpp/variant/string.hpp>
 #include <godot_cpp/variant/variant.hpp>

--- a/fennara-cpp/include/fennara/ui/fennara_plugin.hpp
+++ b/fennara-cpp/include/fennara/ui/fennara_plugin.hpp
@@ -8,6 +8,7 @@
 namespace fennara {
 
 class FennaraLocalBridge;
+class FennaraExportPlugin;
 class FennaraScriptContextMenuPlugin;
 
 class FennaraPlugin : public godot::EditorPlugin {
@@ -19,6 +20,7 @@ protected:
 private:
     FennaraDock *dock_instance = nullptr;
     FennaraLocalBridge *local_bridge = nullptr;
+    godot::Ref<FennaraExportPlugin> export_plugin;
     godot::Ref<FennaraScriptContextMenuPlugin> script_context_menu_plugin;
     bool csharp_preparation_pending = false;
     bool initial_filesystem_scan_completed = false;
@@ -26,9 +28,6 @@ private:
     std::thread update_check_thread;
     void _stop_update_check();
     void _configure_editor_settings();
-    void _ensure_export_presets_exclude_fennara();
-    bool _is_export_preset_section(const godot::String &section) const;
-    godot::PackedStringArray _split_export_filter(const godot::String &raw) const;
     void _ensure_runtime_helper_autoload();
     void _start_csharp_preparation();
     void _on_editor_filesystem_changed();

--- a/fennara-cpp/src/register_types.cpp
+++ b/fennara-cpp/src/register_types.cpp
@@ -25,6 +25,7 @@
 #include "fennara/update/update_coordinator.hpp"
 
 #include "fennara/ui/dock.hpp"
+#include "fennara/ui/export_plugin.hpp"
 #include "fennara/ui/fennara_plugin.hpp"
 #include "fennara/ui/setup_panel.hpp"
 #include "fennara/ui/update_panel.hpp"
@@ -70,6 +71,7 @@ void initialize_fennara(godot::ModuleInitializationLevel p_level) {
     }
 
     if (p_level == godot::MODULE_INITIALIZATION_LEVEL_EDITOR) {
+        godot::ClassDB::register_class<fennara::FennaraExportPlugin>();
         godot::ClassDB::register_class<fennara::FennaraScriptContextMenuPlugin>();
         godot::ClassDB::register_class<fennara::FennaraPlugin>();
         godot::EditorPlugins::add_by_type<fennara::FennaraPlugin>();

--- a/fennara-cpp/src/ui/export_plugin.cpp
+++ b/fennara-cpp/src/ui/export_plugin.cpp
@@ -1,0 +1,368 @@
+#include "fennara/ui/export_plugin.hpp"
+
+#include "fennara/logger.hpp"
+
+#include <godot_cpp/classes/dir_access.hpp>
+#include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#include <godot_cpp/core/class_db.hpp>
+
+namespace fennara {
+
+namespace {
+
+constexpr const char *RUNTIME_AUTOLOAD_KEY =
+    "autoload/_fennara_game_capture";
+constexpr const char *ADDON_EXPORT_PREFIX = "res://addons/fennara/";
+constexpr const char *PROJECT_STATE_EXPORT_PREFIX = "res://.fennara/";
+constexpr const char *EXTENSION_LIST_BACKUP_SUFFIX =
+    ".fennara-export-backup";
+constexpr const char *EXTENSION_LIST_DISCARD_SUFFIX =
+    ".fennara-export-discard";
+constexpr const char *EXTENSION_LIST_STAGING_SUFFIX =
+    ".fennara-export-tmp";
+
+} // namespace
+
+void FennaraExportPlugin::_bind_methods() {
+#ifdef FENNARA_SETUP_TEST_HOOKS
+    godot::ClassDB::bind_method(
+        godot::D_METHOD("test_should_skip_path", "path"),
+        &FennaraExportPlugin::test_should_skip_path);
+    godot::ClassDB::bind_method(
+        godot::D_METHOD("test_filter_extension_list", "contents"),
+        &FennaraExportPlugin::test_filter_extension_list);
+    godot::ClassDB::bind_method(
+        godot::D_METHOD("test_suppress_extension_list_entry"),
+        &FennaraExportPlugin::test_suppress_extension_list_entry);
+    godot::ClassDB::bind_method(
+        godot::D_METHOD("test_export_begin"),
+        &FennaraExportPlugin::test_export_begin);
+    godot::ClassDB::bind_method(
+        godot::D_METHOD("test_export_end"),
+        &FennaraExportPlugin::test_export_end);
+#endif
+}
+
+FennaraExportPlugin::FennaraExportPlugin() {
+    _resolve_extension_list_path();
+    const godot::String backup_path =
+        extension_list_path + godot::String(EXTENSION_LIST_BACKUP_SUFFIX);
+    if (!extension_list_path.is_empty() &&
+        godot::FileAccess::file_exists(backup_path)) {
+        extension_list_changed = true;
+        if (_restore_extension_list_backup()) {
+            FLOG_SYS(
+                "Export guard recovered an interrupted extension registry update");
+        } else {
+            FLOG_ERR(
+                "Export guard could not recover an interrupted extension registry update");
+        }
+    }
+}
+
+FennaraExportPlugin::~FennaraExportPlugin() {
+    _restore_export_state();
+}
+
+godot::String FennaraExportPlugin::_get_name() const {
+    // Godot sorts export plugins by name. This must run before the built-in
+    // GDExtension plugin so skip() also prevents native libraries from being added.
+    return "FennaraExportGuard";
+}
+
+bool FennaraExportPlugin::_supports_platform(
+    const godot::Ref<godot::EditorExportPlatform> &platform) const {
+    (void)platform;
+    return true;
+}
+
+void FennaraExportPlugin::_export_begin(
+    const godot::PackedStringArray &features,
+    bool is_debug,
+    const godot::String &path,
+    uint32_t flags) {
+    (void)features;
+    (void)is_debug;
+    (void)path;
+    (void)flags;
+
+    if (export_active || extension_list_changed) {
+        FLOG_ERR(
+            "Export guard found stale state; restoring it before the next export");
+        _restore_export_state();
+        if (extension_list_changed) {
+            const godot::Ref<godot::EditorExportPlatform> platform =
+                get_export_platform();
+            if (platform.is_valid()) {
+                platform->add_message(
+                    godot::EditorExportPlatform::EXPORT_MESSAGE_ERROR,
+                    "Fennara",
+                    "Could not restore Godot's extension registry from the previous export.");
+            }
+            return;
+        }
+    }
+
+    godot::ProjectSettings *settings =
+        godot::ProjectSettings::get_singleton();
+    if (settings == nullptr) {
+        FLOG_ERR("Export guard could not access ProjectSettings");
+        return;
+    }
+
+    export_active = true;
+    had_runtime_autoload = settings->has_setting(RUNTIME_AUTOLOAD_KEY);
+    if (had_runtime_autoload) {
+        saved_runtime_autoload =
+            settings->get_setting(RUNTIME_AUTOLOAD_KEY);
+        settings->set_setting(RUNTIME_AUTOLOAD_KEY, godot::Variant());
+        FLOG_SYS("Export guard removed the Fennara runtime autoload");
+    } else {
+        saved_runtime_autoload = godot::Variant();
+    }
+
+}
+
+void FennaraExportPlugin::_export_file(
+    const godot::String &path,
+    const godot::String &type,
+    const godot::PackedStringArray &features) {
+    (void)type;
+    (void)features;
+    if (_should_skip_path(path)) {
+        if (path.get_extension().to_lower() == "gdextension") {
+            _suppress_extension_list_entry();
+        }
+        skip();
+    }
+}
+
+void FennaraExportPlugin::_export_end() {
+    _restore_export_state();
+}
+
+bool FennaraExportPlugin::_should_skip_path(const godot::String &path) {
+    const godot::String normalized = path.replace("\\", "/").to_lower();
+    return normalized.begins_with(ADDON_EXPORT_PREFIX) ||
+           normalized.begins_with(PROJECT_STATE_EXPORT_PREFIX);
+}
+
+godot::String FennaraExportPlugin::_filter_extension_list(
+    const godot::String &contents) {
+    godot::PackedStringArray lines = contents.split("\n", true);
+    godot::PackedStringArray kept_lines;
+    for (int64_t index = 0; index < lines.size(); index++) {
+        const godot::String normalized =
+            lines[index].strip_edges().replace("\\", "/").to_lower();
+        if (!normalized.begins_with(ADDON_EXPORT_PREFIX)) {
+            kept_lines.append(lines[index]);
+        }
+    }
+    return godot::String("\n").join(kept_lines);
+}
+
+bool FennaraExportPlugin::_replace_extension_list(
+    const godot::PackedByteArray &contents) {
+    const godot::String staging_path =
+        extension_list_path + godot::String(EXTENSION_LIST_STAGING_SUFFIX);
+    const godot::String backup_path =
+        extension_list_path + godot::String(EXTENSION_LIST_BACKUP_SUFFIX);
+    if (godot::FileAccess::file_exists(backup_path)) {
+        return false;
+    }
+
+    godot::Ref<godot::FileAccess> staging_file = godot::FileAccess::open(
+        staging_path,
+        godot::FileAccess::WRITE);
+    if (staging_file.is_null() ||
+        !staging_file->store_buffer(contents)) {
+        godot::DirAccess::remove_absolute(staging_path);
+        return false;
+    }
+    staging_file.unref();
+
+    if (godot::DirAccess::rename_absolute(
+            extension_list_path,
+            backup_path) != godot::OK) {
+        godot::DirAccess::remove_absolute(staging_path);
+        return false;
+    }
+
+    extension_list_changed = true;
+    if (godot::DirAccess::rename_absolute(
+            staging_path,
+            extension_list_path) != godot::OK) {
+        if (godot::DirAccess::rename_absolute(
+                backup_path,
+                extension_list_path) == godot::OK) {
+            extension_list_changed = false;
+        }
+        godot::DirAccess::remove_absolute(staging_path);
+        return false;
+    }
+    return true;
+}
+
+void FennaraExportPlugin::_resolve_extension_list_path() {
+    godot::ProjectSettings *settings =
+        godot::ProjectSettings::get_singleton();
+    if (settings == nullptr) {
+        extension_list_path = godot::String();
+        return;
+    }
+
+    const bool use_hidden_project_data =
+        settings->get_setting(
+            "application/config/use_hidden_project_data_directory",
+            true);
+    extension_list_path =
+        godot::String(use_hidden_project_data ? "res://.godot" : "res://godot")
+            .path_join("extension_list.cfg");
+}
+
+bool FennaraExportPlugin::_restore_extension_list_backup() {
+    const godot::String backup_path =
+        extension_list_path + godot::String(EXTENSION_LIST_BACKUP_SUFFIX);
+    if (!godot::FileAccess::file_exists(backup_path)) {
+        return false;
+    }
+
+    const godot::String discard_path =
+        extension_list_path + godot::String(EXTENSION_LIST_DISCARD_SUFFIX);
+    godot::DirAccess::remove_absolute(discard_path);
+    const bool had_live_registry =
+        godot::FileAccess::file_exists(extension_list_path);
+    if (had_live_registry &&
+        godot::DirAccess::rename_absolute(
+            extension_list_path,
+            discard_path) != godot::OK) {
+        return false;
+    }
+
+    if (godot::DirAccess::rename_absolute(
+            backup_path,
+            extension_list_path) != godot::OK) {
+        if (had_live_registry) {
+            godot::DirAccess::rename_absolute(
+                discard_path,
+                extension_list_path);
+        }
+        return false;
+    }
+
+    godot::DirAccess::remove_absolute(discard_path);
+    extension_list_changed = false;
+    return true;
+}
+
+void FennaraExportPlugin::_suppress_extension_list_entry() {
+    if (extension_list_changed) {
+        return;
+    }
+
+    godot::ProjectSettings *settings =
+        godot::ProjectSettings::get_singleton();
+    if (settings == nullptr) {
+        FLOG_ERR("Export guard could not locate Godot's extension registry");
+        return;
+    }
+
+    _resolve_extension_list_path();
+    if (!godot::FileAccess::file_exists(extension_list_path)) {
+        extension_list_path = godot::String();
+        return;
+    }
+
+    saved_extension_list =
+        godot::FileAccess::get_file_as_bytes(extension_list_path);
+    const godot::String original =
+        saved_extension_list.get_string_from_utf8();
+    const godot::String filtered = _filter_extension_list(original);
+    if (filtered == original) {
+        extension_list_path = godot::String();
+        saved_extension_list = godot::PackedByteArray();
+        return;
+    }
+
+    if (!_replace_extension_list(filtered.to_utf8_buffer())) {
+        FLOG_ERR("Export guard could not filter Godot's extension registry");
+        if (!extension_list_changed) {
+            extension_list_path = godot::String();
+            saved_extension_list = godot::PackedByteArray();
+        }
+        const godot::Ref<godot::EditorExportPlatform> platform =
+            get_export_platform();
+        if (platform.is_valid()) {
+            platform->add_message(
+                godot::EditorExportPlatform::EXPORT_MESSAGE_ERROR,
+                "Fennara",
+                "Could not remove Fennara from Godot's extension registry.");
+        }
+        return;
+    }
+
+    FLOG_SYS("Export guard removed Fennara from Godot's extension registry");
+}
+
+void FennaraExportPlugin::_restore_export_state() {
+    godot::ProjectSettings *settings =
+        godot::ProjectSettings::get_singleton();
+    if (export_active && settings != nullptr && had_runtime_autoload) {
+        settings->set_setting(RUNTIME_AUTOLOAD_KEY, saved_runtime_autoload);
+        FLOG_SYS("Export guard restored the Fennara runtime autoload");
+    }
+
+    export_active = false;
+    had_runtime_autoload = false;
+    saved_runtime_autoload = godot::Variant();
+
+    if (!extension_list_changed) {
+        return;
+    }
+
+    bool registry_restored = _restore_extension_list_backup();
+    if (!registry_restored && !saved_extension_list.is_empty() &&
+        _replace_extension_list(saved_extension_list)) {
+        const godot::String backup_path =
+            extension_list_path +
+            godot::String(EXTENSION_LIST_BACKUP_SUFFIX);
+        godot::DirAccess::remove_absolute(backup_path);
+        extension_list_changed = false;
+        registry_restored = true;
+    }
+    if (!registry_restored) {
+        FLOG_ERR("Export guard could not restore Godot's extension registry");
+        return;
+    }
+
+    extension_list_path = godot::String();
+    saved_extension_list = godot::PackedByteArray();
+    FLOG_SYS("Export guard restored Godot's extension registry");
+}
+
+#ifdef FENNARA_SETUP_TEST_HOOKS
+bool FennaraExportPlugin::test_should_skip_path(
+    const godot::String &path) const {
+    return _should_skip_path(path);
+}
+
+godot::String FennaraExportPlugin::test_filter_extension_list(
+    const godot::String &contents) const {
+    return _filter_extension_list(contents);
+}
+
+void FennaraExportPlugin::test_suppress_extension_list_entry() {
+    _suppress_extension_list_entry();
+}
+
+void FennaraExportPlugin::test_export_begin() {
+    _export_begin(godot::PackedStringArray(), false, godot::String(), 0);
+}
+
+void FennaraExportPlugin::test_export_end() {
+    _export_end();
+}
+#endif
+
+} // namespace fennara

--- a/fennara-cpp/src/ui/fennara_plugin.cpp
+++ b/fennara-cpp/src/ui/fennara_plugin.cpp
@@ -4,12 +4,11 @@
 #include "fennara/local_bridge.hpp"
 #include "fennara/logger.hpp"
 #include "fennara/update_notice.hpp"
+#include "fennara/ui/export_plugin.hpp"
 #include "fennara/ui/script_context_menu.hpp"
 
 #include <godot_cpp/classes/engine.hpp>
-#include <godot_cpp/classes/config_file.hpp>
 #include <godot_cpp/classes/display_server.hpp>
-#include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_file_system.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
@@ -90,10 +89,12 @@ void FennaraPlugin::_enter_tree() {
 
     _ensure_runtime_helper_autoload();
 
+    export_plugin.instantiate();
+    add_export_plugin(export_plugin);
+
     set_process(true);
 
     _configure_editor_settings();
-    _ensure_export_presets_exclude_fennara();
     local_bridge->request_get_class_info_warmup();
 }
 
@@ -172,119 +173,6 @@ void FennaraPlugin::_configure_editor_settings() {
     }
 }
 
-bool FennaraPlugin::_is_export_preset_section(const godot::String &section) const {
-    if (!section.begins_with("preset.") || section.contains(".options")) {
-        return false;
-    }
-    godot::String suffix = section.substr(7);
-    return !suffix.is_empty() && suffix.is_valid_int();
-}
-
-godot::PackedStringArray FennaraPlugin::_split_export_filter(
-    const godot::String &raw) const {
-    godot::PackedStringArray filters;
-    godot::PackedStringArray parts = raw.split(",", false);
-    for (int i = 0; i < parts.size(); i++) {
-        godot::String trimmed = parts[i].strip_edges();
-        if (!trimmed.is_empty() && !filters.has(trimmed)) {
-            filters.append(trimmed);
-        }
-    }
-    return filters;
-}
-
-void FennaraPlugin::_ensure_export_presets_exclude_fennara() {
-    const godot::String presets_path = "res://export_presets.cfg";
-    const godot::String backup_path = "res://export_presets.cfg.fennara.bak";
-    if (!godot::FileAccess::file_exists(presets_path)) {
-        FLOG_SYS("Export preset guard skipped: export_presets.cfg not found");
-        return;
-    }
-
-    godot::Ref<godot::ConfigFile> config;
-    config.instantiate();
-    godot::Error load_err = config->load(presets_path);
-    if (load_err != godot::OK) {
-        FLOG_ERR("Export preset guard load failed code=" +
-                 godot::String::num_int64(static_cast<int64_t>(load_err)));
-        return;
-    }
-
-    static const char *obsolete_filters[] = {
-        "addons/fennara/*",
-    };
-    static const char *required_filters[] = {
-        "addons/fennara/ai/*",
-        "addons/fennara/bin/*",
-        "addons/fennara/dist/*",
-        "addons/fennara/*.gdextension",
-        "addons/fennara/*.gdextension.uid",
-        "addons/fennara/*.md",
-        "addons/fennara/VERSION",
-        ".fennara/*",
-    };
-
-    bool changed = false;
-    int64_t touched_presets = 0;
-    godot::PackedStringArray sections = config->get_sections();
-    for (int i = 0; i < sections.size(); i++) {
-        godot::String section = sections[i];
-        if (!_is_export_preset_section(section)) {
-            continue;
-        }
-
-        godot::PackedStringArray filters =
-            _split_export_filter(config->get_value(section, "exclude_filter", ""));
-        bool section_changed = false;
-        for (const char *filter : obsolete_filters) {
-            godot::String pattern(filter);
-            int existing_index = filters.find(pattern);
-            if (existing_index >= 0) {
-                filters.remove_at(existing_index);
-                section_changed = true;
-            }
-        }
-        for (const char *filter : required_filters) {
-            godot::String pattern(filter);
-            if (!filters.has(pattern)) {
-                filters.append(pattern);
-                section_changed = true;
-            }
-        }
-
-        if (section_changed) {
-            config->set_value(section, "exclude_filter", godot::String(",").join(filters));
-            changed = true;
-            touched_presets++;
-        }
-    }
-
-    if (!changed) {
-        FLOG_SYS("Export preset guard already configured");
-        return;
-    }
-
-    if (!godot::FileAccess::file_exists(backup_path)) {
-        godot::Error copy_err =
-            godot::DirAccess::copy_absolute(presets_path, backup_path);
-        if (copy_err == godot::OK) {
-            FLOG_SYS("Export preset guard backup created: " + backup_path);
-        } else {
-            FLOG_ERR("Export preset guard backup failed code=" +
-                     godot::String::num_int64(static_cast<int64_t>(copy_err)));
-        }
-    }
-
-    godot::Error save_err = config->save(presets_path);
-    if (save_err == godot::OK) {
-        FLOG_SYS("Export preset guard added Fennara excludes to " +
-                 godot::String::num_int64(touched_presets) + " preset(s)");
-    } else {
-        FLOG_ERR("Export preset guard save failed code=" +
-                 godot::String::num_int64(static_cast<int64_t>(save_err)));
-    }
-}
-
 void FennaraPlugin::_exit_tree() {
     set_process(false);
     _stop_update_check();
@@ -305,6 +193,10 @@ void FennaraPlugin::_exit_tree() {
         remove_context_menu_plugin(script_context_menu_plugin);
         script_context_menu_plugin->set_local_bridge(nullptr);
         script_context_menu_plugin.unref();
+    }
+    if (export_plugin.is_valid()) {
+        remove_export_plugin(export_plugin);
+        export_plugin.unref();
     }
     if (local_bridge) {
         local_bridge->queue_free();

--- a/godot_demo/tests/export_plugin_test.gd
+++ b/godot_demo/tests/export_plugin_test.gd
@@ -1,0 +1,113 @@
+extends SceneTree
+
+
+const RUNTIME_AUTOLOAD_KEY := "autoload/_fennara_game_capture"
+const TEST_AUTOLOAD_VALUE := "*res://addons/fennara/runtime/game_capture_helper.gd"
+const EXTENSION_LIST_BACKUP_SUFFIX := ".fennara-export-backup"
+
+
+func _initialize() -> void:
+	var extension := load("res://addons/fennara/fennara.gdextension")
+	assert(extension != null)
+	var project_data_directory := (
+		"res://.godot"
+		if ProjectSettings.get_setting(
+			"application/config/use_hidden_project_data_directory",
+			true,
+		)
+		else "res://godot"
+	)
+	var extension_list_path := project_data_directory.path_join("extension_list.cfg")
+	var had_original_extension_list := FileAccess.file_exists(extension_list_path)
+	var actual_extension_list := FileAccess.get_file_as_string(extension_list_path)
+	var original_extension_list := actual_extension_list
+	if not original_extension_list.ends_with("\n") and not original_extension_list.is_empty():
+		original_extension_list += "\n"
+	if "res://addons/fennara/" not in original_extension_list:
+		original_extension_list += "res://addons/fennara/fennara.gdextension\n"
+	_write_text(extension_list_path, original_extension_list)
+
+	var export_plugin: Variant = ClassDB.instantiate("FennaraExportPlugin")
+	assert(export_plugin != null)
+
+	assert(export_plugin.test_should_skip_path(
+		"res://addons/fennara/runtime/game_capture_helper.gd",
+	))
+	assert(export_plugin.test_should_skip_path(
+		"RES:\\\\ADDONS\\FENNARA\\VERSION",
+	))
+	assert(export_plugin.test_should_skip_path("res://.fennara/session.json"))
+	assert(not export_plugin.test_should_skip_path(
+		"res://addons/another_plugin/plugin.gd",
+	))
+	assert(export_plugin.test_filter_extension_list(
+		"res://addons/another/addon.gdextension\n"
+		+ "res://addons/fennara/fennara.gdextension\n",
+	) == "res://addons/another/addon.gdextension\n")
+
+	var had_original := ProjectSettings.has_setting(RUNTIME_AUTOLOAD_KEY)
+	var original_value: Variant
+	if had_original:
+		original_value = ProjectSettings.get_setting(RUNTIME_AUTOLOAD_KEY)
+
+	ProjectSettings.set_setting(RUNTIME_AUTOLOAD_KEY, TEST_AUTOLOAD_VALUE)
+	export_plugin.test_export_begin()
+	assert(not ProjectSettings.has_setting(RUNTIME_AUTOLOAD_KEY))
+	export_plugin.test_suppress_extension_list_entry()
+	assert(FileAccess.file_exists(
+		extension_list_path + EXTENSION_LIST_BACKUP_SUFFIX,
+	))
+	assert(
+		"res://addons/fennara/" not in FileAccess.get_file_as_string(
+			extension_list_path,
+		),
+	)
+	export_plugin.test_export_end()
+	assert(ProjectSettings.get_setting(
+		RUNTIME_AUTOLOAD_KEY,
+	) == TEST_AUTOLOAD_VALUE)
+	assert(FileAccess.get_file_as_string(
+		extension_list_path,
+	) == original_extension_list)
+	assert(not FileAccess.file_exists(
+		extension_list_path + EXTENSION_LIST_BACKUP_SUFFIX,
+	))
+
+	ProjectSettings.set_setting(RUNTIME_AUTOLOAD_KEY, null)
+	export_plugin.test_export_begin()
+	assert(not ProjectSettings.has_setting(RUNTIME_AUTOLOAD_KEY))
+	export_plugin.test_export_end()
+	assert(not ProjectSettings.has_setting(RUNTIME_AUTOLOAD_KEY))
+
+	if had_original:
+		ProjectSettings.set_setting(RUNTIME_AUTOLOAD_KEY, original_value)
+	else:
+		ProjectSettings.set_setting(RUNTIME_AUTOLOAD_KEY, null)
+	export_plugin = null
+
+	_write_text(
+		extension_list_path + EXTENSION_LIST_BACKUP_SUFFIX,
+		original_extension_list,
+	)
+	_write_text(extension_list_path, "")
+	var recovery_plugin: Variant = ClassDB.instantiate("FennaraExportPlugin")
+	assert(recovery_plugin != null)
+	assert(FileAccess.get_file_as_string(
+		extension_list_path,
+	) == original_extension_list)
+	assert(not FileAccess.file_exists(
+		extension_list_path + EXTENSION_LIST_BACKUP_SUFFIX,
+	))
+	recovery_plugin = null
+	if had_original_extension_list:
+		_write_text(extension_list_path, actual_extension_list)
+	else:
+		DirAccess.remove_absolute(extension_list_path)
+	print("export plugin test passed")
+	quit()
+
+
+func _write_text(path: String, contents: String) -> void:
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	assert(file != null)
+	file.store_string(contents)

--- a/local/crates/fennara-cli/src/main.rs
+++ b/local/crates/fennara-cli/src/main.rs
@@ -5,6 +5,9 @@ mod doctor;
 mod existing_addon_install;
 mod mcp_setup;
 mod operation;
+mod prepare_export;
+#[cfg(test)]
+mod prepare_export_tests;
 mod project_addon;
 mod project_guidance;
 mod project_install;
@@ -118,6 +121,9 @@ fn run(args: Vec<String>) -> Result<(), String> {
         Some("diagnostics") => diagnostics::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("install") => project_install::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("mcp-setup") => mcp_setup::run(args.iter().skip(1).map(String::as_str).collect()),
+        Some("prepare-export") => {
+            prepare_export::run(args.iter().skip(1).map(String::as_str).collect())
+        }
         Some("update") => release_update::run(args.iter().skip(1).map(String::as_str).collect()),
         Some("recover") => update_apply::recover(args.iter().skip(1).map(String::as_str).collect()),
         Some(update_apply::COMPLETE_COMMAND) => {
@@ -144,6 +150,7 @@ Usage:
   fennara diagnostics [--operation <operation-id>] [--json]
   fennara install [--project <path>] [--version <version>] [--channel pr-<number>]
   fennara mcp-setup <target flags>
+  fennara prepare-export [--project <path>]
   fennara update [--version <version>] [--project <path>] [--no-self-update] [--prepare]
   fennara recover --project <path> [--operation <operation-id>]
   fennara self-update [--version <version>]
@@ -156,6 +163,8 @@ Commands:
              Show a sanitized install or update operation report
   install    Set up Fennara in a Godot project
   mcp-setup  Configure an MCP app to launch Fennara
+  prepare-export
+             Remove Fennara's persistent autoload before a CI export
   update     Update the CLI, local package, addon, and project guidance
   recover    Restore an interrupted native update after Godot is closed
   self-update

--- a/local/crates/fennara-cli/src/prepare_export.rs
+++ b/local/crates/fennara-cli/src/prepare_export.rs
@@ -54,7 +54,17 @@ fn remove_runtime_autoload(source: &str) -> (String, bool) {
 }
 
 fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
-    let suffix = unique_suffix();
+    write_atomic_with_rename(path, contents, &unique_suffix(), |source, destination| {
+        fs::rename(source, destination)
+    })
+}
+
+fn write_atomic_with_rename(
+    path: &Path,
+    contents: &[u8],
+    suffix: &str,
+    mut rename: impl FnMut(&Path, &Path) -> std::io::Result<()>,
+) -> Result<(), String> {
     let file_name = path
         .file_name()
         .and_then(|name| name.to_str())
@@ -74,15 +84,15 @@ fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
         .map_err(|error| format!("failed to flush {}: {error}", display_path(&staging)))?;
     drop(staging_file);
 
-    fs::rename(path, &backup).map_err(|error| {
+    rename(path, &backup).map_err(|error| {
         let _ = fs::remove_file(&staging);
         format!(
             "failed to stage {} for replacement: {error}",
             display_path(path)
         )
     })?;
-    if let Err(error) = fs::rename(&staging, path) {
-        let restore_error = fs::rename(&backup, path).err();
+    if let Err(error) = rename(&staging, path) {
+        let restore_error = rename(&backup, path).err();
         let _ = fs::remove_file(&staging);
         return Err(match restore_error {
             Some(restore) => format!(
@@ -127,7 +137,7 @@ impl PrepareExportOptions {
                         .ok_or_else(|| "--project requires a path".to_string())?;
                     project_dir = Some(PathBuf::from(value));
                 }
-                "-h" | "--help" => return Err(help_text()),
+                "-h" | "--help" => return Err(print_help()),
                 argument => return Err(format!("unknown prepare-export option: {argument}")),
             }
             index += 1;
@@ -136,7 +146,7 @@ impl PrepareExportOptions {
     }
 }
 
-fn help_text() -> String {
+fn print_help() -> String {
     println!(
         "\
 Prepare a Godot checkout for exporting without the Fennara addon.
@@ -153,4 +163,27 @@ before Godot starts when addons/fennara is excluded from a CI checkout."
 #[cfg(test)]
 pub(crate) fn remove_runtime_autoload_for_test(source: &str) -> (String, bool) {
     remove_runtime_autoload(source)
+}
+
+#[cfg(test)]
+pub(crate) fn write_atomic_for_test(path: &Path, contents: &[u8]) -> Result<(), String> {
+    write_atomic(path, contents)
+}
+
+#[cfg(test)]
+pub(crate) fn write_atomic_rollback_for_test(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let mut rename_count = 0;
+    write_atomic_with_rename(path, contents, "rollback-test", |source, destination| {
+        rename_count += 1;
+        if rename_count == 2 {
+            Err(std::io::Error::other("injected replacement failure"))
+        } else {
+            fs::rename(source, destination)
+        }
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn parse_options_for_test(args: Vec<&str>) -> Result<Option<PathBuf>, String> {
+    PrepareExportOptions::parse(args).map(|options| options.project_dir)
 }

--- a/local/crates/fennara-cli/src/prepare_export.rs
+++ b/local/crates/fennara-cli/src/prepare_export.rs
@@ -1,0 +1,156 @@
+use crate::app_layout::display_path;
+use crate::project_install::{ensure_godot_project, resolve_project_dir};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const RUNTIME_AUTOLOAD_NAME: &str = "_fennara_game_capture";
+
+pub fn run(args: Vec<&str>) -> Result<(), String> {
+    let options = PrepareExportOptions::parse(args)?;
+    let project_dir = resolve_project_dir(options.project_dir)?;
+    ensure_godot_project(&project_dir)?;
+    let project_file = project_dir.join("project.godot");
+    let source = fs::read_to_string(&project_file)
+        .map_err(|error| format!("failed to read {}: {error}", display_path(&project_file)))?;
+    let (prepared, removed) = remove_runtime_autoload(&source);
+
+    if removed {
+        write_atomic(&project_file, prepared.as_bytes())?;
+        println!("Prepared project for export");
+        println!("project: {}", display_path(&project_dir));
+        println!("removed autoload: {RUNTIME_AUTOLOAD_NAME}");
+    } else {
+        println!("Project is already prepared for export");
+        println!("project: {}", display_path(&project_dir));
+    }
+    Ok(())
+}
+
+fn remove_runtime_autoload(source: &str) -> (String, bool) {
+    let mut output = String::with_capacity(source.len());
+    let mut in_autoload_section = false;
+    let mut removed = false;
+
+    for line in source.split_inclusive('\n') {
+        let content = line.trim_end_matches(['\r', '\n']);
+        let trimmed = content.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_autoload_section = trimmed == "[autoload]";
+        }
+        if in_autoload_section
+            && trimmed
+                .split_once('=')
+                .is_some_and(|(key, _)| key.trim() == RUNTIME_AUTOLOAD_NAME)
+        {
+            removed = true;
+            continue;
+        }
+        output.push_str(line);
+    }
+
+    (output, removed)
+}
+
+fn write_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let suffix = unique_suffix();
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("project.godot");
+    let staging = path.with_file_name(format!("{file_name}.fennara-{suffix}.tmp"));
+    let backup = path.with_file_name(format!("{file_name}.fennara-{suffix}.previous"));
+    let mut staging_file = OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&staging)
+        .map_err(|error| format!("failed to create {}: {error}", display_path(&staging)))?;
+    staging_file
+        .write_all(contents)
+        .map_err(|error| format!("failed to write {}: {error}", display_path(&staging)))?;
+    staging_file
+        .sync_all()
+        .map_err(|error| format!("failed to flush {}: {error}", display_path(&staging)))?;
+    drop(staging_file);
+
+    fs::rename(path, &backup).map_err(|error| {
+        let _ = fs::remove_file(&staging);
+        format!(
+            "failed to stage {} for replacement: {error}",
+            display_path(path)
+        )
+    })?;
+    if let Err(error) = fs::rename(&staging, path) {
+        let restore_error = fs::rename(&backup, path).err();
+        let _ = fs::remove_file(&staging);
+        return Err(match restore_error {
+            Some(restore) => format!(
+                "failed to replace {}: {error}; restoring the original also failed: {restore}",
+                display_path(path)
+            ),
+            None => format!("failed to replace {}: {error}", display_path(path)),
+        });
+    }
+    if let Err(error) = fs::remove_file(&backup) {
+        eprintln!(
+            "warning: updated {}, but could not remove backup {}: {error}",
+            display_path(path),
+            display_path(&backup)
+        );
+    }
+    Ok(())
+}
+
+fn unique_suffix() -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    format!("{}-{nanos}", std::process::id())
+}
+
+struct PrepareExportOptions {
+    project_dir: Option<PathBuf>,
+}
+
+impl PrepareExportOptions {
+    fn parse(args: Vec<&str>) -> Result<Self, String> {
+        let mut project_dir = None;
+        let mut index = 0;
+        while index < args.len() {
+            match args[index] {
+                "--project" => {
+                    index += 1;
+                    let value = args
+                        .get(index)
+                        .ok_or_else(|| "--project requires a path".to_string())?;
+                    project_dir = Some(PathBuf::from(value));
+                }
+                "-h" | "--help" => return Err(help_text()),
+                argument => return Err(format!("unknown prepare-export option: {argument}")),
+            }
+            index += 1;
+        }
+        Ok(Self { project_dir })
+    }
+}
+
+fn help_text() -> String {
+    println!(
+        "\
+Prepare a Godot checkout for exporting without the Fennara addon.
+
+Usage:
+  fennara prepare-export [--project <path>]
+
+This removes only the _fennara_game_capture entry from project.godot. Run it
+before Godot starts when addons/fennara is excluded from a CI checkout."
+    );
+    String::new()
+}
+
+#[cfg(test)]
+pub(crate) fn remove_runtime_autoload_for_test(source: &str) -> (String, bool) {
+    remove_runtime_autoload(source)
+}

--- a/local/crates/fennara-cli/src/prepare_export_tests.rs
+++ b/local/crates/fennara-cli/src/prepare_export_tests.rs
@@ -1,4 +1,37 @@
-use crate::prepare_export::remove_runtime_autoload_for_test;
+use crate::prepare_export::{
+    parse_options_for_test, remove_runtime_autoload_for_test, write_atomic_for_test,
+    write_atomic_rollback_for_test,
+};
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+struct TestDirectory(PathBuf);
+
+impl TestDirectory {
+    fn new(name: &str) -> Self {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or_default();
+        let path = std::env::temp_dir().join(format!(
+            "fennara-prepare-export-{name}-{}-{suffix}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("test directory should be created");
+        Self(path)
+    }
+
+    fn join(&self, path: &str) -> PathBuf {
+        self.0.join(path)
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}
 
 #[test]
 fn removes_only_the_fennara_runtime_autoload() {
@@ -56,4 +89,72 @@ fn leaves_an_already_prepared_project_unchanged() {
 
     assert!(!removed);
     assert_eq!(prepared, source);
+}
+
+#[test]
+fn atomic_write_replaces_the_original_file() {
+    let directory = TestDirectory::new("atomic-success");
+    let project_file = directory.join("project.godot");
+    fs::write(&project_file, b"original").expect("original should be written");
+
+    write_atomic_for_test(&project_file, b"prepared").expect("replacement should succeed");
+
+    assert_eq!(
+        fs::read(&project_file).expect("project should remain readable"),
+        b"prepared"
+    );
+    assert_eq!(
+        fs::read_dir(&directory.0)
+            .expect("directory should remain readable")
+            .count(),
+        1,
+        "staging and backup files should be removed"
+    );
+}
+
+#[test]
+fn atomic_write_restores_the_original_when_replacement_fails() {
+    let directory = TestDirectory::new("atomic-rollback");
+    let project_file = directory.join("project.godot");
+    fs::write(&project_file, b"original").expect("original should be written");
+
+    let error = write_atomic_rollback_for_test(&project_file, b"prepared")
+        .expect_err("injected replacement failure should be returned");
+
+    assert!(error.contains("failed to replace"));
+    assert_eq!(
+        fs::read(&project_file).expect("original should be restored"),
+        b"original"
+    );
+    assert_eq!(
+        fs::read_dir(&directory.0)
+            .expect("directory should remain readable")
+            .count(),
+        1,
+        "staging and backup files should be removed"
+    );
+}
+
+#[test]
+fn options_reject_project_without_a_path() {
+    assert_eq!(
+        parse_options_for_test(vec!["--project"]).unwrap_err(),
+        "--project requires a path"
+    );
+}
+
+#[test]
+fn options_reject_unknown_flags() {
+    assert_eq!(
+        parse_options_for_test(vec!["--unknown"]).unwrap_err(),
+        "unknown prepare-export option: --unknown"
+    );
+}
+
+#[test]
+fn options_accept_a_project_path() {
+    assert_eq!(
+        parse_options_for_test(vec!["--project", "game"]).unwrap(),
+        Some(PathBuf::from("game"))
+    );
 }

--- a/local/crates/fennara-cli/src/prepare_export_tests.rs
+++ b/local/crates/fennara-cli/src/prepare_export_tests.rs
@@ -1,0 +1,59 @@
+use crate::prepare_export::remove_runtime_autoload_for_test;
+
+#[test]
+fn removes_only_the_fennara_runtime_autoload() {
+    let source = "\
+[application]\n\
+config/name=\"Game\"\n\
+\n\
+[autoload]\n\
+Other=\"*res://other.gd\"\n\
+_fennara_game_capture=\"*res://addons/fennara/runtime/game_capture_helper.gd\"\n\
+\n\
+[rendering]\n\
+renderer/rendering_method=\"gl_compatibility\"\n";
+    let expected = "\
+[application]\n\
+config/name=\"Game\"\n\
+\n\
+[autoload]\n\
+Other=\"*res://other.gd\"\n\
+\n\
+[rendering]\n\
+renderer/rendering_method=\"gl_compatibility\"\n";
+
+    let (prepared, removed) = remove_runtime_autoload_for_test(source);
+
+    assert!(removed);
+    assert_eq!(prepared, expected);
+}
+
+#[test]
+fn preserves_crlf_and_similarly_named_settings() {
+    let source = "\
+[autoload]\r\n\
+_fennara_game_capture_extra=\"res://keep.gd\"\r\n\
+_fennara_game_capture = \"*res://addons/fennara/runtime/game_capture_helper.gd\"\r\n\
+[application]\r\n\
+_fennara_game_capture=\"not-an-autoload\"\r\n";
+    let expected = "\
+[autoload]\r\n\
+_fennara_game_capture_extra=\"res://keep.gd\"\r\n\
+[application]\r\n\
+_fennara_game_capture=\"not-an-autoload\"\r\n";
+
+    let (prepared, removed) = remove_runtime_autoload_for_test(source);
+
+    assert!(removed);
+    assert_eq!(prepared, expected);
+}
+
+#[test]
+fn leaves_an_already_prepared_project_unchanged() {
+    let source = "[application]\nconfig/name=\"Game\"\n";
+
+    let (prepared, removed) = remove_runtime_autoload_for_test(source);
+
+    assert!(!removed);
+    assert_eq!(prepared, source);
+}


### PR DESCRIPTION
## Why

Fennara should be an editor-only dependency, but exported games could still retain the runtime helper and addon files. Projects that excluded the addon from CI also had no supported way to remove the persistent Fennara autoload before Godot validated project startup.

Closes #129.

## What changed

- add a dedicated export plugin that temporarily removes the Fennara runtime autoload, skips `res://addons/fennara/` and `res://.fennara/`, and restores editor state after export
- keep Fennara ahead of Godot's built-in GDExtension exporter so native libraries are never registered for packaging
- filter Godot's generated extension registry through a recoverable backup-and-swap, including interrupted-export recovery
- replace the old per-preset file mutation with export-time behavior that applies to every preset
- add `fennara prepare-export --project <path>` for addon-free CI checkouts, removing only `_fennara_game_capture` before Godot starts
- document the installed-addon export boundary and the addon-free CI workflow

## Validation

- `cd fennara-cpp && uvx scons target=editor`
- `cd fennara-cpp && uvx scons target=editor fennara_setup_tests=yes`
- `<godot-console> --headless --editor --path godot_demo --script res://tests/export_plugin_test.gd`
- ran every Windows native GDScript test listed in `.github/workflows/gdextension-build.yml`
- `cd local && cargo fmt --all --check`
- `cd local && cargo test -p fennara-cli`
- `cd local && cargo clippy -p fennara-cli --all-targets -- -D warnings`
- exported and launched a minimal Windows project, then confirmed its executable directory and PCK contained no Fennara addon files, runtime autoload, extension registry entry, or native library
- ran `fennara prepare-export` twice against a test project to verify targeted removal and idempotency

Assisted by Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an editor export plugin that temporarily removes runtime autoload state and suppresses Fennara-related extension registry entries during export, then restores everything after.
  * Introduced `fennara prepare-export` to remove the persistent autoload entry for addon-free CI export workflows.
* **Documentation**
  * Updated installation and CLI docs with an “export boundary” overview and step-by-step guidance for addon-free exports.
* **Tests**
  * Added an export plugin regression test and extended CI/editor testing to run export flow checks with timeouts and proper exit-code propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->