### PR TITLE
fix: two remaining upgrade-path bugs from a legacy install

### DIFF
--- a/local/crates/fennara-cli/src/daemon_setup.rs
+++ b/local/crates/fennara-cli/src/daemon_setup.rs
@@ -283,8 +283,16 @@ fn parse_success_response(response: &str) -> Result<Value, String> {
 }
 
 fn read_control_token(path: &Path) -> Result<String, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|error| format!("failed to read {}: {error}", display_path(path)))?;
+    let raw = std::fs::read_to_string(path).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            format!(
+                "no local daemon control token at {} ({error}). A Fennara daemon started before control-channel authentication was added has no token file but may still be running and answering health checks. Stop that older daemon process manually (for example, end the fennara-daemon process in your OS process manager or restart your machine), then retry; the next install or update starts a daemon that writes this token on launch.",
+                display_path(path)
+            )
+        } else {
+            format!("failed to read {}: {error}", display_path(path))
+        }
+    })?;
     let token = raw.trim();
     let valid = URL_SAFE_NO_PAD
         .decode(token)
@@ -452,5 +460,17 @@ mod tests {
         let error = read_control_token(&path).unwrap_err();
         assert!(error.contains("control token is invalid"));
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn missing_control_token_explains_legacy_daemon_recovery() {
+        let path = std::env::temp_dir().join(format!(
+            "fennara-missing-control-token-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        let error = read_control_token(&path).unwrap_err();
+        assert!(error.contains("started before control-channel authentication"));
+        assert!(error.contains("Stop that older daemon process manually"));
     }
 }

--- a/local/crates/fennara-cli/src/project_install.rs
+++ b/local/crates/fennara-cli/src/project_install.rs
@@ -38,7 +38,7 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
             options.channel.as_deref(),
         )?;
         if let Some(requested) = options.version.as_deref()
-            && requested != existing.version
+            && requested.strip_prefix('v').unwrap_or(requested) != existing.version
         {
             return Err(operation::failure(
                 FailureClass::ProjectInvalid,

--- a/local/crates/fennara-cli/src/release_identity.rs
+++ b/local/crates/fennara-cli/src/release_identity.rs
@@ -156,7 +156,7 @@ impl ReleaseSelector {
         } else if let Some(channel) = value.strip_prefix("channel:") {
             Self::staging(channel)
         } else {
-            Self::exact(value)
+            Self::exact(value.strip_prefix('v').unwrap_or(value))
         }
     }
 

--- a/local/crates/fennara-cli/src/release_identity_tests.rs
+++ b/local/crates/fennara-cli/src/release_identity_tests.rs
@@ -72,6 +72,24 @@ fn maps_selectors_to_isolated_github_tags() {
     );
 }
 
+#[test]
+fn version_requests_normalize_an_optional_leading_v() {
+    assert_eq!(
+        ReleaseSelector::from_version_request("0.4.0").unwrap(),
+        ReleaseSelector::exact("0.4.0").unwrap()
+    );
+    assert_eq!(
+        ReleaseSelector::from_version_request("v0.4.0").unwrap(),
+        ReleaseSelector::exact("0.4.0").unwrap()
+    );
+    assert_eq!(
+        ReleaseSelector::from_version_request("v0.4.0")
+            .unwrap()
+            .github_tag(),
+        "v0.4.0"
+    );
+}
+
 fn identity(
     track: &str,
     version: &str,

--- a/local/crates/fennara-cli/src/release_update.rs
+++ b/local/crates/fennara-cli/src/release_update.rs
@@ -160,11 +160,9 @@ pub fn run(args: Vec<&str>) -> Result<(), String> {
 }
 
 pub(crate) fn resolve_exact_target(request: &str) -> Result<String, String> {
-    if matches!(
-        ReleaseSelector::from_version_request(request)?,
-        ReleaseSelector::ExactVersion(_)
-    ) {
-        return Ok(request.to_string());
+    if let ReleaseSelector::ExactVersion(version) = ReleaseSelector::from_version_request(request)?
+    {
+        return Ok(version);
     }
     let release = release_client::fetch_release(request)?;
     operation::set_component("release_track", resolved_release_track(&release))?;

--- a/local/crates/fennara-cli/src/release_update_tests.rs
+++ b/local/crates/fennara-cli/src/release_update_tests.rs
@@ -1,6 +1,11 @@
 use crate::release_channel::ChannelPointer;
 use crate::release_client::Release;
-use crate::release_update::resolved_release_track;
+use crate::release_update::{resolve_exact_target, resolved_release_track};
+
+#[test]
+fn exact_target_uses_the_normalized_version() {
+    assert_eq!(resolve_exact_target("v0.4.0").unwrap(), "0.4.0");
+}
 
 #[test]
 fn identifies_stable_and_staging_release_targets_before_handoff() {


### PR DESCRIPTION

## Problem

Issue #126 reports three stacked failures when upgrading an existing install to a
current release:

1. `latest` resolution 404s (`releases/tags/latest` instead of `releases/latest`).
2. `--version v0.4.0` doubles the prefix into `vv0.4.0` and 404s; bare `0.4.0` works.
3. update/install hard-fail on a missing `daemon-control-token` for installs whose
   daemon has never run past the pre-authentication era, with no way to recover.

Checking current `main` against each:

- **(1) is already fixed.** `release_metadata_url` resolves `ReleaseSelector::StableLatest`
  through `releases/latest`, and `stable_latest_uses_github_latest_while_pinned_versions_use_exact_tags`
  already locks this in. The 404 in the issue comes from the *already-installed* 0.3.7 CLI
  binary, which has the old behavior baked in and can't be patched retroactively; the docs
  already tell users on 0.3.8-or-older CLIs to reinstall the CLI once before running
  `fennara update` for exactly this reason.
- **(2) is still broken on `main`**, just manifests differently: `ReleaseSelector::exact`
  parses the raw `--version` string with `semver::Version::parse`, which rejects a leading
  `v`, so `--version v0.4.0` now fails with "invalid release version" instead of a 404 - but
  it still doesn't work.
- **(3) is still broken on `main`.** The daemon-control-token file is only ever written by a
  daemon built with control-channel authentication (post-0.3.7). `daemon_setup::shutdown_if_running`
  and `ensure_switch_available` only skip the token entirely when the daemon isn't running at
  all; if an older daemon predating that authentication is still resident and answering health
  checks, the CLI tries to read a token file that daemon never created and fails with a bare
  "No such file or directory", with no indication of what happened or how to recover.

## Fixes

**Version-prefix normalization** (`local/crates/fennara-cli/src/release_identity.rs`):
`ReleaseSelector::from_version_request` now strips one leading `v` before handing the value to
`ReleaseSelector::exact`, so `0.4.0` and `v0.4.0` resolve to the same release. The same
normalization is applied to the existing-addon reinstall guard in
`local/crates/fennara-cli/src/project_install.rs`, which compared the raw `--version` string
against the installed addon version before this fix and would otherwise reject a v-prefixed
version that actually matched.

**Actionable error for a missing daemon-control-token** (`local/crates/fennara-cli/src/daemon_setup.rs`):
`read_control_token` now distinguishes "file not found" from other read failures. On a missing
token it explains that an older, pre-authentication daemon is likely still running and answering
health checks, and that the recovery is to stop that process manually (OS process manager, or a
restart) and retry - the next daemon started by install/update writes the token on launch. This
keeps the authenticated-shutdown guarantee intact (a missing token still blocks the control
channel; nothing auto-trusts or auto-shuts-down an unauthenticated daemon) while turning a dead
end into a documented recovery path, per the issue's "at minimum the error should say how to
recover" ask.

## Not included (left for maintainer input)

- Auto-migrating/regenerating the token for a still-running legacy daemon was intentionally not
  attempted: the control-token challenge exists to stop an arbitrary local process from
  impersonating the daemon, and silently trusting or shutting down an unauthenticated legacy
  daemon would weaken that guarantee. The safe minimal fix here is the explanatory error above;
  an actual auto-recovery would need a maintainer decision on the trust model.
- `fennara doctor --repair` detection of this exact condition is listed in the issue as "ideally"
  and is a larger, separate change; not attempted here to keep this PR focused.

## Verification

- Added `version_requests_normalize_an_optional_leading_v` in
  `release_identity_tests.rs`, covering `from_version_request("0.4.0")` and
  `from_version_request("v0.4.0")` resolving to the same `ReleaseSelector::ExactVersion` and the
  same `v0.4.0` GitHub tag.
- Added `missing_control_token_explains_legacy_daemon_recovery` in `daemon_setup.rs`, covering
  the new explanatory message on a missing token file.
- `cd local && cargo test --locked` (the command this repo's CI runs) passes locally on this
  branch: all crates green, including the two new tests.

---

Disclosure: this patch was drafted with AI assistance against the issue's diagnosis and the
current `main` sources, then reviewed and tested by a human before submission.

Fixes #126


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages and recovery guidance when the daemon’s control token is missing.
  * Version requests with an optional leading `v` now match consistently during project addon adoption and release selection.
  * Release tags are generated correctly for version inputs such as `v0.4.0`.

* **Tests**
  * Added coverage for missing control tokens and normalized version requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->