### PR TITLE
fix(gdextension): preserve external AnimationTree transitions

### DIFF
--- a/.github/workflows/gdextension-build.yml
+++ b/.github/workflows/gdextension-build.yml
@@ -208,6 +208,7 @@ jobs:
             "res://tests/screenshot_session_viewport_test.gd",
             "res://tests/image_sheet_test.gd",
             "res://tests/runtime_image_context_test.gd",
+            "res://tests/get_node_properties_animation_tree_test.gd",
             "res://tests/ai_guidance_read_test.gd"
           )
           foreach ($testScript in $testScripts) {

--- a/fennara-cpp/src/tools/get_node_properties/tscn_parser.cpp
+++ b/fennara-cpp/src/tools/get_node_properties/tscn_parser.cpp
@@ -136,6 +136,36 @@ bool can_expand_external_resource(const ExtResourceEntry &entry,
     return true;
 }
 
+godot::String format_external_animation_tree_graph(
+    const godot::String &property_name, const ExtResourceEntry &entry,
+    const TextResourceData &resource_data, const godot::String &resource_type,
+    int indent_depth) {
+    godot::String indent = indent_str(indent_depth);
+    godot::String out =
+        indent + property_name + " = <AnimationTreeGraph>\n";
+    out += indent_str(indent_depth + 1) +
+           "<!-- external resource: " + entry.path + " [declared " +
+           entry.type + "] -->\n";
+
+    TscnData graph_data;
+    graph_data.ext_resources = resource_data.ext_resources;
+    graph_data.sub_resources = resource_data.sub_resources;
+
+    godot::String root_id = "__fennara_external_tree_root";
+    while (graph_data.sub_resources.has(root_id)) {
+        root_id += "_";
+    }
+
+    SubResourceBlock root;
+    root.type = resource_type;
+    root.lines = resource_data.root_lines;
+    graph_data.sub_resources[root_id] = root;
+
+    out += format_animation_tree_graph(graph_data, root_id, indent_depth + 1);
+    out += indent + "</AnimationTreeGraph>\n";
+    return out;
+}
+
 godot::String format_external_resource(
     const godot::String &property_name, const ExtResourceEntry &entry,
     int indent_depth, godot::Node *scene_root, godot::Node *target,
@@ -157,6 +187,14 @@ godot::String format_external_resource(
 
     godot::String resource_type =
         resource_data.root_type.is_empty() ? entry.type : resource_data.root_type;
+
+    if (property_name == "tree_root" &&
+        resource_type.begins_with("AnimationNode") &&
+        godot::Object::cast_to<godot::AnimationTree>(target) != nullptr) {
+        return format_external_animation_tree_graph(
+            property_name, entry, resource_data, resource_type, indent_depth);
+    }
+
     godot::String out = indent + property_name + " = <" + resource_type + ">\n";
 
     godot::String comment = indent_str(indent_depth + 1) +

--- a/godot_demo/tests/fixtures/animation_tree_external.tres
+++ b/godot_demo/tests/fixtures/animation_tree_external.tres
@@ -1,0 +1,17 @@
+[gd_resource type="AnimationNodeStateMachine" load_steps=4 format=3]
+
+[sub_resource type="AnimationNodeAnimation" id="idle"]
+animation = &"idle"
+
+[sub_resource type="AnimationNodeAnimation" id="walk"]
+animation = &"walk"
+
+[sub_resource type="AnimationNodeStateMachineTransition" id="transition"]
+advance_mode = 2
+advance_condition = &"go"
+switch_mode = 1
+
+[resource]
+states/idle/node = SubResource("idle")
+states/walk/node = SubResource("walk")
+transitions = ["idle", "walk", SubResource("transition")]

--- a/godot_demo/tests/fixtures/animation_tree_external.tscn
+++ b/godot_demo/tests/fixtures/animation_tree_external.tscn
@@ -1,0 +1,11 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="AnimationNodeStateMachine" path="res://tests/fixtures/animation_tree_external.tres" id="1"]
+
+[node name="Root" type="Node3D"]
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+
+[node name="AnimationTree" type="AnimationTree" parent="."]
+tree_root = ExtResource("1")
+anim_player = NodePath("../AnimationPlayer")

--- a/godot_demo/tests/get_node_properties_animation_tree_test.gd
+++ b/godot_demo/tests/get_node_properties_animation_tree_test.gd
@@ -1,0 +1,33 @@
+extends SceneTree
+
+
+func _initialize() -> void:
+	var extension := load("res://addons/fennara/fennara.gdextension")
+	assert(extension != null)
+
+	var result: Dictionary = ClassDB.class_call_static(
+		"FennaraGetNodePropertiesTool",
+		"execute",
+		{
+			"targets": [
+				{
+					"scene_path": "res://tests/fixtures/animation_tree_external.tscn",
+					"node_path": "AnimationTree",
+				},
+			],
+		},
+	)
+	assert(result.get("success", false))
+
+	var nodes: Array = result.get("nodes", [])
+	assert(nodes.size() == 1)
+	var properties_text := str((nodes[0] as Dictionary).get("properties_text", ""))
+	assert("tree_root = <AnimationTreeGraph>" in properties_text)
+	assert("idle -> walk" in properties_text)
+	assert("advance_mode:2" in properties_text)
+	assert("advance_condition:go" in properties_text)
+	assert("switch_mode:1" in properties_text)
+	assert("<AnimationNodeStateMachineTransition>" not in properties_text)
+
+	print("get_node_properties AnimationTree test passed")
+	quit()


### PR DESCRIPTION
## Summary

- render external `AnimationNode*` resources assigned to `AnimationTree.tree_root` through the existing graph formatter
- preserve transition details such as `advance_mode`, `advance_condition`, and `switch_mode`
- add a focused Godot regression fixture and run it in the Windows native test job

## Why

External `.tres` AnimationTree roots previously went through generic resource formatting. Inline transition subresources were reduced to type placeholders, so `get_node_properties` returned apparently complete output while omitting the state machine's transition logic.

The external resource root is now adapted to the graph formatter's existing `TscnData` shape. This keeps inline and external graph output consistent without introducing a separate formatting path.

Closes #143.

## Validation

```powershell
cd fennara-cpp
uvx scons target=editor
```

```powershell
Godot_v4.5-stable_win64_console.exe --headless --path godot_demo --script res://tests/get_node_properties_animation_tree_test.gd
```

Assisted by Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AnimationTree property output when using externally defined animation graphs.
  * External state machines now display their states, transitions, advance settings, and conditions in the expected graph format.

* **Tests**
  * Added coverage for AnimationTree scenes that reference external animation resources.
  * Added Windows editor validation for the new AnimationTree behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->