### PR TITLE
fix(docs): simplify language navigation

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,10 +1,6 @@
 # Fennara Context
 
 <!-- fennara-doc-nav:start -->
-[Documentation](docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](docs/i18n/zh-CN/CONTEXT.md) · [Español](docs/i18n/es/CONTEXT.md) · [Português do Brasil](docs/i18n/pt-BR/CONTEXT.md) · [日本語](docs/i18n/ja/CONTEXT.md) · [한국어](docs/i18n/ko/CONTEXT.md) · [Русский](docs/i18n/ru/CONTEXT.md) · [Français](docs/i18n/fr/CONTEXT.md) · [Deutsch](docs/i18n/de/CONTEXT.md) · [Türkçe](docs/i18n/tr/CONTEXT.md)
 <!-- fennara-doc-nav:end -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,6 @@
 # Contributing
 
 <!-- fennara-doc-nav:start -->
-[Documentation](docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](docs/i18n/zh-CN/CONTRIBUTING.md) · [Español](docs/i18n/es/CONTRIBUTING.md) · [Português do Brasil](docs/i18n/pt-BR/CONTRIBUTING.md) · [日本語](docs/i18n/ja/CONTRIBUTING.md) · [한국어](docs/i18n/ko/CONTRIBUTING.md) · [Русский](docs/i18n/ru/CONTRIBUTING.md) · [Français](docs/i18n/fr/CONTRIBUTING.md) · [Deutsch](docs/i18n/de/CONTRIBUTING.md) · [Türkçe](docs/i18n/tr/CONTRIBUTING.md)
 <!-- fennara-doc-nav:end -->
 

--- a/README.de.md
+++ b/README.de.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](docs/i18n/de/README.md)
-
-🌐 **Sprachen**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · **Deutsch** · [Türkçe](README.tr.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](README.md)

--- a/README.es.md
+++ b/README.es.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Documentación](docs/i18n/es/README.md)
-
-🌐 **Idiomas**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · **Español** · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](README.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Documentation](docs/i18n/fr/README.md)
-
-🌐 **Langues**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · **Français** · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](README.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](docs/i18n/ja/README.md)
-
-🌐 **言語**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · **日本語** · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](README.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[문서](docs/i18n/ko/README.md)
-
-🌐 **언어**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · **한국어** · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](README.md)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Documentation](docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 <!-- fennara-doc-nav:end -->
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Documentação](docs/i18n/pt-BR/README.md)
-
-🌐 **Idiomas**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · **Português do Brasil** · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](README.md)

--- a/README.ru.md
+++ b/README.ru.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Документация](docs/i18n/ru/README.md)
-
-🌐 **Языки**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · **Русский** · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](README.md)

--- a/README.tr.md
+++ b/README.tr.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](docs/i18n/tr/README.md)
-
-🌐 **Diller**
-
 [English](README.md) · [简体中文](README.zh-CN.md) · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](README.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,10 +3,6 @@
 # Fennara Godot AI
 
 <!-- fennara-doc-nav:start -->
-[文档](docs/i18n/zh-CN/README.md)
-
-🌐 **语言**
-
 [English](README.md) · **简体中文** · [Español](README.es.md) · [Português do Brasil](README.pt-BR.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Русский](README.ru.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Türkçe](README.tr.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](README.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,6 @@
 # Security
 
 <!-- fennara-doc-nav:start -->
-[Documentation](docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](docs/i18n/zh-CN/SECURITY.md) · [Español](docs/i18n/es/SECURITY.md) · [Português do Brasil](docs/i18n/pt-BR/SECURITY.md) · [日本語](docs/i18n/ja/SECURITY.md) · [한국어](docs/i18n/ko/SECURITY.md) · [Русский](docs/i18n/ru/SECURITY.md) · [Français](docs/i18n/fr/SECURITY.md) · [Deutsch](docs/i18n/de/SECURITY.md) · [Türkçe](docs/i18n/tr/SECURITY.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,6 @@
 # Fennara Documentation
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/README.md) · [Español](i18n/es/README.md) · [Português do Brasil](i18n/pt-BR/README.md) · [日本語](i18n/ja/README.md) · [한국어](i18n/ko/README.md) · [Русский](i18n/ru/README.md) · [Français](i18n/fr/README.md) · [Deutsch](i18n/de/README.md) · [Türkçe](i18n/tr/README.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,6 @@
 # Architecture
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/architecture.md) · [Español](i18n/es/architecture.md) · [Português do Brasil](i18n/pt-BR/architecture.md) · [日本語](i18n/ja/architecture.md) · [한국어](i18n/ko/architecture.md) · [Русский](i18n/ru/architecture.md) · [Français](i18n/fr/architecture.md) · [Deutsch](i18n/de/architecture.md) · [Türkçe](i18n/tr/architecture.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/chat-vs-mcp.md
+++ b/docs/chat-vs-mcp.md
@@ -1,10 +1,6 @@
 # MCP Apps Or Built-In Chat?
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/chat-vs-mcp.md) · [Español](i18n/es/chat-vs-mcp.md) · [Português do Brasil](i18n/pt-BR/chat-vs-mcp.md) · [日本語](i18n/ja/chat-vs-mcp.md) · [한국어](i18n/ko/chat-vs-mcp.md) · [Русский](i18n/ru/chat-vs-mcp.md) · [Français](i18n/fr/chat-vs-mcp.md) · [Deutsch](i18n/de/chat-vs-mcp.md) · [Türkçe](i18n/tr/chat-vs-mcp.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,10 +1,6 @@
 # Fennara CLI
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/cli.md) · [Español](i18n/es/cli.md) · [Português do Brasil](i18n/pt-BR/cli.md) · [日本語](i18n/ja/cli.md) · [한국어](i18n/ko/cli.md) · [Русский](i18n/ru/cli.md) · [Français](i18n/fr/cli.md) · [Deutsch](i18n/de/cli.md) · [Türkçe](i18n/tr/cli.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -1,10 +1,6 @@
 # Demos
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/demos.md) · [Español](i18n/es/demos.md) · [Português do Brasil](i18n/pt-BR/demos.md) · [日本語](i18n/ja/demos.md) · [한국어](i18n/ko/demos.md) · [Русский](i18n/ru/demos.md) · [Français](i18n/fr/demos.md) · [Deutsch](i18n/de/demos.md) · [Türkçe](i18n/tr/demos.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,10 +1,6 @@
 # Examples
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/examples.md) · [Español](i18n/es/examples.md) · [Português do Brasil](i18n/pt-BR/examples.md) · [日本語](i18n/ja/examples.md) · [한국어](i18n/ko/examples.md) · [Русский](i18n/ru/examples.md) · [Français](i18n/fr/examples.md) · [Deutsch](i18n/de/examples.md) · [Türkçe](i18n/tr/examples.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,10 +1,6 @@
 # FAQ
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/faq.md) · [Español](i18n/es/faq.md) · [Português do Brasil](i18n/pt-BR/faq.md) · [日本語](i18n/ja/faq.md) · [한국어](i18n/ko/faq.md) · [Русский](i18n/ru/faq.md) · [Français](i18n/fr/faq.md) · [Deutsch](i18n/de/faq.md) · [Türkçe](i18n/tr/faq.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/fennara-vs-traditional-godot-mcp.md
+++ b/docs/fennara-vs-traditional-godot-mcp.md
@@ -1,10 +1,6 @@
 # Fennara vs Traditional Godot MCP
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](i18n/es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](i18n/pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](i18n/ja/fennara-vs-traditional-godot-mcp.md) · [한국어](i18n/ko/fennara-vs-traditional-godot-mcp.md) · [Русский](i18n/ru/fennara-vs-traditional-godot-mcp.md) · [Français](i18n/fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](i18n/de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](i18n/tr/fennara-vs-traditional-godot-mcp.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/github-metadata.md
+++ b/docs/github-metadata.md
@@ -1,10 +1,6 @@
 # GitHub Metadata
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/github-metadata.md) · [Español](i18n/es/github-metadata.md) · [Português do Brasil](i18n/pt-BR/github-metadata.md) · [日本語](i18n/ja/github-metadata.md) · [한국어](i18n/ko/github-metadata.md) · [Русский](i18n/ru/github-metadata.md) · [Français](i18n/fr/github-metadata.md) · [Deutsch](i18n/de/github-metadata.md) · [Türkçe](i18n/tr/github-metadata.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/i18n/de/CONTEXT.md
+++ b/docs/i18n/de/CONTEXT.md
@@ -3,10 +3,6 @@
 # Fennara-Kontext
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · **Deutsch** · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../CONTEXT.md)

--- a/docs/i18n/de/CONTRIBUTING.md
+++ b/docs/i18n/de/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # Mitwirken
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · **Deutsch** · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../CONTRIBUTING.md)

--- a/docs/i18n/de/README.md
+++ b/docs/i18n/de/README.md
@@ -3,10 +3,6 @@
 # Fennara-Dokumentation
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Русский](../ru/README.md) · [Français](../fr/README.md) · **Deutsch** · [Türkçe](../tr/README.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../README.md)

--- a/docs/i18n/de/SECURITY.md
+++ b/docs/i18n/de/SECURITY.md
@@ -3,10 +3,6 @@
 # Sicherheit
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · **Deutsch** · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../SECURITY.md)

--- a/docs/i18n/de/architecture.md
+++ b/docs/i18n/de/architecture.md
@@ -3,10 +3,6 @@
 # Architektur
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · **Deutsch** · [Türkçe](../tr/architecture.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../architecture.md)

--- a/docs/i18n/de/chat-vs-mcp.md
+++ b/docs/i18n/de/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # MCP-Apps oder integrierter Chat?
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · **Deutsch** · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../chat-vs-mcp.md)

--- a/docs/i18n/de/cli.md
+++ b/docs/i18n/de/cli.md
@@ -3,10 +3,6 @@
 # Fennara-CLI
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · **Deutsch** · [Türkçe](../tr/cli.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../cli.md)

--- a/docs/i18n/de/contributors/chat-ui.md
+++ b/docs/i18n/de/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Fennara-Chat-Benutzeroberfläche
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](../README.md)
-
-🌐 **Sprachen**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · **Deutsch** · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../../ui/chat/README.md)

--- a/docs/i18n/de/contributors/godot-addons.md
+++ b/docs/i18n/de/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Godot-Addons
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](../README.md)
-
-🌐 **Sprachen**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · **Deutsch** · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/de/contributors/godot-payload.md
+++ b/docs/i18n/de/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Godot-Payload
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](../README.md)
-
-🌐 **Sprachen**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · **Deutsch** · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../../godot_demo/README.md)

--- a/docs/i18n/de/contributors/local-tools.md
+++ b/docs/i18n/de/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Lokale Fennara-Werkzeuge
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](../README.md)
-
-🌐 **Sprachen**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · **Deutsch** · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../../local/README.md)

--- a/docs/i18n/de/contributors/runtime-helpers.md
+++ b/docs/i18n/de/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # Laufzeit-Helfer
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](../README.md)
-
-🌐 **Sprachen**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · **Deutsch** · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../../runtime/README.md)

--- a/docs/i18n/de/contributors/scripts.md
+++ b/docs/i18n/de/contributors/scripts.md
@@ -3,10 +3,6 @@
 # Skripte
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](../README.md)
-
-🌐 **Sprachen**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · **Deutsch** · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../../../scripts/README.md)

--- a/docs/i18n/de/demos.md
+++ b/docs/i18n/de/demos.md
@@ -3,10 +3,6 @@
 # Demos
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · **Deutsch** · [Türkçe](../tr/demos.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../demos.md)

--- a/docs/i18n/de/examples.md
+++ b/docs/i18n/de/examples.md
@@ -3,10 +3,6 @@
 # Beispiele
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · **Deutsch** · [Türkçe](../tr/examples.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../examples.md)

--- a/docs/i18n/de/faq.md
+++ b/docs/i18n/de/faq.md
@@ -3,10 +3,6 @@
 # FAQ
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · **Deutsch** · [Türkçe](../tr/faq.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../faq.md)

--- a/docs/i18n/de/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/de/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara im Vergleich zu traditionellem Godot MCP
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · **Deutsch** · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/de/github-metadata.md
+++ b/docs/i18n/de/github-metadata.md
@@ -3,10 +3,6 @@
 # GitHub-Metadaten
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · **Deutsch** · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../github-metadata.md)

--- a/docs/i18n/de/languages.md
+++ b/docs/i18n/de/languages.md
@@ -3,10 +3,6 @@
 # Sprachen und Übersetzungsstatus
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · **Deutsch** · [Türkçe](../tr/languages.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../languages.md)

--- a/docs/i18n/de/manual-install.md
+++ b/docs/i18n/de/manual-install.md
@@ -3,10 +3,6 @@
 # Manuelle Installation
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · **Deutsch** · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../manual-install.md)

--- a/docs/i18n/de/mcp-setup.md
+++ b/docs/i18n/de/mcp-setup.md
@@ -3,10 +3,6 @@
 # MCP-Einrichtung
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · **Deutsch** · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../mcp-setup.md)

--- a/docs/i18n/de/open-rpg-demo.md
+++ b/docs/i18n/de/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Aufschlüsselung der Open-RPG-Demo
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · **Deutsch** · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../open-rpg-demo.md)

--- a/docs/i18n/de/providers.md
+++ b/docs/i18n/de/providers.md
@@ -3,10 +3,6 @@
 # Anbieter für den integrierten Chat
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · **Deutsch** · [Türkçe](../tr/providers.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../providers.md)

--- a/docs/i18n/de/release.md
+++ b/docs/i18n/de/release.md
@@ -3,10 +3,6 @@
 # Release-Prozess
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · [한국어](../ko/release.md) · [Русский](../ru/release.md) · [Français](../fr/release.md) · **Deutsch** · [Türkçe](../tr/release.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../release.md)

--- a/docs/i18n/de/repo-map.md
+++ b/docs/i18n/de/repo-map.md
@@ -3,10 +3,6 @@
 # Repositorysübersicht
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · **Deutsch** · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../repo-map.md)

--- a/docs/i18n/de/setup.md
+++ b/docs/i18n/de/setup.md
@@ -3,10 +3,6 @@
 # Einrichtung
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · **Deutsch** · [Türkçe](../tr/setup.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../setup.md)

--- a/docs/i18n/de/slash-commands.md
+++ b/docs/i18n/de/slash-commands.md
@@ -3,10 +3,6 @@
 # Slash-Befehle des integrierten Chats
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · **Deutsch** · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../slash-commands.md)

--- a/docs/i18n/de/telemetry.md
+++ b/docs/i18n/de/telemetry.md
@@ -3,10 +3,6 @@
 # Anonyme Telemetrie
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · **Deutsch** · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../telemetry.md)

--- a/docs/i18n/de/tools.md
+++ b/docs/i18n/de/tools.md
@@ -3,10 +3,6 @@
 # Werkzeuge
 
 <!-- fennara-doc-nav:start -->
-[Dokumentation](README.md)
-
-🌐 **Sprachen**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · **Deutsch** · [Türkçe](../tr/tools.md)
 
 > ℹ️ Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen. [Englische Quelle](../../tools.md)

--- a/docs/i18n/es/CONTEXT.md
+++ b/docs/i18n/es/CONTEXT.md
@@ -3,10 +3,6 @@
 # Contexto de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · **Español** · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../CONTEXT.md)

--- a/docs/i18n/es/CONTRIBUTING.md
+++ b/docs/i18n/es/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # Contribuir
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · **Español** · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../CONTRIBUTING.md)

--- a/docs/i18n/es/README.md
+++ b/docs/i18n/es/README.md
@@ -3,10 +3,6 @@
 # Documentación de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · **Español** · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Русский](../ru/README.md) · [Français](../fr/README.md) · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../README.md)

--- a/docs/i18n/es/SECURITY.md
+++ b/docs/i18n/es/SECURITY.md
@@ -3,10 +3,6 @@
 # Seguridad
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · **Español** · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../SECURITY.md)

--- a/docs/i18n/es/architecture.md
+++ b/docs/i18n/es/architecture.md
@@ -3,10 +3,6 @@
 # Arquitectura
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · **Español** · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../architecture.md)

--- a/docs/i18n/es/chat-vs-mcp.md
+++ b/docs/i18n/es/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # ¿Aplicaciones MCP o chat integrado?
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · **Español** · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../chat-vs-mcp.md)

--- a/docs/i18n/es/cli.md
+++ b/docs/i18n/es/cli.md
@@ -3,10 +3,6 @@
 # CLI de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · **Español** · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../cli.md)

--- a/docs/i18n/es/contributors/chat-ui.md
+++ b/docs/i18n/es/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Interfaz de chat de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentación](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · **Español** · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../../ui/chat/README.md)

--- a/docs/i18n/es/contributors/godot-addons.md
+++ b/docs/i18n/es/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Addons de Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentación](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · **Español** · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/es/contributors/godot-payload.md
+++ b/docs/i18n/es/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Paquete de Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentación](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · **Español** · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../../godot_demo/README.md)

--- a/docs/i18n/es/contributors/local-tools.md
+++ b/docs/i18n/es/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Herramientas locales de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentación](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · **Español** · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../../local/README.md)

--- a/docs/i18n/es/contributors/runtime-helpers.md
+++ b/docs/i18n/es/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # Auxiliares de ejecución
 
 <!-- fennara-doc-nav:start -->
-[Documentación](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · **Español** · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../../runtime/README.md)

--- a/docs/i18n/es/contributors/scripts.md
+++ b/docs/i18n/es/contributors/scripts.md
@@ -3,10 +3,6 @@
 # Scripts
 
 <!-- fennara-doc-nav:start -->
-[Documentación](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · **Español** · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../../../scripts/README.md)

--- a/docs/i18n/es/demos.md
+++ b/docs/i18n/es/demos.md
@@ -3,10 +3,6 @@
 # Demostraciones
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · **Español** · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../demos.md)

--- a/docs/i18n/es/examples.md
+++ b/docs/i18n/es/examples.md
@@ -3,10 +3,6 @@
 # Ejemplos
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · **Español** · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../examples.md)

--- a/docs/i18n/es/faq.md
+++ b/docs/i18n/es/faq.md
@@ -3,10 +3,6 @@
 # Preguntas frecuentes
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · **Español** · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../faq.md)

--- a/docs/i18n/es/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/es/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara frente a un MCP tradicional para Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · **Español** · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/es/github-metadata.md
+++ b/docs/i18n/es/github-metadata.md
@@ -3,10 +3,6 @@
 # Metadatos de GitHub
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · **Español** · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../github-metadata.md)

--- a/docs/i18n/es/languages.md
+++ b/docs/i18n/es/languages.md
@@ -3,10 +3,6 @@
 # Idiomas y estado de las traducciones
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · **Español** · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../languages.md)

--- a/docs/i18n/es/manual-install.md
+++ b/docs/i18n/es/manual-install.md
@@ -3,10 +3,6 @@
 # Instalación manual
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · **Español** · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../manual-install.md)

--- a/docs/i18n/es/mcp-setup.md
+++ b/docs/i18n/es/mcp-setup.md
@@ -3,10 +3,6 @@
 # Configuración de MCP
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · **Español** · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../mcp-setup.md)

--- a/docs/i18n/es/open-rpg-demo.md
+++ b/docs/i18n/es/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Análisis de la demostración Open RPG
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · **Español** · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../open-rpg-demo.md)

--- a/docs/i18n/es/providers.md
+++ b/docs/i18n/es/providers.md
@@ -3,10 +3,6 @@
 # Proveedores del chat integrado
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · **Español** · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../providers.md)

--- a/docs/i18n/es/release.md
+++ b/docs/i18n/es/release.md
@@ -3,10 +3,6 @@
 # Proceso de publicación
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · **Español** · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · [한국어](../ko/release.md) · [Русский](../ru/release.md) · [Français](../fr/release.md) · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../release.md)

--- a/docs/i18n/es/repo-map.md
+++ b/docs/i18n/es/repo-map.md
@@ -3,10 +3,6 @@
 # Mapa del repositorio
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · **Español** · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../repo-map.md)

--- a/docs/i18n/es/setup.md
+++ b/docs/i18n/es/setup.md
@@ -3,10 +3,6 @@
 # Configuración
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · **Español** · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../setup.md)

--- a/docs/i18n/es/slash-commands.md
+++ b/docs/i18n/es/slash-commands.md
@@ -3,10 +3,6 @@
 # Comandos con barra del chat integrado
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · **Español** · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../slash-commands.md)

--- a/docs/i18n/es/telemetry.md
+++ b/docs/i18n/es/telemetry.md
@@ -3,10 +3,6 @@
 # Telemetría anónima
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · **Español** · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../telemetry.md)

--- a/docs/i18n/es/tools.md
+++ b/docs/i18n/es/tools.md
@@ -3,10 +3,6 @@
 # Herramientas
 
 <!-- fennara-doc-nav:start -->
-[Documentación](README.md)
-
-🌐 **Idiomas**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · **Español** · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos. [Fuente en inglés](../../tools.md)

--- a/docs/i18n/fr/CONTEXT.md
+++ b/docs/i18n/fr/CONTEXT.md
@@ -3,10 +3,6 @@
 # Contexte de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · **Français** · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../CONTEXT.md)

--- a/docs/i18n/fr/CONTRIBUTING.md
+++ b/docs/i18n/fr/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # Contribuer
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · **Français** · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../CONTRIBUTING.md)

--- a/docs/i18n/fr/README.md
+++ b/docs/i18n/fr/README.md
@@ -3,10 +3,6 @@
 # Documentation de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Русский](../ru/README.md) · **Français** · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../README.md)

--- a/docs/i18n/fr/SECURITY.md
+++ b/docs/i18n/fr/SECURITY.md
@@ -3,10 +3,6 @@
 # Sécurité
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · **Français** · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../SECURITY.md)

--- a/docs/i18n/fr/architecture.md
+++ b/docs/i18n/fr/architecture.md
@@ -3,10 +3,6 @@
 # Architecture
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · **Français** · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../architecture.md)

--- a/docs/i18n/fr/chat-vs-mcp.md
+++ b/docs/i18n/fr/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # Applications MCP ou chat intégré ?
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · **Français** · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../chat-vs-mcp.md)

--- a/docs/i18n/fr/cli.md
+++ b/docs/i18n/fr/cli.md
@@ -3,10 +3,6 @@
 # CLI Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · **Français** · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../cli.md)

--- a/docs/i18n/fr/contributors/chat-ui.md
+++ b/docs/i18n/fr/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Interface de chat Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../README.md)
-
-🌐 **Langues**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · **Français** · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../../ui/chat/README.md)

--- a/docs/i18n/fr/contributors/godot-addons.md
+++ b/docs/i18n/fr/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Addons Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../README.md)
-
-🌐 **Langues**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · **Français** · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/fr/contributors/godot-payload.md
+++ b/docs/i18n/fr/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Charge utile Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../README.md)
-
-🌐 **Langues**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · **Français** · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../../godot_demo/README.md)

--- a/docs/i18n/fr/contributors/local-tools.md
+++ b/docs/i18n/fr/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Outils locaux de Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../README.md)
-
-🌐 **Langues**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · **Français** · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../../local/README.md)

--- a/docs/i18n/fr/contributors/runtime-helpers.md
+++ b/docs/i18n/fr/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # Auxiliaires d'exécution
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../README.md)
-
-🌐 **Langues**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · **Français** · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../../runtime/README.md)

--- a/docs/i18n/fr/contributors/scripts.md
+++ b/docs/i18n/fr/contributors/scripts.md
@@ -3,10 +3,6 @@
 # Scripts
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../README.md)
-
-🌐 **Langues**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · **Français** · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../../../scripts/README.md)

--- a/docs/i18n/fr/demos.md
+++ b/docs/i18n/fr/demos.md
@@ -3,10 +3,6 @@
 # Démos
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · **Français** · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../demos.md)

--- a/docs/i18n/fr/examples.md
+++ b/docs/i18n/fr/examples.md
@@ -3,10 +3,6 @@
 # Exemples
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · **Français** · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../examples.md)

--- a/docs/i18n/fr/faq.md
+++ b/docs/i18n/fr/faq.md
@@ -3,10 +3,6 @@
 # FAQ
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · **Français** · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../faq.md)

--- a/docs/i18n/fr/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/fr/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara face à un MCP Godot traditionnel
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · **Français** · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/fr/github-metadata.md
+++ b/docs/i18n/fr/github-metadata.md
@@ -3,10 +3,6 @@
 # Métadonnées GitHub
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · **Français** · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../github-metadata.md)

--- a/docs/i18n/fr/languages.md
+++ b/docs/i18n/fr/languages.md
@@ -3,10 +3,6 @@
 # Langues et état des traductions
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · **Français** · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../languages.md)

--- a/docs/i18n/fr/manual-install.md
+++ b/docs/i18n/fr/manual-install.md
@@ -3,10 +3,6 @@
 # Installation manuelle
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · **Français** · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../manual-install.md)

--- a/docs/i18n/fr/mcp-setup.md
+++ b/docs/i18n/fr/mcp-setup.md
@@ -3,10 +3,6 @@
 # Configuration MCP
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · **Français** · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../mcp-setup.md)

--- a/docs/i18n/fr/open-rpg-demo.md
+++ b/docs/i18n/fr/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Analyse de la démo Open RPG
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · **Français** · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../open-rpg-demo.md)

--- a/docs/i18n/fr/providers.md
+++ b/docs/i18n/fr/providers.md
@@ -3,10 +3,6 @@
 # Fournisseurs du chat intégré
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · **Français** · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../providers.md)

--- a/docs/i18n/fr/release.md
+++ b/docs/i18n/fr/release.md
@@ -3,10 +3,6 @@
 # Processus de publication
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · [한국어](../ko/release.md) · [Русский](../ru/release.md) · **Français** · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../release.md)

--- a/docs/i18n/fr/repo-map.md
+++ b/docs/i18n/fr/repo-map.md
@@ -3,10 +3,6 @@
 # Plan du dépôt
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · **Français** · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../repo-map.md)

--- a/docs/i18n/fr/setup.md
+++ b/docs/i18n/fr/setup.md
@@ -3,10 +3,6 @@
 # Installation
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · **Français** · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../setup.md)

--- a/docs/i18n/fr/slash-commands.md
+++ b/docs/i18n/fr/slash-commands.md
@@ -3,10 +3,6 @@
 # Commandes slash du chat intégré
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · **Français** · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../slash-commands.md)

--- a/docs/i18n/fr/telemetry.md
+++ b/docs/i18n/fr/telemetry.md
@@ -3,10 +3,6 @@
 # Télémétrie anonyme
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · **Français** · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../telemetry.md)

--- a/docs/i18n/fr/tools.md
+++ b/docs/i18n/fr/tools.md
@@ -3,10 +3,6 @@
 # Outils
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Langues**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · **Français** · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue. [Source anglaise](../../tools.md)

--- a/docs/i18n/ja/CONTEXT.md
+++ b/docs/i18n/ja/CONTEXT.md
@@ -3,10 +3,6 @@
 # Fennara 用語集
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · **日本語** · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../CONTEXT.md)

--- a/docs/i18n/ja/CONTRIBUTING.md
+++ b/docs/i18n/ja/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # コントリビューション
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · **日本語** · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../CONTRIBUTING.md)

--- a/docs/i18n/ja/README.md
+++ b/docs/i18n/ja/README.md
@@ -3,10 +3,6 @@
 # Fennara ドキュメント
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · **日本語** · [한국어](../ko/README.md) · [Русский](../ru/README.md) · [Français](../fr/README.md) · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../README.md)

--- a/docs/i18n/ja/SECURITY.md
+++ b/docs/i18n/ja/SECURITY.md
@@ -3,10 +3,6 @@
 # セキュリティ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · **日本語** · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../SECURITY.md)

--- a/docs/i18n/ja/architecture.md
+++ b/docs/i18n/ja/architecture.md
@@ -3,10 +3,6 @@
 # アーキテクチャ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · **日本語** · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../architecture.md)

--- a/docs/i18n/ja/chat-vs-mcp.md
+++ b/docs/i18n/ja/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # MCP アプリと内蔵チャットのどちらを使うべきですか？
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · **日本語** · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../chat-vs-mcp.md)

--- a/docs/i18n/ja/cli.md
+++ b/docs/i18n/ja/cli.md
@@ -3,10 +3,6 @@
 # Fennara CLI
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · **日本語** · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../cli.md)

--- a/docs/i18n/ja/contributors/chat-ui.md
+++ b/docs/i18n/ja/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Fennara チャット UI
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](../README.md)
-
-🌐 **言語**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · **日本語** · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../../ui/chat/README.md)

--- a/docs/i18n/ja/contributors/godot-addons.md
+++ b/docs/i18n/ja/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Godot アドオン
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](../README.md)
-
-🌐 **言語**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · **日本語** · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/ja/contributors/godot-payload.md
+++ b/docs/i18n/ja/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Godot ペイロード
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](../README.md)
-
-🌐 **言語**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · **日本語** · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../../godot_demo/README.md)

--- a/docs/i18n/ja/contributors/local-tools.md
+++ b/docs/i18n/ja/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Fennara ローカルツール
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](../README.md)
-
-🌐 **言語**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · **日本語** · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../../local/README.md)

--- a/docs/i18n/ja/contributors/runtime-helpers.md
+++ b/docs/i18n/ja/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # ランタイムヘルパー
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](../README.md)
-
-🌐 **言語**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · **日本語** · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../../runtime/README.md)

--- a/docs/i18n/ja/contributors/scripts.md
+++ b/docs/i18n/ja/contributors/scripts.md
@@ -3,10 +3,6 @@
 # スクリプト
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](../README.md)
-
-🌐 **言語**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · **日本語** · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../../../scripts/README.md)

--- a/docs/i18n/ja/demos.md
+++ b/docs/i18n/ja/demos.md
@@ -3,10 +3,6 @@
 # デモ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · **日本語** · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../demos.md)

--- a/docs/i18n/ja/examples.md
+++ b/docs/i18n/ja/examples.md
@@ -3,10 +3,6 @@
 # 使用例
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · **日本語** · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../examples.md)

--- a/docs/i18n/ja/faq.md
+++ b/docs/i18n/ja/faq.md
@@ -3,10 +3,6 @@
 # よくある質問
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · **日本語** · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../faq.md)

--- a/docs/i18n/ja/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/ja/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara と従来の Godot MCP の比較
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · **日本語** · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/ja/github-metadata.md
+++ b/docs/i18n/ja/github-metadata.md
@@ -3,10 +3,6 @@
 # GitHub メタデータ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · **日本語** · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../github-metadata.md)

--- a/docs/i18n/ja/languages.md
+++ b/docs/i18n/ja/languages.md
@@ -3,10 +3,6 @@
 # 言語と翻訳状況
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · **日本語** · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../languages.md)

--- a/docs/i18n/ja/manual-install.md
+++ b/docs/i18n/ja/manual-install.md
@@ -3,10 +3,6 @@
 # 手動インストール
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · **日本語** · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../manual-install.md)

--- a/docs/i18n/ja/mcp-setup.md
+++ b/docs/i18n/ja/mcp-setup.md
@@ -3,10 +3,6 @@
 # MCP セットアップ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · **日本語** · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../mcp-setup.md)

--- a/docs/i18n/ja/open-rpg-demo.md
+++ b/docs/i18n/ja/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Open RPG デモ解説
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · **日本語** · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../open-rpg-demo.md)

--- a/docs/i18n/ja/providers.md
+++ b/docs/i18n/ja/providers.md
@@ -3,10 +3,6 @@
 # 内蔵チャットプロバイダー
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · **日本語** · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../providers.md)

--- a/docs/i18n/ja/release.md
+++ b/docs/i18n/ja/release.md
@@ -3,10 +3,6 @@
 # リリース手順
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · **日本語** · [한국어](../ko/release.md) · [Русский](../ru/release.md) · [Français](../fr/release.md) · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../release.md)

--- a/docs/i18n/ja/repo-map.md
+++ b/docs/i18n/ja/repo-map.md
@@ -3,10 +3,6 @@
 # リポジトリマップ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · **日本語** · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../repo-map.md)

--- a/docs/i18n/ja/setup.md
+++ b/docs/i18n/ja/setup.md
@@ -3,10 +3,6 @@
 # セットアップ
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · **日本語** · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../setup.md)

--- a/docs/i18n/ja/slash-commands.md
+++ b/docs/i18n/ja/slash-commands.md
@@ -3,10 +3,6 @@
 # 内蔵チャットのスラッシュコマンド
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · **日本語** · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../slash-commands.md)

--- a/docs/i18n/ja/telemetry.md
+++ b/docs/i18n/ja/telemetry.md
@@ -3,10 +3,6 @@
 # 匿名テレメトリー
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · **日本語** · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../telemetry.md)

--- a/docs/i18n/ja/tools.md
+++ b/docs/i18n/ja/tools.md
@@ -3,10 +3,6 @@
 # ツール
 
 <!-- fennara-doc-nav:start -->
-[ドキュメント](README.md)
-
-🌐 **言語**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · **日本語** · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ 英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。 [英語の原文](../../tools.md)

--- a/docs/i18n/ko/CONTEXT.md
+++ b/docs/i18n/ko/CONTEXT.md
@@ -3,10 +3,6 @@
 # Fennara 용어
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · **한국어** · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../CONTEXT.md)

--- a/docs/i18n/ko/CONTRIBUTING.md
+++ b/docs/i18n/ko/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # 기여하기
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · **한국어** · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../CONTRIBUTING.md)

--- a/docs/i18n/ko/README.md
+++ b/docs/i18n/ko/README.md
@@ -3,10 +3,6 @@
 # Fennara 문서
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · **한국어** · [Русский](../ru/README.md) · [Français](../fr/README.md) · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../README.md)

--- a/docs/i18n/ko/SECURITY.md
+++ b/docs/i18n/ko/SECURITY.md
@@ -3,10 +3,6 @@
 # 보안
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · **한국어** · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../SECURITY.md)

--- a/docs/i18n/ko/architecture.md
+++ b/docs/i18n/ko/architecture.md
@@ -3,10 +3,6 @@
 # 아키텍처
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · **한국어** · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../architecture.md)

--- a/docs/i18n/ko/chat-vs-mcp.md
+++ b/docs/i18n/ko/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # MCP 앱과 내장 채팅 중 무엇을 사용할까요?
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · **한국어** · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../chat-vs-mcp.md)

--- a/docs/i18n/ko/cli.md
+++ b/docs/i18n/ko/cli.md
@@ -3,10 +3,6 @@
 # Fennara CLI
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · **한국어** · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../cli.md)

--- a/docs/i18n/ko/contributors/chat-ui.md
+++ b/docs/i18n/ko/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Fennara 채팅 UI
 
 <!-- fennara-doc-nav:start -->
-[문서](../README.md)
-
-🌐 **언어**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · **한국어** · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../../ui/chat/README.md)

--- a/docs/i18n/ko/contributors/godot-addons.md
+++ b/docs/i18n/ko/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Godot 애드온
 
 <!-- fennara-doc-nav:start -->
-[문서](../README.md)
-
-🌐 **언어**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · **한국어** · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/ko/contributors/godot-payload.md
+++ b/docs/i18n/ko/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Godot 페이로드
 
 <!-- fennara-doc-nav:start -->
-[문서](../README.md)
-
-🌐 **언어**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · **한국어** · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../../godot_demo/README.md)

--- a/docs/i18n/ko/contributors/local-tools.md
+++ b/docs/i18n/ko/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Fennara 로컬 도구
 
 <!-- fennara-doc-nav:start -->
-[문서](../README.md)
-
-🌐 **언어**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · **한국어** · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../../local/README.md)

--- a/docs/i18n/ko/contributors/runtime-helpers.md
+++ b/docs/i18n/ko/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # 런타임 헬퍼
 
 <!-- fennara-doc-nav:start -->
-[문서](../README.md)
-
-🌐 **언어**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · **한국어** · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../../runtime/README.md)

--- a/docs/i18n/ko/contributors/scripts.md
+++ b/docs/i18n/ko/contributors/scripts.md
@@ -3,10 +3,6 @@
 # 스크립트
 
 <!-- fennara-doc-nav:start -->
-[문서](../README.md)
-
-🌐 **언어**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · **한국어** · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../../../scripts/README.md)

--- a/docs/i18n/ko/demos.md
+++ b/docs/i18n/ko/demos.md
@@ -3,10 +3,6 @@
 # 데모
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · **한국어** · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../demos.md)

--- a/docs/i18n/ko/examples.md
+++ b/docs/i18n/ko/examples.md
@@ -3,10 +3,6 @@
 # 예제
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · **한국어** · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../examples.md)

--- a/docs/i18n/ko/faq.md
+++ b/docs/i18n/ko/faq.md
@@ -3,10 +3,6 @@
 # 자주 묻는 질문
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · **한국어** · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../faq.md)

--- a/docs/i18n/ko/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/ko/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara와 기존 Godot MCP 비교
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · **한국어** · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/ko/github-metadata.md
+++ b/docs/i18n/ko/github-metadata.md
@@ -3,10 +3,6 @@
 # GitHub 메타데이터
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · **한국어** · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../github-metadata.md)

--- a/docs/i18n/ko/languages.md
+++ b/docs/i18n/ko/languages.md
@@ -3,10 +3,6 @@
 # 언어 및 번역 상태
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · **한국어** · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../languages.md)

--- a/docs/i18n/ko/manual-install.md
+++ b/docs/i18n/ko/manual-install.md
@@ -3,10 +3,6 @@
 # 수동 설치
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · **한국어** · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../manual-install.md)

--- a/docs/i18n/ko/mcp-setup.md
+++ b/docs/i18n/ko/mcp-setup.md
@@ -3,10 +3,6 @@
 # MCP 설정
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · **한국어** · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../mcp-setup.md)

--- a/docs/i18n/ko/open-rpg-demo.md
+++ b/docs/i18n/ko/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Open RPG 데모 분석
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · **한국어** · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../open-rpg-demo.md)

--- a/docs/i18n/ko/providers.md
+++ b/docs/i18n/ko/providers.md
@@ -3,10 +3,6 @@
 # 내장 채팅 제공업체
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · **한국어** · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../providers.md)

--- a/docs/i18n/ko/release.md
+++ b/docs/i18n/ko/release.md
@@ -3,10 +3,6 @@
 # 릴리스 절차
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · **한국어** · [Русский](../ru/release.md) · [Français](../fr/release.md) · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../release.md)

--- a/docs/i18n/ko/repo-map.md
+++ b/docs/i18n/ko/repo-map.md
@@ -3,10 +3,6 @@
 # 저장소 지도
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · **한국어** · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../repo-map.md)

--- a/docs/i18n/ko/setup.md
+++ b/docs/i18n/ko/setup.md
@@ -3,10 +3,6 @@
 # 설정
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · **한국어** · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../setup.md)

--- a/docs/i18n/ko/slash-commands.md
+++ b/docs/i18n/ko/slash-commands.md
@@ -3,10 +3,6 @@
 # 내장 채팅 슬래시 명령
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · **한국어** · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../slash-commands.md)

--- a/docs/i18n/ko/telemetry.md
+++ b/docs/i18n/ko/telemetry.md
@@ -3,10 +3,6 @@
 # 익명 텔레메트리
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · **한국어** · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../telemetry.md)

--- a/docs/i18n/ko/tools.md
+++ b/docs/i18n/ko/tools.md
@@ -3,10 +3,6 @@
 # 도구
 
 <!-- fennara-doc-nav:start -->
-[문서](README.md)
-
-🌐 **언어**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · **한국어** · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ 영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다. [영문 원본](../../tools.md)

--- a/docs/i18n/languages.json
+++ b/docs/i18n/languages.json
@@ -4,79 +4,59 @@
   "locales": [
     {
       "code": "en",
-      "nativeName": "English",
-      "docsLabel": "Documentation",
-      "languagesLabel": "Languages"
+      "nativeName": "English"
     },
     {
       "code": "zh-CN",
       "nativeName": "简体中文",
-      "docsLabel": "文档",
-      "languagesLabel": "语言",
       "sourceLabel": "英文原文",
       "reviewNotice": "由 AI 根据英文原文撰写，欢迎母语者审阅。"
     },
     {
       "code": "es",
       "nativeName": "Español",
-      "docsLabel": "Documentación",
-      "languagesLabel": "Idiomas",
       "sourceLabel": "Fuente en inglés",
       "reviewNotice": "Traducción redactada por IA a partir del original en inglés. Se agradece la revisión de hablantes nativos."
     },
     {
       "code": "pt-BR",
       "nativeName": "Português do Brasil",
-      "docsLabel": "Documentação",
-      "languagesLabel": "Idiomas",
       "sourceLabel": "Fonte em inglês",
       "reviewNotice": "Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda."
     },
     {
       "code": "ja",
       "nativeName": "日本語",
-      "docsLabel": "ドキュメント",
-      "languagesLabel": "言語",
       "sourceLabel": "英語の原文",
       "reviewNotice": "英語の原文を基に AI が執筆した翻訳です。ネイティブスピーカーによるレビューを歓迎します。"
     },
     {
       "code": "ko",
       "nativeName": "한국어",
-      "docsLabel": "문서",
-      "languagesLabel": "언어",
       "sourceLabel": "영문 원본",
       "reviewNotice": "영문 원본을 바탕으로 AI가 작성한 번역입니다. 원어민 검토를 환영합니다."
     },
     {
       "code": "ru",
       "nativeName": "Русский",
-      "docsLabel": "Документация",
-      "languagesLabel": "Языки",
       "sourceLabel": "Источник на английском",
       "reviewNotice": "Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка."
     },
     {
       "code": "fr",
       "nativeName": "Français",
-      "docsLabel": "Documentation",
-      "languagesLabel": "Langues",
       "sourceLabel": "Source anglaise",
       "reviewNotice": "Traduction rédigée par une IA à partir de la source anglaise. La relecture par des locuteurs natifs est la bienvenue."
     },
     {
       "code": "de",
       "nativeName": "Deutsch",
-      "docsLabel": "Dokumentation",
-      "languagesLabel": "Sprachen",
       "sourceLabel": "Englische Quelle",
       "reviewNotice": "Diese Übersetzung wurde von einer KI anhand der englischen Quelle verfasst. Eine Prüfung durch Muttersprachler ist willkommen."
     },
     {
       "code": "tr",
       "nativeName": "Türkçe",
-      "docsLabel": "Belgeler",
-      "languagesLabel": "Diller",
       "sourceLabel": "İngilizce kaynak",
       "reviewNotice": "Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır."
     }

--- a/docs/i18n/pt-BR/CONTEXT.md
+++ b/docs/i18n/pt-BR/CONTEXT.md
@@ -3,10 +3,6 @@
 # Contexto do Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · **Português do Brasil** · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../CONTEXT.md)

--- a/docs/i18n/pt-BR/CONTRIBUTING.md
+++ b/docs/i18n/pt-BR/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # Como contribuir
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · **Português do Brasil** · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../CONTRIBUTING.md)

--- a/docs/i18n/pt-BR/README.md
+++ b/docs/i18n/pt-BR/README.md
@@ -3,10 +3,6 @@
 # Documentação do Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · **Português do Brasil** · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Русский](../ru/README.md) · [Français](../fr/README.md) · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../README.md)

--- a/docs/i18n/pt-BR/SECURITY.md
+++ b/docs/i18n/pt-BR/SECURITY.md
@@ -3,10 +3,6 @@
 # Segurança
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · **Português do Brasil** · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../SECURITY.md)

--- a/docs/i18n/pt-BR/architecture.md
+++ b/docs/i18n/pt-BR/architecture.md
@@ -3,10 +3,6 @@
 # Arquitetura
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · **Português do Brasil** · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../architecture.md)

--- a/docs/i18n/pt-BR/chat-vs-mcp.md
+++ b/docs/i18n/pt-BR/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # Aplicativos MCP ou chat integrado?
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · **Português do Brasil** · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../chat-vs-mcp.md)

--- a/docs/i18n/pt-BR/cli.md
+++ b/docs/i18n/pt-BR/cli.md
@@ -3,10 +3,6 @@
 # CLI do Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · **Português do Brasil** · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../cli.md)

--- a/docs/i18n/pt-BR/contributors/chat-ui.md
+++ b/docs/i18n/pt-BR/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Interface de chat do Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentação](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · **Português do Brasil** · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../../ui/chat/README.md)

--- a/docs/i18n/pt-BR/contributors/godot-addons.md
+++ b/docs/i18n/pt-BR/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Addons do Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentação](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · **Português do Brasil** · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/pt-BR/contributors/godot-payload.md
+++ b/docs/i18n/pt-BR/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Payload do Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentação](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · **Português do Brasil** · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../../godot_demo/README.md)

--- a/docs/i18n/pt-BR/contributors/local-tools.md
+++ b/docs/i18n/pt-BR/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Ferramentas locais do Fennara
 
 <!-- fennara-doc-nav:start -->
-[Documentação](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · **Português do Brasil** · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../../local/README.md)

--- a/docs/i18n/pt-BR/contributors/runtime-helpers.md
+++ b/docs/i18n/pt-BR/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # Auxiliares de runtime
 
 <!-- fennara-doc-nav:start -->
-[Documentação](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · **Português do Brasil** · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../../runtime/README.md)

--- a/docs/i18n/pt-BR/contributors/scripts.md
+++ b/docs/i18n/pt-BR/contributors/scripts.md
@@ -3,10 +3,6 @@
 # Scripts
 
 <!-- fennara-doc-nav:start -->
-[Documentação](../README.md)
-
-🌐 **Idiomas**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · **Português do Brasil** · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../../../scripts/README.md)

--- a/docs/i18n/pt-BR/demos.md
+++ b/docs/i18n/pt-BR/demos.md
@@ -3,10 +3,6 @@
 # Demonstrações
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · **Português do Brasil** · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../demos.md)

--- a/docs/i18n/pt-BR/examples.md
+++ b/docs/i18n/pt-BR/examples.md
@@ -3,10 +3,6 @@
 # Exemplos
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · **Português do Brasil** · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../examples.md)

--- a/docs/i18n/pt-BR/faq.md
+++ b/docs/i18n/pt-BR/faq.md
@@ -3,10 +3,6 @@
 # Perguntas frequentes
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · **Português do Brasil** · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../faq.md)

--- a/docs/i18n/pt-BR/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/pt-BR/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara em comparação com MCP tradicional para Godot
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · **Português do Brasil** · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/pt-BR/github-metadata.md
+++ b/docs/i18n/pt-BR/github-metadata.md
@@ -3,10 +3,6 @@
 # Metadados do GitHub
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · **Português do Brasil** · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../github-metadata.md)

--- a/docs/i18n/pt-BR/languages.md
+++ b/docs/i18n/pt-BR/languages.md
@@ -3,10 +3,6 @@
 # Idiomas e status das traduções
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · **Português do Brasil** · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../languages.md)

--- a/docs/i18n/pt-BR/manual-install.md
+++ b/docs/i18n/pt-BR/manual-install.md
@@ -3,10 +3,6 @@
 # Instalação manual
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · **Português do Brasil** · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../manual-install.md)

--- a/docs/i18n/pt-BR/mcp-setup.md
+++ b/docs/i18n/pt-BR/mcp-setup.md
@@ -3,10 +3,6 @@
 # Configuração de MCP
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · **Português do Brasil** · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../mcp-setup.md)

--- a/docs/i18n/pt-BR/open-rpg-demo.md
+++ b/docs/i18n/pt-BR/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Explicação da demonstração Open RPG
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · **Português do Brasil** · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../open-rpg-demo.md)

--- a/docs/i18n/pt-BR/providers.md
+++ b/docs/i18n/pt-BR/providers.md
@@ -3,10 +3,6 @@
 # Provedores do chat integrado
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · **Português do Brasil** · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../providers.md)

--- a/docs/i18n/pt-BR/release.md
+++ b/docs/i18n/pt-BR/release.md
@@ -3,10 +3,6 @@
 # Processo de lançamento
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · **Português do Brasil** · [日本語](../ja/release.md) · [한국어](../ko/release.md) · [Русский](../ru/release.md) · [Français](../fr/release.md) · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../release.md)

--- a/docs/i18n/pt-BR/repo-map.md
+++ b/docs/i18n/pt-BR/repo-map.md
@@ -3,10 +3,6 @@
 # Mapa do repositório
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · **Português do Brasil** · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../repo-map.md)

--- a/docs/i18n/pt-BR/setup.md
+++ b/docs/i18n/pt-BR/setup.md
@@ -3,10 +3,6 @@
 # Configuração
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · **Português do Brasil** · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../setup.md)

--- a/docs/i18n/pt-BR/slash-commands.md
+++ b/docs/i18n/pt-BR/slash-commands.md
@@ -3,10 +3,6 @@
 # Comandos de barra do chat integrado
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · **Português do Brasil** · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../slash-commands.md)

--- a/docs/i18n/pt-BR/telemetry.md
+++ b/docs/i18n/pt-BR/telemetry.md
@@ -3,10 +3,6 @@
 # Telemetria anônima
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · **Português do Brasil** · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../telemetry.md)

--- a/docs/i18n/pt-BR/tools.md
+++ b/docs/i18n/pt-BR/tools.md
@@ -3,10 +3,6 @@
 # Ferramentas
 
 <!-- fennara-doc-nav:start -->
-[Documentação](README.md)
-
-🌐 **Idiomas**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · **Português do Brasil** · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ Tradução redigida por IA a partir do original em inglês. A revisão por falantes nativos é bem-vinda. [Fonte em inglês](../../tools.md)

--- a/docs/i18n/ru/CONTEXT.md
+++ b/docs/i18n/ru/CONTEXT.md
@@ -3,10 +3,6 @@
 # Контекст Fennara
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · **Русский** · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../CONTEXT.md)

--- a/docs/i18n/ru/CONTRIBUTING.md
+++ b/docs/i18n/ru/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # Участие в разработке
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · **Русский** · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../CONTRIBUTING.md)

--- a/docs/i18n/ru/README.md
+++ b/docs/i18n/ru/README.md
@@ -3,10 +3,6 @@
 # Документация Fennara
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · **Русский** · [Français](../fr/README.md) · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../README.md)

--- a/docs/i18n/ru/SECURITY.md
+++ b/docs/i18n/ru/SECURITY.md
@@ -3,10 +3,6 @@
 # Безопасность
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · **Русский** · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../SECURITY.md)

--- a/docs/i18n/ru/architecture.md
+++ b/docs/i18n/ru/architecture.md
@@ -3,10 +3,6 @@
 # Архитектура
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · **Русский** · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../architecture.md)

--- a/docs/i18n/ru/chat-vs-mcp.md
+++ b/docs/i18n/ru/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # MCP-приложения или встроенный чат?
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · **Русский** · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../chat-vs-mcp.md)

--- a/docs/i18n/ru/cli.md
+++ b/docs/i18n/ru/cli.md
@@ -3,10 +3,6 @@
 # CLI Fennara
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · **Русский** · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../cli.md)

--- a/docs/i18n/ru/contributors/chat-ui.md
+++ b/docs/i18n/ru/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Интерфейс чата Fennara
 
 <!-- fennara-doc-nav:start -->
-[Документация](../README.md)
-
-🌐 **Языки**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · **Русский** · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../../ui/chat/README.md)

--- a/docs/i18n/ru/contributors/godot-addons.md
+++ b/docs/i18n/ru/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Аддоны Godot
 
 <!-- fennara-doc-nav:start -->
-[Документация](../README.md)
-
-🌐 **Языки**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · **Русский** · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/ru/contributors/godot-payload.md
+++ b/docs/i18n/ru/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Полезная нагрузка Godot
 
 <!-- fennara-doc-nav:start -->
-[Документация](../README.md)
-
-🌐 **Языки**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · **Русский** · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../../godot_demo/README.md)

--- a/docs/i18n/ru/contributors/local-tools.md
+++ b/docs/i18n/ru/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Локальные инструменты Fennara
 
 <!-- fennara-doc-nav:start -->
-[Документация](../README.md)
-
-🌐 **Языки**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · **Русский** · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../../local/README.md)

--- a/docs/i18n/ru/contributors/runtime-helpers.md
+++ b/docs/i18n/ru/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # Вспомогательные средства рантайма
 
 <!-- fennara-doc-nav:start -->
-[Документация](../README.md)
-
-🌐 **Языки**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · **Русский** · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../../runtime/README.md)

--- a/docs/i18n/ru/contributors/scripts.md
+++ b/docs/i18n/ru/contributors/scripts.md
@@ -3,10 +3,6 @@
 # Скрипты
 
 <!-- fennara-doc-nav:start -->
-[Документация](../README.md)
-
-🌐 **Языки**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · **Русский** · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../../../scripts/README.md)

--- a/docs/i18n/ru/demos.md
+++ b/docs/i18n/ru/demos.md
@@ -3,10 +3,6 @@
 # Демонстрации
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · **Русский** · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../demos.md)

--- a/docs/i18n/ru/examples.md
+++ b/docs/i18n/ru/examples.md
@@ -3,10 +3,6 @@
 # Примеры
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · **Русский** · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../examples.md)

--- a/docs/i18n/ru/faq.md
+++ b/docs/i18n/ru/faq.md
@@ -3,10 +3,6 @@
 # Частые вопросы
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · **Русский** · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../faq.md)

--- a/docs/i18n/ru/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/ru/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara в сравнении с традиционным MCP для Godot
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · **Русский** · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/ru/github-metadata.md
+++ b/docs/i18n/ru/github-metadata.md
@@ -3,10 +3,6 @@
 # Метаданные GitHub
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · **Русский** · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../github-metadata.md)

--- a/docs/i18n/ru/languages.md
+++ b/docs/i18n/ru/languages.md
@@ -3,10 +3,6 @@
 # Языки и состояние переводов
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · **Русский** · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../languages.md)

--- a/docs/i18n/ru/manual-install.md
+++ b/docs/i18n/ru/manual-install.md
@@ -3,10 +3,6 @@
 # Ручная установка
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · **Русский** · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../manual-install.md)

--- a/docs/i18n/ru/mcp-setup.md
+++ b/docs/i18n/ru/mcp-setup.md
@@ -3,10 +3,6 @@
 # Настройка MCP
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · **Русский** · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../mcp-setup.md)

--- a/docs/i18n/ru/open-rpg-demo.md
+++ b/docs/i18n/ru/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Разбор демонстрации Open RPG
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · **Русский** · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../open-rpg-demo.md)

--- a/docs/i18n/ru/providers.md
+++ b/docs/i18n/ru/providers.md
@@ -3,10 +3,6 @@
 # Провайдеры встроенного чата
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · **Русский** · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../providers.md)

--- a/docs/i18n/ru/release.md
+++ b/docs/i18n/ru/release.md
@@ -3,10 +3,6 @@
 # Процесс выпуска
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · [한국어](../ko/release.md) · **Русский** · [Français](../fr/release.md) · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../release.md)

--- a/docs/i18n/ru/repo-map.md
+++ b/docs/i18n/ru/repo-map.md
@@ -3,10 +3,6 @@
 # Карта репозитория
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · **Русский** · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../repo-map.md)

--- a/docs/i18n/ru/setup.md
+++ b/docs/i18n/ru/setup.md
@@ -3,10 +3,6 @@
 # Настройка
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · **Русский** · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../setup.md)

--- a/docs/i18n/ru/slash-commands.md
+++ b/docs/i18n/ru/slash-commands.md
@@ -3,10 +3,6 @@
 # Slash-команды встроенного чата
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · **Русский** · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../slash-commands.md)

--- a/docs/i18n/ru/telemetry.md
+++ b/docs/i18n/ru/telemetry.md
@@ -3,10 +3,6 @@
 # Анонимная телеметрия
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · **Русский** · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../telemetry.md)

--- a/docs/i18n/ru/tools.md
+++ b/docs/i18n/ru/tools.md
@@ -3,10 +3,6 @@
 # Инструменты
 
 <!-- fennara-doc-nav:start -->
-[Документация](README.md)
-
-🌐 **Языки**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · **Русский** · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ Перевод написан ИИ на основе английского оригинала. Приветствуется проверка носителями языка. [Источник на английском](../../tools.md)

--- a/docs/i18n/tr/CONTEXT.md
+++ b/docs/i18n/tr/CONTEXT.md
@@ -3,10 +3,6 @@
 # Fennara Bağlamı
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../../CONTEXT.md) · [简体中文](../zh-CN/CONTEXT.md) · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../CONTEXT.md)

--- a/docs/i18n/tr/CONTRIBUTING.md
+++ b/docs/i18n/tr/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # Katkıda Bulunma
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../../CONTRIBUTING.md) · [简体中文](../zh-CN/CONTRIBUTING.md) · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../CONTRIBUTING.md)

--- a/docs/i18n/tr/README.md
+++ b/docs/i18n/tr/README.md
@@ -3,10 +3,6 @@
 # Fennara Belgeleri
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../README.md) · [简体中文](../zh-CN/README.md) · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Русский](../ru/README.md) · [Français](../fr/README.md) · [Deutsch](../de/README.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../README.md)

--- a/docs/i18n/tr/SECURITY.md
+++ b/docs/i18n/tr/SECURITY.md
@@ -3,10 +3,6 @@
 # Güvenlik
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../../SECURITY.md) · [简体中文](../zh-CN/SECURITY.md) · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../SECURITY.md)

--- a/docs/i18n/tr/architecture.md
+++ b/docs/i18n/tr/architecture.md
@@ -3,10 +3,6 @@
 # Mimari
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../architecture.md) · [简体中文](../zh-CN/architecture.md) · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../architecture.md)

--- a/docs/i18n/tr/chat-vs-mcp.md
+++ b/docs/i18n/tr/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # MCP Uygulamaları mı, Yerleşik Sohbet mi?
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../chat-vs-mcp.md) · [简体中文](../zh-CN/chat-vs-mcp.md) · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../chat-vs-mcp.md)

--- a/docs/i18n/tr/cli.md
+++ b/docs/i18n/tr/cli.md
@@ -3,10 +3,6 @@
 # Fennara CLI
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../cli.md) · [简体中文](../zh-CN/cli.md) · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../cli.md)

--- a/docs/i18n/tr/contributors/chat-ui.md
+++ b/docs/i18n/tr/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Fennara Sohbet Kullanıcı Arayüzü
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](../README.md)
-
-🌐 **Diller**
-
 [English](../../../../ui/chat/README.md) · [简体中文](../../zh-CN/contributors/chat-ui.md) · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../../ui/chat/README.md)

--- a/docs/i18n/tr/contributors/godot-addons.md
+++ b/docs/i18n/tr/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Godot Eklentileri
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](../README.md)
-
-🌐 **Diller**
-
 [English](../../../../godot_demo/addons/README.md) · [简体中文](../../zh-CN/contributors/godot-addons.md) · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/tr/contributors/godot-payload.md
+++ b/docs/i18n/tr/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Godot Veri Yükü
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](../README.md)
-
-🌐 **Diller**
-
 [English](../../../../godot_demo/README.md) · [简体中文](../../zh-CN/contributors/godot-payload.md) · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../../godot_demo/README.md)

--- a/docs/i18n/tr/contributors/local-tools.md
+++ b/docs/i18n/tr/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Fennara Yerel Araçları
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](../README.md)
-
-🌐 **Diller**
-
 [English](../../../../local/README.md) · [简体中文](../../zh-CN/contributors/local-tools.md) · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../../local/README.md)

--- a/docs/i18n/tr/contributors/runtime-helpers.md
+++ b/docs/i18n/tr/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # Çalışma Zamanı Yardımcıları
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](../README.md)
-
-🌐 **Diller**
-
 [English](../../../../runtime/README.md) · [简体中文](../../zh-CN/contributors/runtime-helpers.md) · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../../runtime/README.md)

--- a/docs/i18n/tr/contributors/scripts.md
+++ b/docs/i18n/tr/contributors/scripts.md
@@ -3,10 +3,6 @@
 # Betikler
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](../README.md)
-
-🌐 **Diller**
-
 [English](../../../../scripts/README.md) · [简体中文](../../zh-CN/contributors/scripts.md) · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../../../scripts/README.md)

--- a/docs/i18n/tr/demos.md
+++ b/docs/i18n/tr/demos.md
@@ -3,10 +3,6 @@
 # Demolar
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../demos.md) · [简体中文](../zh-CN/demos.md) · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../demos.md)

--- a/docs/i18n/tr/examples.md
+++ b/docs/i18n/tr/examples.md
@@ -3,10 +3,6 @@
 # Örnekler
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../examples.md) · [简体中文](../zh-CN/examples.md) · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../examples.md)

--- a/docs/i18n/tr/faq.md
+++ b/docs/i18n/tr/faq.md
@@ -3,10 +3,6 @@
 # SSS
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../faq.md) · [简体中文](../zh-CN/faq.md) · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../faq.md)

--- a/docs/i18n/tr/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/tr/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara ile Geleneksel Godot MCP Karşılaştırması
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · [简体中文](../zh-CN/fennara-vs-traditional-godot-mcp.md) · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/tr/github-metadata.md
+++ b/docs/i18n/tr/github-metadata.md
@@ -3,10 +3,6 @@
 # GitHub Meta Verileri
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../github-metadata.md) · [简体中文](../zh-CN/github-metadata.md) · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../github-metadata.md)

--- a/docs/i18n/tr/languages.md
+++ b/docs/i18n/tr/languages.md
@@ -3,10 +3,6 @@
 # Diller ve Çeviri Durumu
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../languages.md) · [简体中文](../zh-CN/languages.md) · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../languages.md)

--- a/docs/i18n/tr/manual-install.md
+++ b/docs/i18n/tr/manual-install.md
@@ -3,10 +3,6 @@
 # Elle Kurulum
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../manual-install.md) · [简体中文](../zh-CN/manual-install.md) · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../manual-install.md)

--- a/docs/i18n/tr/mcp-setup.md
+++ b/docs/i18n/tr/mcp-setup.md
@@ -3,10 +3,6 @@
 # MCP Kurulumu
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../mcp-setup.md) · [简体中文](../zh-CN/mcp-setup.md) · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../mcp-setup.md)

--- a/docs/i18n/tr/open-rpg-demo.md
+++ b/docs/i18n/tr/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Open RPG Demo Dökümü
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../open-rpg-demo.md) · [简体中文](../zh-CN/open-rpg-demo.md) · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../open-rpg-demo.md)

--- a/docs/i18n/tr/providers.md
+++ b/docs/i18n/tr/providers.md
@@ -3,10 +3,6 @@
 # Yerleşik Sohbet Sağlayıcıları
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../providers.md) · [简体中文](../zh-CN/providers.md) · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../providers.md)

--- a/docs/i18n/tr/release.md
+++ b/docs/i18n/tr/release.md
@@ -3,10 +3,6 @@
 # Sürüm Süreci
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../release.md) · [简体中文](../zh-CN/release.md) · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · [한국어](../ko/release.md) · [Русский](../ru/release.md) · [Français](../fr/release.md) · [Deutsch](../de/release.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../release.md)

--- a/docs/i18n/tr/repo-map.md
+++ b/docs/i18n/tr/repo-map.md
@@ -3,10 +3,6 @@
 # Depo Haritası
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../repo-map.md) · [简体中文](../zh-CN/repo-map.md) · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../repo-map.md)

--- a/docs/i18n/tr/setup.md
+++ b/docs/i18n/tr/setup.md
@@ -3,10 +3,6 @@
 # Kurulum
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../setup.md) · [简体中文](../zh-CN/setup.md) · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../setup.md)

--- a/docs/i18n/tr/slash-commands.md
+++ b/docs/i18n/tr/slash-commands.md
@@ -3,10 +3,6 @@
 # Yerleşik Sohbet Eğik Çizgi Komutları
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../slash-commands.md) · [简体中文](../zh-CN/slash-commands.md) · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../slash-commands.md)

--- a/docs/i18n/tr/telemetry.md
+++ b/docs/i18n/tr/telemetry.md
@@ -3,10 +3,6 @@
 # Anonim Telemetri
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../telemetry.md) · [简体中文](../zh-CN/telemetry.md) · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../telemetry.md)

--- a/docs/i18n/tr/tools.md
+++ b/docs/i18n/tr/tools.md
@@ -3,10 +3,6 @@
 # Araçlar
 
 <!-- fennara-doc-nav:start -->
-[Belgeler](README.md)
-
-🌐 **Diller**
-
 [English](../../tools.md) · [简体中文](../zh-CN/tools.md) · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · **Türkçe**
 
 > ℹ️ Bu çeviri İngilizce kaynak temel alınarak yapay zeka tarafından yazılmıştır. Ana dil konuşurlarının incelemesi memnuniyetle karşılanır. [İngilizce kaynak](../../tools.md)

--- a/docs/i18n/zh-CN/CONTEXT.md
+++ b/docs/i18n/zh-CN/CONTEXT.md
@@ -3,10 +3,6 @@
 # Fennara 术语
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../../CONTEXT.md) · **简体中文** · [Español](../es/CONTEXT.md) · [Português do Brasil](../pt-BR/CONTEXT.md) · [日本語](../ja/CONTEXT.md) · [한국어](../ko/CONTEXT.md) · [Русский](../ru/CONTEXT.md) · [Français](../fr/CONTEXT.md) · [Deutsch](../de/CONTEXT.md) · [Türkçe](../tr/CONTEXT.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../CONTEXT.md)

--- a/docs/i18n/zh-CN/CONTRIBUTING.md
+++ b/docs/i18n/zh-CN/CONTRIBUTING.md
@@ -3,10 +3,6 @@
 # 参与贡献
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../../CONTRIBUTING.md) · **简体中文** · [Español](../es/CONTRIBUTING.md) · [Português do Brasil](../pt-BR/CONTRIBUTING.md) · [日本語](../ja/CONTRIBUTING.md) · [한국어](../ko/CONTRIBUTING.md) · [Русский](../ru/CONTRIBUTING.md) · [Français](../fr/CONTRIBUTING.md) · [Deutsch](../de/CONTRIBUTING.md) · [Türkçe](../tr/CONTRIBUTING.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../CONTRIBUTING.md)

--- a/docs/i18n/zh-CN/README.md
+++ b/docs/i18n/zh-CN/README.md
@@ -3,10 +3,6 @@
 # Fennara 文档
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../README.md) · **简体中文** · [Español](../es/README.md) · [Português do Brasil](../pt-BR/README.md) · [日本語](../ja/README.md) · [한국어](../ko/README.md) · [Русский](../ru/README.md) · [Français](../fr/README.md) · [Deutsch](../de/README.md) · [Türkçe](../tr/README.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../README.md)

--- a/docs/i18n/zh-CN/SECURITY.md
+++ b/docs/i18n/zh-CN/SECURITY.md
@@ -3,10 +3,6 @@
 # 安全
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../../SECURITY.md) · **简体中文** · [Español](../es/SECURITY.md) · [Português do Brasil](../pt-BR/SECURITY.md) · [日本語](../ja/SECURITY.md) · [한국어](../ko/SECURITY.md) · [Русский](../ru/SECURITY.md) · [Français](../fr/SECURITY.md) · [Deutsch](../de/SECURITY.md) · [Türkçe](../tr/SECURITY.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../SECURITY.md)

--- a/docs/i18n/zh-CN/architecture.md
+++ b/docs/i18n/zh-CN/architecture.md
@@ -3,10 +3,6 @@
 # 架构
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../architecture.md) · **简体中文** · [Español](../es/architecture.md) · [Português do Brasil](../pt-BR/architecture.md) · [日本語](../ja/architecture.md) · [한국어](../ko/architecture.md) · [Русский](../ru/architecture.md) · [Français](../fr/architecture.md) · [Deutsch](../de/architecture.md) · [Türkçe](../tr/architecture.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../architecture.md)

--- a/docs/i18n/zh-CN/chat-vs-mcp.md
+++ b/docs/i18n/zh-CN/chat-vs-mcp.md
@@ -3,10 +3,6 @@
 # MCP 应用还是内置聊天？
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../chat-vs-mcp.md) · **简体中文** · [Español](../es/chat-vs-mcp.md) · [Português do Brasil](../pt-BR/chat-vs-mcp.md) · [日本語](../ja/chat-vs-mcp.md) · [한국어](../ko/chat-vs-mcp.md) · [Русский](../ru/chat-vs-mcp.md) · [Français](../fr/chat-vs-mcp.md) · [Deutsch](../de/chat-vs-mcp.md) · [Türkçe](../tr/chat-vs-mcp.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../chat-vs-mcp.md)

--- a/docs/i18n/zh-CN/cli.md
+++ b/docs/i18n/zh-CN/cli.md
@@ -3,10 +3,6 @@
 # Fennara CLI
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../cli.md) · **简体中文** · [Español](../es/cli.md) · [Português do Brasil](../pt-BR/cli.md) · [日本語](../ja/cli.md) · [한국어](../ko/cli.md) · [Русский](../ru/cli.md) · [Français](../fr/cli.md) · [Deutsch](../de/cli.md) · [Türkçe](../tr/cli.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../cli.md)

--- a/docs/i18n/zh-CN/contributors/chat-ui.md
+++ b/docs/i18n/zh-CN/contributors/chat-ui.md
@@ -3,10 +3,6 @@
 # Fennara 聊天 UI
 
 <!-- fennara-doc-nav:start -->
-[文档](../README.md)
-
-🌐 **语言**
-
 [English](../../../../ui/chat/README.md) · **简体中文** · [Español](../../es/contributors/chat-ui.md) · [Português do Brasil](../../pt-BR/contributors/chat-ui.md) · [日本語](../../ja/contributors/chat-ui.md) · [한국어](../../ko/contributors/chat-ui.md) · [Русский](../../ru/contributors/chat-ui.md) · [Français](../../fr/contributors/chat-ui.md) · [Deutsch](../../de/contributors/chat-ui.md) · [Türkçe](../../tr/contributors/chat-ui.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../../ui/chat/README.md)

--- a/docs/i18n/zh-CN/contributors/godot-addons.md
+++ b/docs/i18n/zh-CN/contributors/godot-addons.md
@@ -3,10 +3,6 @@
 # Godot 插件
 
 <!-- fennara-doc-nav:start -->
-[文档](../README.md)
-
-🌐 **语言**
-
 [English](../../../../godot_demo/addons/README.md) · **简体中文** · [Español](../../es/contributors/godot-addons.md) · [Português do Brasil](../../pt-BR/contributors/godot-addons.md) · [日本語](../../ja/contributors/godot-addons.md) · [한국어](../../ko/contributors/godot-addons.md) · [Русский](../../ru/contributors/godot-addons.md) · [Français](../../fr/contributors/godot-addons.md) · [Deutsch](../../de/contributors/godot-addons.md) · [Türkçe](../../tr/contributors/godot-addons.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../../godot_demo/addons/README.md)

--- a/docs/i18n/zh-CN/contributors/godot-payload.md
+++ b/docs/i18n/zh-CN/contributors/godot-payload.md
@@ -3,10 +3,6 @@
 # Godot 负载
 
 <!-- fennara-doc-nav:start -->
-[文档](../README.md)
-
-🌐 **语言**
-
 [English](../../../../godot_demo/README.md) · **简体中文** · [Español](../../es/contributors/godot-payload.md) · [Português do Brasil](../../pt-BR/contributors/godot-payload.md) · [日本語](../../ja/contributors/godot-payload.md) · [한국어](../../ko/contributors/godot-payload.md) · [Русский](../../ru/contributors/godot-payload.md) · [Français](../../fr/contributors/godot-payload.md) · [Deutsch](../../de/contributors/godot-payload.md) · [Türkçe](../../tr/contributors/godot-payload.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../../godot_demo/README.md)

--- a/docs/i18n/zh-CN/contributors/local-tools.md
+++ b/docs/i18n/zh-CN/contributors/local-tools.md
@@ -3,10 +3,6 @@
 # Fennara 本地工具
 
 <!-- fennara-doc-nav:start -->
-[文档](../README.md)
-
-🌐 **语言**
-
 [English](../../../../local/README.md) · **简体中文** · [Español](../../es/contributors/local-tools.md) · [Português do Brasil](../../pt-BR/contributors/local-tools.md) · [日本語](../../ja/contributors/local-tools.md) · [한국어](../../ko/contributors/local-tools.md) · [Русский](../../ru/contributors/local-tools.md) · [Français](../../fr/contributors/local-tools.md) · [Deutsch](../../de/contributors/local-tools.md) · [Türkçe](../../tr/contributors/local-tools.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../../local/README.md)

--- a/docs/i18n/zh-CN/contributors/runtime-helpers.md
+++ b/docs/i18n/zh-CN/contributors/runtime-helpers.md
@@ -3,10 +3,6 @@
 # 运行时辅助脚本
 
 <!-- fennara-doc-nav:start -->
-[文档](../README.md)
-
-🌐 **语言**
-
 [English](../../../../runtime/README.md) · **简体中文** · [Español](../../es/contributors/runtime-helpers.md) · [Português do Brasil](../../pt-BR/contributors/runtime-helpers.md) · [日本語](../../ja/contributors/runtime-helpers.md) · [한국어](../../ko/contributors/runtime-helpers.md) · [Русский](../../ru/contributors/runtime-helpers.md) · [Français](../../fr/contributors/runtime-helpers.md) · [Deutsch](../../de/contributors/runtime-helpers.md) · [Türkçe](../../tr/contributors/runtime-helpers.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../../runtime/README.md)

--- a/docs/i18n/zh-CN/contributors/scripts.md
+++ b/docs/i18n/zh-CN/contributors/scripts.md
@@ -3,10 +3,6 @@
 # 脚本
 
 <!-- fennara-doc-nav:start -->
-[文档](../README.md)
-
-🌐 **语言**
-
 [English](../../../../scripts/README.md) · **简体中文** · [Español](../../es/contributors/scripts.md) · [Português do Brasil](../../pt-BR/contributors/scripts.md) · [日本語](../../ja/contributors/scripts.md) · [한국어](../../ko/contributors/scripts.md) · [Русский](../../ru/contributors/scripts.md) · [Français](../../fr/contributors/scripts.md) · [Deutsch](../../de/contributors/scripts.md) · [Türkçe](../../tr/contributors/scripts.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../../../scripts/README.md)

--- a/docs/i18n/zh-CN/demos.md
+++ b/docs/i18n/zh-CN/demos.md
@@ -3,10 +3,6 @@
 # 演示
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../demos.md) · **简体中文** · [Español](../es/demos.md) · [Português do Brasil](../pt-BR/demos.md) · [日本語](../ja/demos.md) · [한국어](../ko/demos.md) · [Русский](../ru/demos.md) · [Français](../fr/demos.md) · [Deutsch](../de/demos.md) · [Türkçe](../tr/demos.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../demos.md)

--- a/docs/i18n/zh-CN/examples.md
+++ b/docs/i18n/zh-CN/examples.md
@@ -3,10 +3,6 @@
 # 示例
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../examples.md) · **简体中文** · [Español](../es/examples.md) · [Português do Brasil](../pt-BR/examples.md) · [日本語](../ja/examples.md) · [한국어](../ko/examples.md) · [Русский](../ru/examples.md) · [Français](../fr/examples.md) · [Deutsch](../de/examples.md) · [Türkçe](../tr/examples.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../examples.md)

--- a/docs/i18n/zh-CN/faq.md
+++ b/docs/i18n/zh-CN/faq.md
@@ -3,10 +3,6 @@
 # 常见问题
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../faq.md) · **简体中文** · [Español](../es/faq.md) · [Português do Brasil](../pt-BR/faq.md) · [日本語](../ja/faq.md) · [한국어](../ko/faq.md) · [Русский](../ru/faq.md) · [Français](../fr/faq.md) · [Deutsch](../de/faq.md) · [Türkçe](../tr/faq.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../faq.md)

--- a/docs/i18n/zh-CN/fennara-vs-traditional-godot-mcp.md
+++ b/docs/i18n/zh-CN/fennara-vs-traditional-godot-mcp.md
@@ -3,10 +3,6 @@
 # Fennara 与传统 Godot MCP 的对比
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../fennara-vs-traditional-godot-mcp.md) · **简体中文** · [Español](../es/fennara-vs-traditional-godot-mcp.md) · [Português do Brasil](../pt-BR/fennara-vs-traditional-godot-mcp.md) · [日本語](../ja/fennara-vs-traditional-godot-mcp.md) · [한국어](../ko/fennara-vs-traditional-godot-mcp.md) · [Русский](../ru/fennara-vs-traditional-godot-mcp.md) · [Français](../fr/fennara-vs-traditional-godot-mcp.md) · [Deutsch](../de/fennara-vs-traditional-godot-mcp.md) · [Türkçe](../tr/fennara-vs-traditional-godot-mcp.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../fennara-vs-traditional-godot-mcp.md)

--- a/docs/i18n/zh-CN/github-metadata.md
+++ b/docs/i18n/zh-CN/github-metadata.md
@@ -3,10 +3,6 @@
 # GitHub 元数据
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../github-metadata.md) · **简体中文** · [Español](../es/github-metadata.md) · [Português do Brasil](../pt-BR/github-metadata.md) · [日本語](../ja/github-metadata.md) · [한국어](../ko/github-metadata.md) · [Русский](../ru/github-metadata.md) · [Français](../fr/github-metadata.md) · [Deutsch](../de/github-metadata.md) · [Türkçe](../tr/github-metadata.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../github-metadata.md)

--- a/docs/i18n/zh-CN/languages.md
+++ b/docs/i18n/zh-CN/languages.md
@@ -3,10 +3,6 @@
 # 语言与翻译状态
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../languages.md) · **简体中文** · [Español](../es/languages.md) · [Português do Brasil](../pt-BR/languages.md) · [日本語](../ja/languages.md) · [한국어](../ko/languages.md) · [Русский](../ru/languages.md) · [Français](../fr/languages.md) · [Deutsch](../de/languages.md) · [Türkçe](../tr/languages.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../languages.md)

--- a/docs/i18n/zh-CN/manual-install.md
+++ b/docs/i18n/zh-CN/manual-install.md
@@ -3,10 +3,6 @@
 # 手动安装
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../manual-install.md) · **简体中文** · [Español](../es/manual-install.md) · [Português do Brasil](../pt-BR/manual-install.md) · [日本語](../ja/manual-install.md) · [한국어](../ko/manual-install.md) · [Русский](../ru/manual-install.md) · [Français](../fr/manual-install.md) · [Deutsch](../de/manual-install.md) · [Türkçe](../tr/manual-install.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../manual-install.md)

--- a/docs/i18n/zh-CN/mcp-setup.md
+++ b/docs/i18n/zh-CN/mcp-setup.md
@@ -3,10 +3,6 @@
 # MCP 设置
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../mcp-setup.md) · **简体中文** · [Español](../es/mcp-setup.md) · [Português do Brasil](../pt-BR/mcp-setup.md) · [日本語](../ja/mcp-setup.md) · [한국어](../ko/mcp-setup.md) · [Русский](../ru/mcp-setup.md) · [Français](../fr/mcp-setup.md) · [Deutsch](../de/mcp-setup.md) · [Türkçe](../tr/mcp-setup.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../mcp-setup.md)

--- a/docs/i18n/zh-CN/open-rpg-demo.md
+++ b/docs/i18n/zh-CN/open-rpg-demo.md
@@ -3,10 +3,6 @@
 # Open RPG 演示详解
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../open-rpg-demo.md) · **简体中文** · [Español](../es/open-rpg-demo.md) · [Português do Brasil](../pt-BR/open-rpg-demo.md) · [日本語](../ja/open-rpg-demo.md) · [한국어](../ko/open-rpg-demo.md) · [Русский](../ru/open-rpg-demo.md) · [Français](../fr/open-rpg-demo.md) · [Deutsch](../de/open-rpg-demo.md) · [Türkçe](../tr/open-rpg-demo.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../open-rpg-demo.md)

--- a/docs/i18n/zh-CN/providers.md
+++ b/docs/i18n/zh-CN/providers.md
@@ -3,10 +3,6 @@
 # 内置聊天提供方
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../providers.md) · **简体中文** · [Español](../es/providers.md) · [Português do Brasil](../pt-BR/providers.md) · [日本語](../ja/providers.md) · [한국어](../ko/providers.md) · [Русский](../ru/providers.md) · [Français](../fr/providers.md) · [Deutsch](../de/providers.md) · [Türkçe](../tr/providers.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../providers.md)

--- a/docs/i18n/zh-CN/release.md
+++ b/docs/i18n/zh-CN/release.md
@@ -3,10 +3,6 @@
 # 发布流程
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../release.md) · **简体中文** · [Español](../es/release.md) · [Português do Brasil](../pt-BR/release.md) · [日本語](../ja/release.md) · [한국어](../ko/release.md) · [Русский](../ru/release.md) · [Français](../fr/release.md) · [Deutsch](../de/release.md) · [Türkçe](../tr/release.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../release.md)

--- a/docs/i18n/zh-CN/repo-map.md
+++ b/docs/i18n/zh-CN/repo-map.md
@@ -3,10 +3,6 @@
 # 仓库地图
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../repo-map.md) · **简体中文** · [Español](../es/repo-map.md) · [Português do Brasil](../pt-BR/repo-map.md) · [日本語](../ja/repo-map.md) · [한국어](../ko/repo-map.md) · [Русский](../ru/repo-map.md) · [Français](../fr/repo-map.md) · [Deutsch](../de/repo-map.md) · [Türkçe](../tr/repo-map.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../repo-map.md)

--- a/docs/i18n/zh-CN/setup.md
+++ b/docs/i18n/zh-CN/setup.md
@@ -3,10 +3,6 @@
 # 设置
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../setup.md) · **简体中文** · [Español](../es/setup.md) · [Português do Brasil](../pt-BR/setup.md) · [日本語](../ja/setup.md) · [한국어](../ko/setup.md) · [Русский](../ru/setup.md) · [Français](../fr/setup.md) · [Deutsch](../de/setup.md) · [Türkçe](../tr/setup.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../setup.md)

--- a/docs/i18n/zh-CN/slash-commands.md
+++ b/docs/i18n/zh-CN/slash-commands.md
@@ -3,10 +3,6 @@
 # 内置聊天斜杠命令
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../slash-commands.md) · **简体中文** · [Español](../es/slash-commands.md) · [Português do Brasil](../pt-BR/slash-commands.md) · [日本語](../ja/slash-commands.md) · [한국어](../ko/slash-commands.md) · [Русский](../ru/slash-commands.md) · [Français](../fr/slash-commands.md) · [Deutsch](../de/slash-commands.md) · [Türkçe](../tr/slash-commands.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../slash-commands.md)

--- a/docs/i18n/zh-CN/telemetry.md
+++ b/docs/i18n/zh-CN/telemetry.md
@@ -3,10 +3,6 @@
 # 匿名遥测
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../telemetry.md) · **简体中文** · [Español](../es/telemetry.md) · [Português do Brasil](../pt-BR/telemetry.md) · [日本語](../ja/telemetry.md) · [한국어](../ko/telemetry.md) · [Русский](../ru/telemetry.md) · [Français](../fr/telemetry.md) · [Deutsch](../de/telemetry.md) · [Türkçe](../tr/telemetry.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../telemetry.md)

--- a/docs/i18n/zh-CN/tools.md
+++ b/docs/i18n/zh-CN/tools.md
@@ -3,10 +3,6 @@
 # 工具
 
 <!-- fennara-doc-nav:start -->
-[文档](README.md)
-
-🌐 **语言**
-
 [English](../../tools.md) · **简体中文** · [Español](../es/tools.md) · [Português do Brasil](../pt-BR/tools.md) · [日本語](../ja/tools.md) · [한국어](../ko/tools.md) · [Русский](../ru/tools.md) · [Français](../fr/tools.md) · [Deutsch](../de/tools.md) · [Türkçe](../tr/tools.md)
 
 > ℹ️ 由 AI 根据英文原文撰写，欢迎母语者审阅。 [英文原文](../../tools.md)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,10 +1,6 @@
 # Languages And Translation Status
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/languages.md) · [Español](i18n/es/languages.md) · [Português do Brasil](i18n/pt-BR/languages.md) · [日本語](i18n/ja/languages.md) · [한국어](i18n/ko/languages.md) · [Русский](i18n/ru/languages.md) · [Français](i18n/fr/languages.md) · [Deutsch](i18n/de/languages.md) · [Türkçe](i18n/tr/languages.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/manual-install.md
+++ b/docs/manual-install.md
@@ -1,10 +1,6 @@
 # Manual Install
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/manual-install.md) · [Español](i18n/es/manual-install.md) · [Português do Brasil](i18n/pt-BR/manual-install.md) · [日本語](i18n/ja/manual-install.md) · [한국어](i18n/ko/manual-install.md) · [Русский](i18n/ru/manual-install.md) · [Français](i18n/fr/manual-install.md) · [Deutsch](i18n/de/manual-install.md) · [Türkçe](i18n/tr/manual-install.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,10 +1,6 @@
 # MCP Setup
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/mcp-setup.md) · [Español](i18n/es/mcp-setup.md) · [Português do Brasil](i18n/pt-BR/mcp-setup.md) · [日本語](i18n/ja/mcp-setup.md) · [한국어](i18n/ko/mcp-setup.md) · [Русский](i18n/ru/mcp-setup.md) · [Français](i18n/fr/mcp-setup.md) · [Deutsch](i18n/de/mcp-setup.md) · [Türkçe](i18n/tr/mcp-setup.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/open-rpg-demo.md
+++ b/docs/open-rpg-demo.md
@@ -1,10 +1,6 @@
 # Open RPG Demo Breakdown
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/open-rpg-demo.md) · [Español](i18n/es/open-rpg-demo.md) · [Português do Brasil](i18n/pt-BR/open-rpg-demo.md) · [日本語](i18n/ja/open-rpg-demo.md) · [한국어](i18n/ko/open-rpg-demo.md) · [Русский](i18n/ru/open-rpg-demo.md) · [Français](i18n/fr/open-rpg-demo.md) · [Deutsch](i18n/de/open-rpg-demo.md) · [Türkçe](i18n/tr/open-rpg-demo.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,10 +1,6 @@
 # Built-In Chat Providers
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/providers.md) · [Español](i18n/es/providers.md) · [Português do Brasil](i18n/pt-BR/providers.md) · [日本語](i18n/ja/providers.md) · [한국어](i18n/ko/providers.md) · [Русский](i18n/ru/providers.md) · [Français](i18n/fr/providers.md) · [Deutsch](i18n/de/providers.md) · [Türkçe](i18n/tr/providers.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,10 +1,6 @@
 # Release Process
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/release.md) · [Español](i18n/es/release.md) · [Português do Brasil](i18n/pt-BR/release.md) · [日本語](i18n/ja/release.md) · [한국어](i18n/ko/release.md) · [Русский](i18n/ru/release.md) · [Français](i18n/fr/release.md) · [Deutsch](i18n/de/release.md) · [Türkçe](i18n/tr/release.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -1,10 +1,6 @@
 # Repo Map
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/repo-map.md) · [Español](i18n/es/repo-map.md) · [Português do Brasil](i18n/pt-BR/repo-map.md) · [日本語](i18n/ja/repo-map.md) · [한국어](i18n/ko/repo-map.md) · [Русский](i18n/ru/repo-map.md) · [Français](i18n/fr/repo-map.md) · [Deutsch](i18n/de/repo-map.md) · [Türkçe](i18n/tr/repo-map.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,10 +1,6 @@
 # Setup
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/setup.md) · [Español](i18n/es/setup.md) · [Português do Brasil](i18n/pt-BR/setup.md) · [日本語](i18n/ja/setup.md) · [한국어](i18n/ko/setup.md) · [Русский](i18n/ru/setup.md) · [Français](i18n/fr/setup.md) · [Deutsch](i18n/de/setup.md) · [Türkçe](i18n/tr/setup.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/slash-commands.md
+++ b/docs/slash-commands.md
@@ -1,10 +1,6 @@
 # Built-In Chat Slash Commands
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/slash-commands.md) · [Español](i18n/es/slash-commands.md) · [Português do Brasil](i18n/pt-BR/slash-commands.md) · [日本語](i18n/ja/slash-commands.md) · [한국어](i18n/ko/slash-commands.md) · [Русский](i18n/ru/slash-commands.md) · [Français](i18n/fr/slash-commands.md) · [Deutsch](i18n/de/slash-commands.md) · [Türkçe](i18n/tr/slash-commands.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,10 +1,6 @@
 # Anonymous Telemetry
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/telemetry.md) · [Español](i18n/es/telemetry.md) · [Português do Brasil](i18n/pt-BR/telemetry.md) · [日本語](i18n/ja/telemetry.md) · [한국어](i18n/ko/telemetry.md) · [Русский](i18n/ru/telemetry.md) · [Français](i18n/fr/telemetry.md) · [Deutsch](i18n/de/telemetry.md) · [Türkçe](i18n/tr/telemetry.md)
 <!-- fennara-doc-nav:end -->
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,10 +1,6 @@
 # Tools
 
 <!-- fennara-doc-nav:start -->
-[Documentation](README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](i18n/zh-CN/tools.md) · [Español](i18n/es/tools.md) · [Português do Brasil](i18n/pt-BR/tools.md) · [日本語](i18n/ja/tools.md) · [한국어](i18n/ko/tools.md) · [Русский](i18n/ru/tools.md) · [Français](i18n/fr/tools.md) · [Deutsch](i18n/de/tools.md) · [Türkçe](i18n/tr/tools.md)
 <!-- fennara-doc-nav:end -->
 

--- a/godot_demo/README.md
+++ b/godot_demo/README.md
@@ -1,10 +1,6 @@
 # Godot Payload
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](../docs/i18n/zh-CN/contributors/godot-payload.md) · [Español](../docs/i18n/es/contributors/godot-payload.md) · [Português do Brasil](../docs/i18n/pt-BR/contributors/godot-payload.md) · [日本語](../docs/i18n/ja/contributors/godot-payload.md) · [한국어](../docs/i18n/ko/contributors/godot-payload.md) · [Русский](../docs/i18n/ru/contributors/godot-payload.md) · [Français](../docs/i18n/fr/contributors/godot-payload.md) · [Deutsch](../docs/i18n/de/contributors/godot-payload.md) · [Türkçe](../docs/i18n/tr/contributors/godot-payload.md)
 <!-- fennara-doc-nav:end -->
 

--- a/godot_demo/addons/README.md
+++ b/godot_demo/addons/README.md
@@ -1,10 +1,6 @@
 # Godot Addons
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../../docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](../../docs/i18n/zh-CN/contributors/godot-addons.md) · [Español](../../docs/i18n/es/contributors/godot-addons.md) · [Português do Brasil](../../docs/i18n/pt-BR/contributors/godot-addons.md) · [日本語](../../docs/i18n/ja/contributors/godot-addons.md) · [한국어](../../docs/i18n/ko/contributors/godot-addons.md) · [Русский](../../docs/i18n/ru/contributors/godot-addons.md) · [Français](../../docs/i18n/fr/contributors/godot-addons.md) · [Deutsch](../../docs/i18n/de/contributors/godot-addons.md) · [Türkçe](../../docs/i18n/tr/contributors/godot-addons.md)
 <!-- fennara-doc-nav:end -->
 

--- a/local/README.md
+++ b/local/README.md
@@ -1,10 +1,6 @@
 # Fennara Local Tools
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](../docs/i18n/zh-CN/contributors/local-tools.md) · [Español](../docs/i18n/es/contributors/local-tools.md) · [Português do Brasil](../docs/i18n/pt-BR/contributors/local-tools.md) · [日本語](../docs/i18n/ja/contributors/local-tools.md) · [한국어](../docs/i18n/ko/contributors/local-tools.md) · [Русский](../docs/i18n/ru/contributors/local-tools.md) · [Français](../docs/i18n/fr/contributors/local-tools.md) · [Deutsch](../docs/i18n/de/contributors/local-tools.md) · [Türkçe](../docs/i18n/tr/contributors/local-tools.md)
 <!-- fennara-doc-nav:end -->
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -1,10 +1,6 @@
 # Runtime Helpers
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](../docs/i18n/zh-CN/contributors/runtime-helpers.md) · [Español](../docs/i18n/es/contributors/runtime-helpers.md) · [Português do Brasil](../docs/i18n/pt-BR/contributors/runtime-helpers.md) · [日本語](../docs/i18n/ja/contributors/runtime-helpers.md) · [한국어](../docs/i18n/ko/contributors/runtime-helpers.md) · [Русский](../docs/i18n/ru/contributors/runtime-helpers.md) · [Français](../docs/i18n/fr/contributors/runtime-helpers.md) · [Deutsch](../docs/i18n/de/contributors/runtime-helpers.md) · [Türkçe](../docs/i18n/tr/contributors/runtime-helpers.md)
 <!-- fennara-doc-nav:end -->
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,10 +1,6 @@
 # Scripts
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](../docs/i18n/zh-CN/contributors/scripts.md) · [Español](../docs/i18n/es/contributors/scripts.md) · [Português do Brasil](../docs/i18n/pt-BR/contributors/scripts.md) · [日本語](../docs/i18n/ja/contributors/scripts.md) · [한국어](../docs/i18n/ko/contributors/scripts.md) · [Русский](../docs/i18n/ru/contributors/scripts.md) · [Français](../docs/i18n/fr/contributors/scripts.md) · [Deutsch](../docs/i18n/de/contributors/scripts.md) · [Türkçe](../docs/i18n/tr/contributors/scripts.md)
 <!-- fennara-doc-nav:end -->
 

--- a/scripts/doc-i18n-lib.mjs
+++ b/scripts/doc-i18n-lib.mjs
@@ -43,10 +43,6 @@ export function renderNavigation(document, localeCode) {
     localeCode === config.canonicalLocale
       ? document.source
       : targetFor(document, localeCode);
-  const docsHome =
-    localeCode === config.canonicalLocale
-      ? "docs/README.md"
-      : `docs/i18n/${localeCode}/README.md`;
   const languageLinks = config.locales.map((candidate) => {
     const target =
       candidate.code === config.canonicalLocale
@@ -59,10 +55,6 @@ export function renderNavigation(document, localeCode) {
   });
   const lines = [
     NAV_START,
-    `[${locale.docsLabel}](${relativeLink(currentPath, docsHome)})`,
-    "",
-    `🌐 **${locale.languagesLabel}**`,
-    "",
     languageLinks.join(" · "),
   ];
   if (localeCode !== config.canonicalLocale) {

--- a/ui/chat/README.md
+++ b/ui/chat/README.md
@@ -1,10 +1,6 @@
 # Fennara Chat UI
 
 <!-- fennara-doc-nav:start -->
-[Documentation](../../docs/README.md)
-
-🌐 **Languages**
-
 **English** · [简体中文](../../docs/i18n/zh-CN/contributors/chat-ui.md) · [Español](../../docs/i18n/es/contributors/chat-ui.md) · [Português do Brasil](../../docs/i18n/pt-BR/contributors/chat-ui.md) · [日本語](../../docs/i18n/ja/contributors/chat-ui.md) · [한국어](../../docs/i18n/ko/contributors/chat-ui.md) · [Русский](../../docs/i18n/ru/contributors/chat-ui.md) · [Français](../../docs/i18n/fr/contributors/chat-ui.md) · [Deutsch](../../docs/i18n/de/contributors/chat-ui.md) · [Türkçe](../../docs/i18n/tr/contributors/chat-ui.md)
 <!-- fennara-doc-nav:end -->
 


### PR DESCRIPTION
## Purpose

Remove redundant labels from the multilingual navigation introduced by PR #135.

## What changed

- removes the documentation-home shortcut from every managed documentation page
- removes the `Languages` heading and its localized equivalents
- leaves only the always-visible language-link row
- preserves the translated-page review notice and English-source link
- removes the now-unused localized label fields from the navigation manifest

This produces a smaller navigation block without changing translated prose, source hashes, stable anchors, or documentation coverage.

## Validation

```bash
node scripts/sync-doc-navigation.mjs --check
node scripts/check-doc-i18n.mjs
git diff --check origin/main...HEAD
```

Assisted by Codex
